### PR TITLE
fix(#79): consistent control height for buttons and inputs (border-box + responsive controlHeight)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,11 @@ FodyWeavers.xsd
 *storybook.log
 storybook-static
 dist
+CLAUDE.md
+docs/
+
+# Obsidian
+.obsidian/
+
+# macOS
+.DS_Store

--- a/src/components/Button/Button.css.ts
+++ b/src/components/Button/Button.css.ts
@@ -2,7 +2,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 
 const {
-  components: { button },
+  components: { button, controlHeight },
   font,
   core,
   focusRing,
@@ -10,6 +10,13 @@ const {
 
 const root = style({
   width: 'fit-content',
+  // Fixed, responsive height shared with inputs; border-box absorbs each variant's border
+  // so filled/outlined/text render identical heights (issue #79).
+  height: controlHeight,
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   fontSize: button.fontSize,
   lineHeight: button.lineHeight,
   letterSpacing: font.letterSpacing,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from 'storybook/test';
 import { Button } from './Button';
+import { TextField } from '../TextField';
+import { Select } from '../Select';
 import { SearchIcon } from '../../icons/SearchIcon';
 
 const meta = {
@@ -62,4 +65,39 @@ export const WithoutText: Story = {
       <SearchIcon />
     </Button>
   ),
+};
+
+/**
+ * All single-line controls (button variants, text input, select) must render at the
+ * same shared, responsive control height — borders absorbed via box-sizing (issue #79).
+ */
+export const ControlHeightConsistency: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 16 }}>
+      <Button variant="filled">Filled</Button>
+      <Button variant="outlined">Outlined</Button>
+      <Button variant="text">Text</Button>
+      <TextField inputLabel="Text input" placeholder="Input" />
+      <Select inputLabel="Select picker" options={['One', 'Two']} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const filled = canvas.getByRole('button', { name: 'Filled' });
+    const outlined = canvas.getByRole('button', { name: 'Outlined' });
+    const text = canvas.getByRole('button', { name: 'Text' });
+    const textInput = canvas.getByRole('textbox', { name: 'Text input' });
+    const selectInput = canvas.getByRole('textbox', { name: 'Select picker' });
+
+    const heightOf = (el: Element) => Math.round(el.getBoundingClientRect().height);
+    const reference = heightOf(filled);
+
+    // Filled is the design source of truth; every other control must match it exactly.
+    await expect(reference).toBeGreaterThan(0);
+    await expect(heightOf(outlined)).toBe(reference);
+    await expect(heightOf(text)).toBe(reference);
+    await expect(heightOf(textInput)).toBe(reference);
+    await expect(heightOf(selectInput)).toBe(reference);
+  },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -7,8 +7,8 @@ import { SearchIcon } from '../../icons/SearchIcon';
 import { ArrowRightIcon } from '../../icons/ArrowRightIcon';
 import { vars } from '../../theme';
 
-// Size in-button icons with the design-system icon.size token (20px, matching the
-// button line-height) rather than an emoji or a hardcoded value.
+// Size in-button icons with the design-system icon.size token (a fixed 20px) rather
+// than an emoji or a hardcoded value.
 const iconSize = vars.components.icon.size.medium;
 const iconProps = { style: { width: iconSize, height: iconSize } };
 
@@ -148,8 +148,13 @@ export const ControlHeightConsistency: Story = {
     const text = canvas.getByRole('button', { name: 'Text' });
     const controls = [textInput, selectInput, filled, outlined, text];
 
-    const heightOf = (el: Element) => Math.round(el.getBoundingClientRect().height);
-    const bottomOf = (el: Element) => Math.round(el.getBoundingClientRect().bottom);
+    const heightOf = (el: Element) => el.getBoundingClientRect().height;
+    const bottomOf = (el: Element) => el.getBoundingClientRect().bottom;
+
+    // Variants reach the same border-box height via different border configs (filled has
+    // none, outlined a full border, text a bottom border), so allow 1px of sub-pixel
+    // rounding slack rather than asserting exact equality.
+    const TOLERANCE = 1;
 
     // Filled is the design source of truth: every control matches its height, and
     // bottom-alignment puts every bottom border on the same line.
@@ -157,8 +162,8 @@ export const ControlHeightConsistency: Story = {
     const referenceBottom = bottomOf(filled);
     await expect(referenceHeight).toBeGreaterThan(0);
     for (const control of controls) {
-      await expect(heightOf(control)).toBe(referenceHeight);
-      await expect(bottomOf(control)).toBe(referenceBottom);
+      await expect(Math.abs(heightOf(control) - referenceHeight)).toBeLessThanOrEqual(TOLERANCE);
+      await expect(Math.abs(bottomOf(control) - referenceBottom)).toBeLessThanOrEqual(TOLERANCE);
     }
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -23,8 +23,54 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  render: (args) => <Button {...args}>Dark Button</Button>,
+/** High-emphasis, primary action. Use at most one filled button per view. */
+export const Filled: Story = {
+  args: { variant: 'filled' },
+};
+
+/** Medium emphasis — secondary actions placed alongside a filled button. */
+export const Outlined: Story = {
+  args: { variant: 'outlined' },
+};
+
+/** Low emphasis — tertiary or inline actions. */
+export const Text: Story = {
+  args: { variant: 'text' },
+};
+
+/** All three variants side by side, sharing the same control height (issue #79). */
+export const Variants: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+      <Button {...args} variant="filled">
+        Filled
+      </Button>
+      <Button {...args} variant="outlined">
+        Outlined
+      </Button>
+      <Button {...args} variant="text">
+        Text
+      </Button>
+    </div>
+  ),
+};
+
+/** Disabled appearance for each variant. */
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+      <Button {...args} variant="filled">
+        Filled
+      </Button>
+      <Button {...args} variant="outlined">
+        Outlined
+      </Button>
+      <Button {...args} variant="text">
+        Text
+      </Button>
+    </div>
+  ),
 };
 
 export const LeftIcon: Story = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -121,36 +121,44 @@ export const WithoutText: Story = {
 };
 
 /**
- * All single-line controls (button variants, text input, select) must render at the
+ * All single-line controls (text input, select, button variants) must render at the
  * same shared, responsive control height — borders absorbed via box-sizing (issue #79).
+ *
+ * Inputs (which carry a label above the box) sit on the left and the buttons on the
+ * right, bottom-aligned: because every control box is the same height, their bottom
+ * borders land on a single line.
  */
 export const ControlHeightConsistency: Story = {
   render: () => (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 16 }}>
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 16 }}>
+      <TextField inputLabel="Text input" placeholder="Input" />
+      <Select inputLabel="Select picker" options={['One', 'Two']} />
       <Button variant="filled">Filled</Button>
       <Button variant="outlined">Outlined</Button>
       <Button variant="text">Text</Button>
