### PR TITLE
fix(TREDS-46): fix Select chevron rotation and toggle behavior

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -68,12 +68,11 @@ function SelectRightSection({
       <IconButton
         aria-label={dropDownOpened ? collapseButtonLabel : expandButtonLabel}
         variant="dark"
-        onClick={() => {
-          toggleDropdown();
-        }}
+        onMouseDown={(e) => e.nativeEvent.stopPropagation()}
+        onClick={toggleDropdown}
         size={'sm'}
       >
-        {dropDownOpened ? <ChevronDownIcon rotate={180} /> : <ChevronDownIcon />}
+        <ChevronDownIcon style={dropDownOpened ? { transform: 'rotate(180deg)' } : undefined} />
       </IconButton>
     </Flex>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,6 +7,7 @@ import { mergeClassNames } from '../../utils.ts';
 import { IconButton } from '../IconButton';
 import { TextField } from '../TextField';
 import {
+  chevronOpen,
   dropDown,
   dropDownOption,
   inputField,
@@ -72,7 +73,7 @@ function SelectRightSection({
         onClick={toggleDropdown}
         size={'sm'}
       >
-        <ChevronDownIcon style={dropDownOpened ? { transform: 'rotate(180deg)' } : undefined} />
+        <ChevronDownIcon className={dropDownOpened ? chevronOpen : undefined} />
       </IconButton>
     </Flex>
   );


### PR DESCRIPTION
## Summary

- Fixes the chevron visual indicator: uses `style={{ transform: 'rotate(180deg)' }}` when the dropdown is open instead of the no-op `rotate={180}` SVG attribute
- Fixes the chevron button not closing the dropdown: Mantine's `Popover.useClickOutside` listens on `document` for `mousedown` and treats the chevron button (a DOM sibling of `<input>`) as "outside", closing the dropdown before `onClick` fires — causing `toggleDropdown()` to reopen it instead. Stopping native `mousedown` propagation on the button prevents this race condition.

## Test plan

- [ ] Clicking the chevron opens the dropdown and chevron points up
- [ ] Clicking the chevron again closes the dropdown and chevron points down
- [ ] Selecting an option closes the dropdown
- [ ] Clicking the input field also toggles the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)