### PR TITLE
docs: expand 0.4.0 changelog to full release scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-08-03
 
+Bundles everything merged since `v0.3.1`.
+
+### Upgrade notes
+
+- **Breaking — font packages changed.** Update your install:
+  `npm install @tampere/treds@0.4.0 @fontsource-variable/montserrat @fontsource-variable/open-sans`
+  then `npm uninstall @fontsource/montserrat @fontsource/open-sans`.
+- **Control heights changed.** Buttons, text inputs, and selects now share one
+  responsive height token with `box-sizing: border-box`. Tight or custom-aligned
+  layouts may shift by a few pixels at some breakpoints — worth a quick visual
+  check on dense forms.
+
 ### Changed
 
 - **BREAKING:** Migrated typography to variable fonts. The peer dependencies
   `@fontsource/montserrat` and `@fontsource/open-sans` are replaced by
-  `@fontsource-variable/montserrat` and `@fontsource-variable/open-sans`.
-  Consumers must update their installed font packages accordingly.
-- Font families are now `"Montserrat Variable"` (headings) and
-  `"Open Sans Variable"` (body). `ThemeProvider` imports the variable font CSS
-  from the `@fontsource-variable/*` packages; as peer dependencies these stay
-  external in the published bundle and are resolved by the consumer's build.
+  `@fontsource-variable/montserrat` and `@fontsource-variable/open-sans`
+  (#86). Font families are now `"Montserrat Variable"` (headings) and
+  `"Open Sans Variable"` (body); `ThemeProvider` imports the variable font CSS
+  from the `@fontsource-variable/*` packages, which stay external in the
+  published bundle and are resolved by the consumer's build. Replaces the nine
+  discrete `@fontsource/*` per-weight CSS imports with one variable-axis import
+  per family.
+- Consistent responsive control height across buttons/inputs/selects via a new
+  `controlHeight` token with `border-box` sizing (#79, #80).
+- Internal: `LoadingIndicators` folder renamed to `LoadingSpinner` — the public
+  `LoadingSpinner` export is unchanged, so no consumer action is required.
 
-### Removed
+### Fixed
 
-- The nine discrete `@fontsource/*` per-weight CSS imports in `ThemeProvider`,
-  replaced by one variable-axis import per family.
+- Select chevron rotation and toggle behavior (#78).
+- Missing font family in the theme (#68).
+- Restored missing `RadioButton` export and corrected the `Modal` index export
+  (#64).
+- Added the missing `ArrowDownIcon` export (#77).
+
+### Internal / tooling
+
+- Conventional Commits config and git push hooks (#67).
+- `.npmrc` template (#66).
+- Issue templates.


### PR DESCRIPTION
Expands the `0.4.0` CHANGELOG entry (added in #86) to cover the whole release since `v0.3.1` — not just the font change:

- control-height token (#79/#80)
- Select chevron/toggle (#78), theme font-family (#68), `RadioButton`/`Modal` exports (#64), `ArrowDownIcon` export (#77)
- tooling: conventional commits (#67), `.npmrc` template (#66), issue templates
- **Upgrade notes** for the breaking font peer-dep swap and the control-height layout shift

Should merge **before** tagging `v0.4.0` so the tag includes the complete changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