-      <TextField inputLabel="Text input" placeholder="Input" />
-      <Select inputLabel="Select picker" options={['One', 'Two']} />
     </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    const textInput = canvas.getByRole('textbox', { name: 'Text input' });
+    const selectInput = canvas.getByRole('textbox', { name: 'Select picker' });
     const filled = canvas.getByRole('button', { name: 'Filled' });
     const outlined = canvas.getByRole('button', { name: 'Outlined' });
     const text = canvas.getByRole('button', { name: 'Text' });
-    const textInput = canvas.getByRole('textbox', { name: 'Text input' });
-    const selectInput = canvas.getByRole('textbox', { name: 'Select picker' });
+    const controls = [textInput, selectInput, filled, outlined, text];
 
     const heightOf = (el: Element) => Math.round(el.getBoundingClientRect().height);
-    const reference = heightOf(filled);
+    const bottomOf = (el: Element) => Math.round(el.getBoundingClientRect().bottom);
 
-    // Filled is the design source of truth; every other control must match it exactly.
-    await expect(reference).toBeGreaterThan(0);
-    await expect(heightOf(outlined)).toBe(reference);
-    await expect(heightOf(text)).toBe(reference);
-    await expect(heightOf(textInput)).toBe(reference);
-    await expect(heightOf(selectInput)).toBe(reference);
+    // Filled is the design source of truth: every control matches its height, and
+    // bottom-alignment puts every bottom border on the same line.
+    const referenceHeight = heightOf(filled);
+    const referenceBottom = bottomOf(filled);
+    await expect(referenceHeight).toBeGreaterThan(0);
+    for (const control of controls) {
+      await expect(heightOf(control)).toBe(referenceHeight);
+      await expect(bottomOf(control)).toBe(referenceBottom);
+    }
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -4,6 +4,13 @@ import { Button } from './Button';
 import { TextField } from '../TextField';
 import { Select } from '../Select';
 import { SearchIcon } from '../../icons/SearchIcon';
+import { ArrowRightIcon } from '../../icons/ArrowRightIcon';
+import { vars } from '../../theme';
+
+// Size in-button icons with the design-system icon.size token (20px, matching the
+// button line-height) rather than an emoji or a hardcoded value.
+const iconSize = vars.components.icon.size.medium;
+const iconProps = { style: { width: iconSize, height: iconSize } };
 
 const meta = {
   argTypes: {
@@ -73,42 +80,42 @@ export const Disabled: Story = {
   ),
 };
 
+/** Leading TREDS icon. */
 export const LeftIcon: Story = {
   render: (args) => (
-    <Button {...args} leftIcon={<span>🔍</span>}>
+    <Button {...args} leftIcon={<SearchIcon {...iconProps} />}>
       Search
     </Button>
   ),
 };
 
+/** Trailing TREDS icon. */
 export const RightIcon: Story = {
   render: (args) => (
-    <Button {...args} rightIcon={<span>➡️</span>}>
+    <Button {...args} rightIcon={<ArrowRightIcon {...iconProps} />}>
       Next
     </Button>
   ),
 };
 
+/** Leading and trailing TREDS icons. */
 export const BothIcons: Story = {
   render: (args) => (
-    <Button {...args} leftIcon={<span>🚀</span>} rightIcon={<span>🚀</span>}>
+    <Button
+      {...args}
+      leftIcon={<SearchIcon {...iconProps} />}
+      rightIcon={<ArrowRightIcon {...iconProps} />}
+    >
       Search Next
     </Button>
   ),
 };
 
-export const WithSvgIcon: Story = {
-  render: (args) => (
-    <Button {...args} leftIcon={<SearchIcon />}>
-      SVG Icon
-    </Button>
-  ),
-};
-
+/** Icon-only button. Always provide an aria-label for accessibility. */
 export const WithoutText: Story = {
   render: (args) => (
-    <Button {...args} aria-label="Magnifier">
-      <SearchIcon />
+    <Button {...args} aria-label="Search">
+      <SearchIcon {...iconProps} />
     </Button>
   ),
 };

--- a/src/components/Select/Select.css.ts
+++ b/src/components/Select/Select.css.ts
@@ -4,9 +4,8 @@ import { vars } from '../../theme';
 const {
   spacing,
   core,
-  font,
   text,
-  components: { typography, input, textField, item },
+  components: { typography, input, item },
   focusRing,
 } = vars;
 
@@ -16,64 +15,6 @@ export const chevronOpen = style({
 
 export const root = style({
   alignItems: 'center',
-});
-
-export const inputText = style({
-  color: text.secondary,
-});
-
-const wrapperBase = style([
-  inputText,
-  {
-    flex: 1,
-    borderRadius: core.cornerRadius,
-    fontSize: input.font.label.fontSize,
-    lineHeight: input.font.text.lineHeight,
-    letterSpacing: font.letterSpacing,
-    minHeight: textField.minHeight,
-    padding: `${input.padding.vertical} ${input.padding.horizontal}`,
-    alignItems: 'flex-start',
-    gap: input.spacing.horizontalSpacing,
-  },
-]);
-
-export const inputWrapper = styleVariants({
-  default: [
-    wrapperBase,
-    {
-      pointerEvents: 'all',
-      cursor: 'pointer',
-      border: `${input.stroke.weight.default} solid ${core.states.default}`,
-      background: core.background,
-      selectors: {
-        '&::placeholder': {
-          color: text.secondary,
-        },
-        '&:hover': {
-          border: `${input.stroke.weight.default} solid ${core.states.hover}`,
-          background: core.background,
-        },
-        '&:focus-visible': {
-          background: core.background,
-          ...focusRing,
-        },
-      },
-    },
-  ],
-  disabled: [
-    wrapperBase,
-    {
-      border: `${input.stroke.weight.default} solid ${core.states.disabled}`,
-      background: core.backgroundDisabled,
-      pointerEvents: 'none',
-    },
-  ],
-  error: [
-    wrapperBase,
-    {
-      border: `${input.stroke.weight.default} solid ${core.states.error}`,
-    },
-  ],
 });
 
 export const inputField = style({

--- a/src/components/TextField/TextField.css.ts
+++ b/src/components/TextField/TextField.css.ts
@@ -4,7 +4,7 @@ import { vars } from '../../theme';
 const {
   core,
   font,
-  components: { input: inputVars, textField },
+  components: { input: inputVars, textField, controlHeight },
   text,
   focusRing,
 } = vars;
@@ -50,9 +50,12 @@ export const inputRoot = style({
   fontSize: inputVars.font.text.fontSize,
   lineHeight: inputVars.font.text.lineHeight,
   letterSpacing: font.letterSpacing,
-  minHeight: textField.minHeight,
+  // Fixed, responsive height shared with buttons; border-box absorbs the 2px border so the
+  // input matches button variants at every breakpoint (issue #79).
+  height: controlHeight,
+  boxSizing: 'border-box',
   padding: `${inputVars.padding.vertical} ${inputVars.padding.horizontal}`,
-  alignItems: 'flex-start',
+  alignItems: 'center',
   gap: inputVars.spacing.horizontalSpacing,
   border: `${inputVars.stroke.weight.default} solid ${core.states.default}`,
   background: core.background,

--- a/src/components/TextField/TextField.css.ts
+++ b/src/components/TextField/TextField.css.ts
@@ -50,8 +50,8 @@ export const inputRoot = style({
   fontSize: inputVars.font.text.fontSize,
   lineHeight: inputVars.font.text.lineHeight,
   letterSpacing: font.letterSpacing,
-  // Fixed, responsive height shared with buttons; border-box absorbs the 2px border so the
-  // input matches button variants at every breakpoint (issue #79).
+  // Fixed, responsive height shared with buttons; border-box absorbs the stroke-weight border
+  // so the input matches button variants at every breakpoint (issue #79).
   height: controlHeight,
   boxSizing: 'border-box',
   padding: `${inputVars.padding.vertical} ${inputVars.padding.horizontal}`,

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -458,9 +458,11 @@ const fontFamilyHeader = 'Montserrat, sans-serif';
 const fontFamilyBody = 'Open Sans, sans-serif';
 
 // Shared height for single-line controls (buttons, text inputs, selects), responsive per
-// breakpoint. Authoritative values from the Figma `Breakpoint` variable collection
-// (Input/Line-height + 2 × Spacing/Small); matches the `filled` button at every breakpoint.
-// Borders are absorbed into this height via `box-sizing: border-box`. See issue #79.
+// breakpoint. Values come from the Figma `Breakpoint` variable collection and equal
+// `input.lineHeight + 2 × spacing.sm` (Figma: Input/Line-height + 2 × Spacing/Small) at each
+// breakpoint — keep this table in sync if either of those tokens changes. Every button variant
+// and input renders at this height; borders are absorbed via `box-sizing: border-box`.
+// See issue #79.
 const controlHeights = {
   xxl: '52px',
   xl: '52px',

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -457,8 +457,22 @@ const core = {
 const fontFamilyHeader = 'Montserrat, sans-serif';
 const fontFamilyBody = 'Open Sans, sans-serif';
 
+// Shared height for single-line controls (buttons, text inputs, selects), responsive per
+// breakpoint. Authoritative values from the Figma `Breakpoint` variable collection
+// (Input/Line-height + 2 × Spacing/Small); matches the `filled` button at every breakpoint.
+// Borders are absorbed into this height via `box-sizing: border-box`. See issue #79.
+const controlHeights = {
+  xxl: '52px',
+  xl: '52px',
+  lg: '52px',
+  md: '42px',
+  sm: '40px',
+  xs: '40px',
+} as const satisfies Record<keyof typeof breakpoints, string>;
+
 export function getComponents(bp: keyof typeof breakpoints) {
   return {
+    controlHeight: rem(controlHeights[bp]),
     breadcrumbs: {
       activePageFontWeight: '600',
     },


### PR DESCRIPTION
## Summary

Fixes #79. Closes #32. Buttons and inputs now share a single, responsive control height so they line up when placed side by side. Previously borders were added *outside* the box, so `outlined` (+4px), `text` (+2px) and `TextField` inputs (+4px) inflated above the `filled` button.

This also resolves #32 (inputs/selects taller than buttons in Firefox only): giving the input a fixed `height` + `box-sizing: border-box` means Firefox's `line-height: normal` floor governs only the text flow inside the box, not the box's outer height — verified in Firefox 151 (see comment below).

## Approach

- **New responsive `controlHeight` token** in `getComponents` (`themeVariables.ts`): per-breakpoint `xxl/xl/lg 52 · md 42 · sm/xs 40`, authoritative per the Figma `Breakpoint` variable collection. Exposed as `vars.components.controlHeight`, updating via the existing media-query machinery.
- **`Button.css.ts`** — all variants get `height: controlHeight` + `box-sizing: border-box` + flex centering. `filled` is visually unchanged; `outlined`/`text` come *down* to match.
- **`TextField.css.ts`** — input swaps the hardcoded, non-responsive `minHeight: 52px` for `height: controlHeight` + `border-box`.
- **`Select`** — no code change needed: it renders a `<TextField>` internally, so the fix propagates automatically.
- **`TextArea`** deliberately untouched — it's multi-line and legitimately needs `minHeight` to grow.

## Also in this PR

- `refactor`: removed dead `inputWrapper`/`wrapperBase`/`inputText` styles in `Select.css.ts` (carried a stale non-responsive `minHeight`).
- `docs`: Button stories reworked — named per-variant stories (`Filled`/`Outlined`/`Text`), `Variants` + `Disabled` showcases, and JSDoc "when to use" descriptions so `outlined`/`text` are visible in autodocs without touching controls. Icon stories now use real TREDS icons sized via the `icon.size.medium` token instead of emoji placeholders.
- `chore`: gitignore additions (`CLAUDE.md`, `docs/`, `.obsidian/`, `.DS_Store`).

## Testing

- New `ControlHeightConsistency` story (`Button.stories.tsx`) asserts all five controls (text input, select, 3 button variants) render at the **same height** *and* share the same **bottom-border line**.
- Full suite green: **81/81 tests** across 19 files (real Chromium / Mantine components), `tsc`, ESLint, Prettier all clean.
- **Firefox 151 manually verified** (the suite runs Chromium-only): all five controls render at identical heights — 52px at ≥lg, 40px at xs — despite Firefox resolving the input `line-height` *higher* than the buttons'. See comment below for the measurements.

## Notes

- The DateField (#52) calendar dropdowns are temporarily at 38px on `feat/52-datefield`; once this merges, that override should be reverted to `vars.components.controlHeight`.
- Heads-up: `SearchField.stories.tsx` is intermittently flaky in full-suite runs (passes in isolation) — pre-existing, unrelated to this change.

