### PR TITLE
fix: v1.0.0 fidelity fixes (#85, #82, #48, #45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -434,3 +434,6 @@ docs/
 
 # Playwright MCP debug output
 .playwright-mcp/
+
+# Subagent-driven-development scratch workspace (ledgers, briefs, review packages)
+.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Visual: SearchField's search trigger icon now shrinks at narrow
   breakpoints** instead of staying a fixed size, matching the control's
   responsive sizing.
+- **Breaking: `TableRow` selection is now a controlled prop.** See "Breaking
+  changes" under `### Changed` below for the migration.
+- **Breaking: the `red` color palette's internal structure changed** for
+  consumers of the raw `colors`/`themeVariablesV2` palette. See "Breaking
+  changes" under `### Changed` below — semantic token consumers are
+  unaffected.
+
+### Added
+
+- `IconButton` now supports `size="xs"`, matching the extra-small variant
+  already available on other controls.
 
 ### Fixed
 
@@ -33,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overlay contrast opacity (5% → 10%). The red color palette's internal
   structure was also cleaned up to match Figma's 3-step scale — no visible
   color change, since the correct value was already reachable under a
-  differently-named key (#85). Note: these corrections apply to the
+  differently-named key (see "Breaking changes" below for raw-palette
+  consumers) (#85). Note: these corrections apply to the
   library's live CSS/rendered output; the package's raw `themeVariables` JS
   export still returns the pre-fix values pending
   [#92](https://github.com/Tampere/Tampere-design-system/issues/92).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     </TableRow>
   ```
 
+- **Breaking: the `red` color palette's internal structure changed.**
+  `colors.red` (exposed via `vars.colors` and the raw `themeVariablesV2`
+  export) now has 3 steps instead of 4, matching Figma. `red['400']` was
+  removed, and the value it held (`#ae1e20`) now lives under `red['300']`
+  instead of the old, non-Figma `red['300']` (`#da2321`). This only affects
+  consumers who referenced the raw `colors` palette directly instead of the
+  semantic `core.error`/`core.states.error` tokens, which resolve to the
+  same corrected color as before (#85).
+
 ## [0.5.0] - 2026-08-06
 
 **Storybook:** https://tampere.github.io/Tampere-design-system/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,23 +18,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the calendar popover's drop shadow.
 - **Visual: IconButton `size="sm"` icons are slightly larger.** The rendered
   icon grows from 16px to 18px to match Figma.
+- **Visual: IconButton `size="lg"` is now square.** Because the button's root
+  has no explicit width/height (it sizes to its content), correcting the icon
+  from 24×28 to 24×24 also shrinks the rendered button box to match. This
+  affects `Pagination`'s chevron buttons and `Modal`'s close button — worth a
+  quick visual check.
 - **Visual: IconButton contrast-disabled icons are slightly darker.** The
   disabled icon color moves one shade darker (neutral/300 → neutral/400) to
   match Figma.
 - **Visual: SearchField's search trigger icon now shrinks at narrow
   breakpoints** instead of staying a fixed size, matching the control's
   responsive sizing.
-- **Breaking: `TableRow` selection is now a controlled prop.** See "Breaking
-  changes" under `### Changed` below for the migration.
+- **Breaking: `TableRow` selection is now a controlled prop.** See the
+  **Breaking:** entries under `### Changed` below for the migration.
 - **Breaking: the `red` color palette's internal structure changed** for
-  consumers of the raw `colors`/`themeVariablesV2` palette. See "Breaking
-  changes" under `### Changed` below — semantic token consumers are
-  unaffected.
+  consumers of the raw `colors`/`themeVariablesV2` palette. See the
+  **Breaking:** entries under `### Changed` below — semantic token consumers
+  are unaffected.
 
 ### Added
 
 - `IconButton` now supports `size="xs"`, matching the extra-small variant
   already available on other controls.
+- `TableRow` now sets `aria-selected` to reflect its `selected` state, for
+  assistive technology (#48).
 
 ### Fixed
 
@@ -44,8 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overlay contrast opacity (5% → 10%). The red color palette's internal
   structure was also cleaned up to match Figma's 3-step scale — no visible
   color change, since the correct value was already reachable under a
-  differently-named key (see "Breaking changes" below for raw-palette
-  consumers) (#85). Note: these corrections apply to the
+  differently-named key (see the **Breaking:** entry under `### Changed`
+  below for raw-palette consumers) (#85). Note: these corrections apply to the
   library's live CSS/rendered output; the package's raw `themeVariables` JS
   export still returns the pre-fix values pending
   [#92](https://github.com/Tampere/Tampere-design-system/issues/92).
@@ -53,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   size instead of staying a fixed 24px (#82).
 - Pagination's "next page" chevron now renders the actual right-pointing
   icon instead of a rotated left-pointing one (no visible change) (#45).
+- IconButton's `size="lg"` icon is now square (24×24, was 24×28) to match
+  Figma; since the button's root is content-sized, this also shrinks the
+  rendered button box, affecting `Pagination`'s chevron buttons and `Modal`'s
+  close button (#93, #45).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (pre-1.0: breaking changes bump the minor version).
 
+## [Unreleased]
+
+### Fixed
+
+- Token values corrected to match Figma: dropshadow (was a solid grey, now
+  Figma's semi-transparent black), icon xs/sm sizes (12/16px → 16/18px),
+  IconButton contrast-disabled color (neutral/300 → neutral/400), hover
+  overlay contrast opacity (5% → 10%). The red color palette's internal
+  structure was also cleaned up to match Figma's 3-step scale — no visible
+  color change, since the correct value was already reachable under a
+  differently-named key (#85).
+- `SearchField`'s search trigger icon now scales with the responsive control
+  size instead of staying a fixed 24px (#82).
+- Pagination's "next page" chevron now renders the actual right-pointing
+  icon instead of a rotated left-pointing one (no visible change) (#45).
+
+### Changed
+
+- **Breaking:** `TableRow` selection is now a controlled prop
+  (`selected`/`onSelectedChange`) instead of an internal DOM `classList`
+  mutation. Consumers relying on the previous click-to-toggle-automatically
+  behavior must now manage selection state themselves (#48).
+
 ## [0.5.0] - 2026-08-06
 
 **Storybook:** https://tampere.github.io/Tampere-design-system/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **Visual: Accordion item shadow changed.** The drop shadow under each
+  `Accordion` item is now Figma's semi-transparent black (was an opaque
+  grey). Worth a quick visual check if you have snapshot tests.
+- **Visual: DateField calendar popover shadow changed.** Same
+  opaque-grey-to-semi-transparent-black correction as `Accordion`, applied to
+  the calendar popover's drop shadow.
+- **Visual: IconButton `size="sm"` icons are slightly larger.** The rendered
+  icon grows from 16px to 18px to match Figma.
+- **Visual: IconButton contrast-disabled icons are slightly darker.** The
+  disabled icon color moves one shade darker (neutral/300 → neutral/400) to
+  match Figma.
+- **Visual: SearchField's search trigger icon now shrinks at narrow
+  breakpoints** instead of staying a fixed size, matching the control's
+  responsive sizing.
+
 ### Fixed
 
 - Token values corrected to match Figma: dropshadow (was a solid grey, now
@@ -16,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overlay contrast opacity (5% → 10%). The red color palette's internal
   structure was also cleaned up to match Figma's 3-step scale — no visible
   color change, since the correct value was already reachable under a
-  differently-named key (#85).
+  differently-named key (#85). Note: these corrections apply to the
+  library's live CSS/rendered output; the package's raw `themeVariables` JS
+  export still returns the pre-fix values pending
+  [#92](https://github.com/Tampere/Tampere-design-system/issues/92).
 - `SearchField`'s search trigger icon now scales with the responsive control
   size instead of staying a fixed 24px (#82).
 - Pagination's "next page" chevron now renders the actual right-pointing
@@ -28,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`selected`/`onSelectedChange`) instead of an internal DOM `classList`
   mutation. Consumers relying on the previous click-to-toggle-automatically
   behavior must now manage selection state themselves (#48).
+
+  ```diff
+  - <TableRow onClick={handleClick}>
+  + <TableRow selected={isSelected} onSelectedChange={setIsSelected}>
+      <TableCell>...</TableCell>
+    </TableRow>
+  ```
 
 ## [0.5.0] - 2026-08-06
 

--- a/src/components/Accordion/Accordion.css.ts
+++ b/src/components/Accordion/Accordion.css.ts
@@ -74,7 +74,7 @@ export const chevron = style({
 export const item = style({
   display: 'flex',
   flexDirection: 'column',
-  boxShadow: `0px 1px 4px 0px ${core.dropshadow}`, // TODO: Use theme variable
+  boxShadow: `0px 1px 4px 0px ${core.dropshadow}`,
 });
 
 export const content = style({

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import { Accordion, AccordionItem } from './Accordion';
+import { item as accordionItem } from './Accordion.css.ts';
 
 const meta: Meta<typeof Accordion> = {
   argTypes: {
@@ -42,15 +44,13 @@ export const Primary: Story = {
       </AccordionItem>
     </Accordion>
   ),
-  play: async () => {
+  play: async ({ canvasElement }) => {
     // Test: Verify that Accordion item uses the corrected dropshadow token (semi-transparent black)
-    const items = document.querySelectorAll('[class*="item"]');
-    for (const item of items) {
-      const shadow = window.getComputedStyle(item).boxShadow;
+    const items = canvasElement.querySelectorAll(`.${accordionItem}`);
+    await expect(items.length).toBeGreaterThan(0);
+    for (const el of items) {
       // Assert that the shadow includes rgba(0, 0, 0, 0.5) (semi-transparent black at 50% opacity)
-      if (!shadow.match(/rgba\(0,\s*0,\s*0,\s*0\.5\)/)) {
-        throw new Error(`Accordion item shadow does not match expected value. Got: ${shadow}`);
-      }
+      await expect(getComputedStyle(el).boxShadow).toMatch(/rgba\(0,\s*0,\s*0,\s*0\.5\)/);
     }
   },
 };

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -42,4 +42,15 @@ export const Primary: Story = {
       </AccordionItem>
     </Accordion>
   ),
+  play: async () => {
+    // Test: Verify that Accordion item uses the corrected dropshadow token (semi-transparent black)
+    const items = document.querySelectorAll('[class*="item"]');
+    for (const item of items) {
+      const shadow = window.getComputedStyle(item).boxShadow;
+      // Assert that the shadow includes rgba(0, 0, 0, 0.5) (semi-transparent black at 50% opacity)
+      if (!shadow.match(/rgba\(0,\s*0,\s*0,\s*0\.5\)/)) {
+        throw new Error(`Accordion item shadow does not match expected value. Got: ${shadow}`);
+      }
+    }
+  },
 };

--- a/src/components/Checkbox/Checkbox.css.ts
+++ b/src/components/Checkbox/Checkbox.css.ts
@@ -6,7 +6,6 @@ const {
   spacing,
   focusRing,
   core,
-  colors,
   components: { iconButton },
   text,
 } = vars;
@@ -98,5 +97,5 @@ globalStyle(`${input}[data-disabled=true] + svg path`, {
 
 // Error state
 globalStyle(`${input}[data-error=true] + svg path`, {
-  fill: colors.red[400],
+  fill: core.states.error,
 });

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import { useArgs } from '@storybook/client-api';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 import { Checkbox } from './Checkbox';
 
 const meta = {
@@ -67,6 +68,13 @@ export const Disabled: Story = {
 export const Error: Story = {
   args: { label: 'Error option', error: true },
   render: (args) => <Checkbox {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const path = canvas.getByRole('checkbox').parentElement?.querySelector('svg path');
+    await expect(path).toBeTruthy();
+    // Figma Common/Error = Red/300 (#ae1e20).
+    await expect(getComputedStyle(path as Element).fill).toBe('rgb(174, 30, 32)');
+  },
 };
 
 export const RichLabel: Story = {

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 import { DateField } from './DateField';
 import { dayCellOutsideMonth, dayCellDisabled } from './DateField.css.ts';
 import { vars } from '../../theme';
+import { themeVariables } from '../../theme/themeVariables';
 
 const meta = {
   component: DateField,
@@ -1466,5 +1467,13 @@ export const OutsideMonthDayMeetsContrast: Story = {
       .find((b) => b.textContent?.trim() === '31' && b.className.includes(dayCellOutsideMonth));
     await expect(outsideJuly31).toBeTruthy();
     await expect(getComputedStyle(outsideJuly31!).opacity).toBe('1');
+  },
+};
+
+export const HoverOverlayContrastMatchesFigma: Story = {
+  // core.hover.overlayContrast has no rendered consumer yet — direct token check.
+  // Figma Background/Overlay/Contrast (#ffffff1a) is ~10% white, not 5%.
+  play: async () => {
+    await expect(themeVariables.core.hover.overlayContrast).toBe('rgba(255, 255, 255, 0.1000)');
   },
 };

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -234,7 +234,15 @@ export const OpenCalendar: Story = {
     await userEvent.click(canvas.getByLabelText('Avaa kalenteri'));
     // Dropdown portals to document.body, outside canvasElement
     const body = within(document.body);
-    await expect(await body.findByTestId('date-field-calendar')).toBeInTheDocument();
+    const dialog = await body.findByTestId('date-field-calendar');
+    await expect(dialog).toBeInTheDocument();
+
+    // The dropshadow token must match Figma's semi-transparent black
+    // (Effects/Dropshadow = #00000080), not a solid opaque grey.
+    const popover = dialog.closest('[role="dialog"]')?.parentElement;
+    await expect(popover).toBeTruthy();
+    const boxShadow = getComputedStyle(popover as Element).boxShadow;
+    await expect(boxShadow).toMatch(/rgba\(0,\s*0,\s*0,\s*0\.5\)/);
   },
 };
 

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -1474,7 +1474,9 @@ export const OutsideMonthDayMeetsContrast: Story = {
 };
 
 export const HoverOverlayContrastMatchesFigma: Story = {
-  // core.hover.overlayContrast has no rendered consumer yet — direct token check.
+  // core.hover.overlayContrast is now also rendered via
+  // iconButton.states.contrast.overlay; this stays a direct token check since
+  // no story currently asserts on that background visually.
   // Figma Background/Overlay/Contrast (#ffffff1a) is ~10% white, not 5%.
   play: async () => {
     await expect(themeVariables.core.hover.overlayContrast).toBe('rgba(255, 255, 255, 0.1000)');

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -4,7 +4,7 @@ import { within, userEvent, waitFor, fireEvent } from '@storybook/testing-librar
 import { expect, fn } from 'storybook/test';
 import dayjs from 'dayjs';
 import { DateField } from './DateField';
-import { dayCellOutsideMonth, dayCellDisabled } from './DateField.css.ts';
+import { dayCellOutsideMonth, dayCellDisabled, popoverContent } from './DateField.css.ts';
 import { vars } from '../../theme';
 import { themeVariables } from '../../theme/themeVariables';
 
@@ -239,8 +239,11 @@ export const OpenCalendar: Story = {
     await expect(dialog).toBeInTheDocument();
 
     // The dropshadow token must match Figma's semi-transparent black
-    // (Effects/Dropshadow = #00000080), not a solid opaque grey.
-    const popover = dialog.closest('[role="dialog"]')?.parentElement;
+    // (Effects/Dropshadow = #00000080), not a solid opaque grey. Query by the
+    // exported style class directly (as Accordion's equivalent test does)
+    // rather than walking Mantine's internal Popover DOM nesting, which is
+    // not a stable public contract.
+    const popover = document.querySelector(`.${popoverContent}`);
     await expect(popover).toBeTruthy();
     const boxShadow = getComputedStyle(popover as Element).boxShadow;
     await expect(boxShadow).toMatch(/rgba\(0,\s*0,\s*0,\s*0\.5\)/);

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -41,7 +41,7 @@ globalStyle(`${root}[data-size="md"] svg`, {
 });
 globalStyle(`${root}[data-size="lg"] svg`, {
   width: icon.size.large,
-  height: icon.size.extraLarge,
+  height: icon.size.large,
 });
 globalStyle(`${root}[data-size="xl"] svg`, {
   width: icon.size.extraLarge,

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -27,6 +27,10 @@ export const iconWrapper = style({
   justifyContent: 'center',
 });
 
+globalStyle(`${root}[data-size="xs"] svg`, {
+  width: icon.size.extraSmall,
+  height: icon.size.extraSmall,
+});
 globalStyle(`${root}[data-size="sm"] svg`, {
   width: icon.size.small,
   height: icon.size.small,

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -84,6 +84,9 @@ export const Colored: Story = {
 };
 
 export const SmallSizeIconMatchesToken: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
   // The rendered icon inside a "sm" IconButton must be sized from
   // components.icon.size.small (Figma: 18px), not a stale 16px value.
   render: (args) => (
@@ -101,6 +104,9 @@ export const SmallSizeIconMatchesToken: Story = {
 };
 
 export const ExtraSmallIconTokenMatchesFigma: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
   // components.icon.size.extraSmall has no rendered consumer yet (no
   // IconButton "xs" variant exists), so this is a direct token-value check
   // rather than a DOM assertion.

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -4,8 +4,6 @@ import { within } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { IconButton } from './IconButton';
 import { SearchIcon } from '../../icons/SearchIcon';
-import { themeVariables } from '../../theme/themeVariables';
-import { rem } from '@mantine/core';
 
 const meta = {
   argTypes: {
@@ -103,15 +101,23 @@ export const SmallSizeIconMatchesToken: Story = {
   },
 };
 
-export const ExtraSmallIconTokenMatchesFigma: Story = {
+export const ExtraSmallSizeIconMatchesToken: Story = {
   // Test-only: carries a `play` assertion, not documentation, so it's hidden
   // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
   tags: ['!dev', '!autodocs'],
-  // components.icon.size.extraSmall has no rendered consumer yet (no
-  // IconButton "xs" variant exists), so this is a direct token-value check
-  // rather than a DOM assertion.
-  render: (args) => <IconButton {...args} size="md" variant="light" />,
-  play: async () => {
-    await expect(themeVariables.components.icon.size.extraSmall).toBe(rem('16px'));
+  // The rendered icon inside an "xs" IconButton must be sized from
+  // components.icon.size.extraSmall (Figma: 16px), not fall back to the raw
+  // icon's own default size for lack of a data-size="xs" style rule.
+  render: (args) => (
+    <IconButton {...args} size="xs" variant="light">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const svg = canvas.getByRole('button').querySelector('svg') as SVGElement;
+    await expect(svg).toBeTruthy();
+    const width = getComputedStyle(svg).width;
+    await expect(width).toBe('16px');
   },
 };

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,7 +1,11 @@
 import { Box, Flex } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 import { IconButton } from './IconButton';
 import { SearchIcon } from '../../icons/SearchIcon';
+import { themeVariables } from '../../theme/themeVariables';
+import { rem } from '@mantine/core';
 
 const meta = {
   argTypes: {
@@ -69,4 +73,31 @@ export const Colored: Story = {
       </Box>
     </Flex>
   ),
+};
+
+export const SmallSizeIconMatchesToken: Story = {
+  // The rendered icon inside a "sm" IconButton must be sized from
+  // components.icon.size.small (Figma: 18px), not a stale 16px value.
+  render: (args) => (
+    <IconButton {...args} size="sm" variant="light">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const svg = canvas.getByRole('button').querySelector('svg') as SVGElement;
+    await expect(svg).toBeTruthy();
+    const width = getComputedStyle(svg).width;
+    await expect(width).toBe('18px');
+  },
+};
+
+export const ExtraSmallIconTokenMatchesFigma: Story = {
+  // components.icon.size.extraSmall has no rendered consumer yet (no
+  // IconButton "xs" variant exists), so this is a direct token-value check
+  // rather than a DOM assertion.
+  render: (args) => <IconButton {...args} size="md" variant="light" />,
+  play: async () => {
+    await expect(themeVariables.components.icon.size.extraSmall).toBe(rem('16px'));
+  },
 };

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -123,3 +123,25 @@ export const ExtraSmallSizeIconMatchesToken: Story = {
     await expect(width).toBe('16px');
   },
 };
+
+export const LargeSizeIconMatchesToken: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
+  // The rendered icon inside a "lg" IconButton must be square, sized from
+  // components.icon.size.large (Figma: 24px) on both axes — not stretched by
+  // pairing a mismatched height token.
+  render: (args) => (
+    <IconButton {...args} size="lg" variant="light">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const svg = canvas.getByRole('button').querySelector('svg') as SVGElement;
+    await expect(svg).toBeTruthy();
+    const { width, height } = getComputedStyle(svg);
+    await expect(width).toBe('24px');
+    await expect(height).toBe('24px');
+  },
+};

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -47,7 +47,7 @@ export const Light: Story = {
 
 export const Disabled: Story = {
   render: (args) => (
-    <IconButton disabled variant="light" size="md" {...args}>
+    <IconButton variant="light" size="md" {...args} disabled>
       <SearchIcon fill="gray" />
     </IconButton>
   ),

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -12,12 +12,14 @@ const meta = {
     size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     disabled: { control: 'boolean' },
     onClick: { action: 'clicked' },
+    'aria-label': { control: 'text' },
   },
   args: {
     children: '<Icon />',
     variant: 'light',
     size: 'md',
     disabled: false,
+    'aria-label': 'Search',
   },
   component: IconButton,
 } satisfies Meta<typeof IconButton>;

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -51,6 +51,14 @@ export const Disabled: Story = {
       <SearchIcon fill="gray" />
     </IconButton>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const path = canvas.getByRole('button').querySelector('path') as SVGPathElement;
+    await expect(path).toBeTruthy();
+    // Figma Components/Icon-button/Contrast/Disabled = Neutral/400 (#9999a0),
+    // not Neutral/300 (#c9c9ce).
+    await expect(getComputedStyle(path).fill).toBe('rgb(153, 153, 160)');
+  },
 };
 
 export const Colored: Story = {

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -53,7 +53,9 @@ export const Disabled: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const path = canvas.getByRole('button').querySelector('path') as SVGPathElement;
+    const button = canvas.getByRole('button', { name: 'Search' });
+    await expect(button).toBeInTheDocument();
+    const path = button.querySelector('path') as SVGPathElement;
     await expect(path).toBeTruthy();
     // Figma Components/Icon-button/Contrast/Disabled = Neutral/400 (#9999a0),
     // not Neutral/300 (#c9c9ce).

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -4,7 +4,7 @@ import { mergeClassNames } from '../../utils';
 import { iconWrapper, iconRoot } from './IconButton.css.ts';
 
 type IconButtonVariant = 'light' | 'dark';
-type IconButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+type IconButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface Props extends ActionIconProps, PropsWithChildren {
   variant?: IconButtonVariant;

--- a/src/components/Pagination/Pagination.css.ts
+++ b/src/components/Pagination/Pagination.css.ts
@@ -75,5 +75,4 @@ export const leftButton = style({
 export const rightButton = style({
   width: pagination.itemWidth,
   height: pagination.itemHeight,
-  transform: 'rotate(180deg)',
 });

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 // react hooks not required here; story state is managed via Storybook args
 import { useArgs } from '@storybook/client-api';
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 
 import { Pagination } from './Pagination';
 
@@ -47,5 +49,28 @@ export const Primary: Story = {
         maxVisiblePages={args.maxVisiblePages}
       />
     );
+  },
+};
+
+export const ChevronsPointCorrectDirections: Story = {
+  args: {
+    pageCount: 5,
+    activePageIndex: 2,
+    onPageChange: () => {},
+    leftButtonLabel: 'Previous',
+    rightButtonLabel: 'Next',
+  },
+  render: (args) => <Pagination {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const leftPath = canvas.getByLabelText('Previous').querySelector('path') as SVGPathElement;
+    const rightPath = canvas.getByLabelText('Next').querySelector('path') as SVGPathElement;
+
+    // ChevronLeftIcon's path starts near the SVG's right edge (x≈15) curving
+    // to a point at the left (x≈7); ChevronRightIcon is the mirror image.
+    // Asserting on the raw path data pins the actual rendered glyph, not an
+    // incidental CSS transform that happens to produce the same pixels.
+    await expect(leftPath.getAttribute('d')).toContain('M15.207 20.207');
+    await expect(rightPath.getAttribute('d')).toContain('M8.79297 3.79297');
   },
 };

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -53,6 +53,9 @@ export const Primary: Story = {
 };
 
 export const ChevronsPointCorrectDirections: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
   args: {
     pageCount: 5,
     activePageIndex: 2,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import { Flex, List, UnstyledButton } from '@mantine/core';
 import { IconButton } from '../IconButton/IconButton.tsx';
 import { ChevronLeftIcon } from '../../icons/ChevronLeftIcon.tsx';
+import { ChevronRightIcon } from '../../icons/ChevronRightIcon.tsx';
 import { leftButton, list, listItem, rightButton } from './Pagination.css.ts';
 
 interface Props {
@@ -122,7 +123,7 @@ export function Pagination({
         size="lg"
         variant="dark"
       >
-        <ChevronLeftIcon />
+        <ChevronRightIcon />
       </IconButton>
     </Flex>
   );

--- a/src/components/RadioButton/RadioButton.css.ts
+++ b/src/components/RadioButton/RadioButton.css.ts
@@ -4,7 +4,6 @@ import { vars } from '../../theme';
 const {
   core,
   focusRing,
-  colors,
   components: { typography, icon: iconVars, iconButton },
   text,
   spacing,
@@ -86,7 +85,7 @@ globalStyle(`${input}[data-disabled=true] + svg path`, {
 
 // Error state
 globalStyle(`${input}[data-error=true] + svg path`, {
-  fill: colors.red[400],
+  fill: core.states.error,
 });
 
 // Focus ring (shared)

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useArgs } from '@storybook/client-api';
+import { expect, within } from 'storybook/test';
 import { RadioButton } from './RadioButton';
 
 const meta: Meta<typeof RadioButton> = {
@@ -71,6 +72,13 @@ export const Error: Story = {
       } catch {}
     };
     return <RadioButton {...args} checked={checked} onClick={handleClick} />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const path = canvas.getByRole('radio').parentElement?.querySelector('svg path');
+    await expect(path).toBeTruthy();
+    // Figma Common/Error = Red/300 (#ae1e20).
+    await expect(getComputedStyle(path as Element).fill).toBe('rgb(174, 30, 32)');
   },
 };
 

--- a/src/components/SearchField/SearchField.css.ts
+++ b/src/components/SearchField/SearchField.css.ts
@@ -70,6 +70,14 @@ export const listOptions = style({
   padding: 0,
 });
 
+// The search trigger icon scales with the responsive control size: its width
+// tracks the button line-height token, so it shrinks with the field instead
+// of staying a fixed 24px. Mirrors DateField.css.ts's identical `triggerIcon`.
+export const triggerIcon = style({
+  width: buttonVars.lineHeight,
+  height: 'auto',
+});
+
 globalStyle(`${option}[data-combobox-selected="true"]`, {
   background: item.background.selected.default,
   fontWeight: item.highlightFontWeight,

--- a/src/components/SearchField/SearchField.stories.tsx
+++ b/src/components/SearchField/SearchField.stories.tsx
@@ -324,6 +324,9 @@ export const ClearInput: Story = {
 };
 
 export const TriggerIconTracksControlSize: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
   // The search trigger icon must scale with the responsive control size (it is
   // sized to the button's line-height token), not stay a fixed 24px while the
   // field shrinks on small breakpoints. Mirrors DateField's identical fix.

--- a/src/components/SearchField/SearchField.stories.tsx
+++ b/src/components/SearchField/SearchField.stories.tsx
@@ -322,3 +322,27 @@ export const ClearInput: Story = {
     await expect(input).toHaveValue('');
   },
 };
+
+export const TriggerIconTracksControlSize: Story = {
+  // The search trigger icon must scale with the responsive control size (it is
+  // sized to the button's line-height token), not stay a fixed 24px while the
+  // field shrinks on small breakpoints. Mirrors DateField's identical fix.
+  args: {
+    inputLabel: 'Search',
+    data: [],
+    clearButtonLabel: 'Clear',
+    onSearch: () => {},
+    onChange: () => {},
+    searchButtonProps: { 'aria-label': 'Etsi' },
+  },
+  render: (args) => <SearchField {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByLabelText('Etsi');
+    const icon = trigger.querySelector('svg') as SVGElement;
+    await expect(icon).toBeTruthy();
+    const lineHeightPx = parseFloat(getComputedStyle(trigger).lineHeight);
+    const iconWidth = icon.getBoundingClientRect().width;
+    await expect(iconWidth).toBeCloseTo(lineHeightPx, 0);
+  },
+};

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -5,13 +5,13 @@ import { themeVariables } from '../../theme/themeVariables.ts';
 import { Button, ButtonProps } from '../Button';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { TextField, TextFieldProps } from '../TextField/';
-import { dropdown, inputWrapper, listOptions, option } from './SearchField.css.ts';
+import { dropdown, inputWrapper, listOptions, option, triggerIcon } from './SearchField.css.ts';
 
 // Search button component
 const SearchButton = ({ disabled, ...restProps }: ButtonProps) => {
   return (
     <Button variant="filled" disabled={disabled} {...restProps}>
-      <SearchIcon {...(!disabled && { fill: 'white' })} />
+      <SearchIcon className={triggerIcon} {...(!disabled && { fill: 'white' })} />
     </Button>
   );
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import { Stack } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 import {
   Table,
   TableBody,
@@ -122,5 +125,45 @@ export const Primary: Story = {
         </TableFooter>
       </Stack>
     );
+  },
+};
+
+export const SelectableRows: Story = {
+  render: () => {
+    const SelectableTable = () => {
+      const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+      return (
+        <Table>
+          <TableBody>
+            {['Row one', 'Row two'].map((label, index) => (
+              <TableRow
+                key={label}
+                selected={selectedIndex === index}
+                onSelectedChange={(selected) => setSelectedIndex(selected ? index : null)}
+              >
+                <TableCell>{label}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      );
+    };
+    return <SelectableTable />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const firstRow = canvas.getByText('Row one').closest('tr') as HTMLElement;
+    const secondRow = canvas.getByText('Row two').closest('tr') as HTMLElement;
+
+    await expect(firstRow.className).not.toMatch(/selected/);
+    await userEvent.click(firstRow);
+    await expect(firstRow.className).toMatch(/selected/);
+
+    // Selecting the second row deselects the first — selection state lives in
+    // React (the story's useState), not in the DOM, so this could not have
+    // worked correctly under the old classList-mutation implementation.
+    await userEvent.click(secondRow);
+    await expect(secondRow.className).toMatch(/selected/);
+    await expect(firstRow.className).not.toMatch(/selected/);
   },
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -156,14 +156,18 @@ export const SelectableRows: Story = {
     const secondRow = canvas.getByText('Row two').closest('tr') as HTMLElement;
 
     await expect(firstRow.className).not.toMatch(/selected/);
+    await expect(firstRow).toHaveAttribute('aria-selected', 'false');
     await userEvent.click(firstRow);
     await expect(firstRow.className).toMatch(/selected/);
+    await expect(firstRow).toHaveAttribute('aria-selected', 'true');
 
     // Selecting the second row deselects the first — selection state lives in
     // React (the story's useState), not in the DOM, so this could not have
     // worked correctly under the old classList-mutation implementation.
     await userEvent.click(secondRow);
     await expect(secondRow.className).toMatch(/selected/);
+    await expect(secondRow).toHaveAttribute('aria-selected', 'true');
     await expect(firstRow.className).not.toMatch(/selected/);
+    await expect(firstRow).toHaveAttribute('aria-selected', 'false');
   },
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -57,6 +57,9 @@ type TableRowSelection =
       /** Called with the new selection state when the row is clicked. */
       onSelectedChange: (selected: boolean) => void;
     }
+  // `never` (not `{}` or `Partial<...>`) is required here — either of those
+  // would silently allow `selected` alone, reopening the "selected but never
+  // togglable" bug this union exists to prevent (#48).
   | { selected?: never; onSelectedChange?: never };
 
 export type TableRowProps = ComponentPropsWithoutRef<'tr'> & TableRowSelection;
@@ -72,6 +75,7 @@ export function TableRow({
   return (
     <MantineTable.Tr
       {...props}
+      aria-selected={selected}
       onClick={(e) => {
         onClick?.(e);
         onSelectedChange?.(!selected);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -50,24 +50,29 @@ export function TableCell({ children, className, ...props }: ComponentPropsWitho
   );
 }
 
+export interface TableRowProps extends ComponentPropsWithoutRef<'tr'> {
+  /** Whether this row is currently selected. Controlled — the consumer owns this state. */
+  selected?: boolean;
+  /** Called with the new selection state when the row is clicked. */
+  onSelectedChange?: (selected: boolean) => void;
+}
+
 export function TableRow({
   children,
   className,
   onClick,
+  selected,
+  onSelectedChange,
   ...props
-}: ComponentPropsWithoutRef<'tr'>) {
+}: TableRowProps) {
   return (
     <MantineTable.Tr
       {...props}
       onClick={(e) => {
         onClick?.(e);
-        if (e.currentTarget.classList.contains('selected')) {
-          e.currentTarget.classList.remove('selected');
-        } else {
-          e.currentTarget.classList.add('selected');
-        }
+        onSelectedChange?.(!selected);
       }}
-      className={cx([tableRow, className])}
+      className={cx([tableRow, selected && 'selected', className])}
     >
       {children}
     </MantineTable.Tr>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -50,12 +50,16 @@ export function TableCell({ children, className, ...props }: ComponentPropsWitho
   );
 }
 
-export interface TableRowProps extends ComponentPropsWithoutRef<'tr'> {
-  /** Whether this row is currently selected. Controlled — the consumer owns this state. */
-  selected?: boolean;
-  /** Called with the new selection state when the row is clicked. */
-  onSelectedChange?: (selected: boolean) => void;
-}
+type TableRowSelection =
+  | {
+      /** Whether this row is currently selected. Controlled — the consumer owns this state. */
+      selected: boolean;
+      /** Called with the new selection state when the row is clicked. */
+      onSelectedChange: (selected: boolean) => void;
+    }
+  | { selected?: never; onSelectedChange?: never };
+
+export type TableRowProps = ComponentPropsWithoutRef<'tr'> & TableRowSelection;
 
 export function TableRow({
   children,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -70,12 +70,13 @@ export function TableRow({
   onClick,
   selected,
   onSelectedChange,
+  'aria-selected': ariaSelected,
   ...props
 }: TableRowProps) {
   return (
     <MantineTable.Tr
       {...props}
-      aria-selected={selected}
+      aria-selected={selected ?? ariaSelected}
       onClick={(e) => {
         onClick?.(e);
         onSelectedChange?.(!selected);

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 // react hooks not required here; story state is managed via Storybook args
 import { useArgs } from '@storybook/client-api';
+import { expect, within } from 'storybook/test';
 import { TextField } from './TextField';
 
 const meta = {
@@ -55,6 +56,12 @@ export const Disabled: Story = {
 export const WithError: Story = {
   args: { inputLabel: 'Email', error: 'Invalid email', placeholder: 'you@example.com' },
   render: (args) => <TextField {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText('you@example.com');
+    // Figma Common/Error = Red/300 (#ae1e20), reached via the shared core.states.error token.
+    await expect(getComputedStyle(input).borderColor).toBe('rgb(174, 30, 32)');
+  },
 };
 
 export const WithHelperText: Story = {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -19,6 +19,7 @@ export {
   TableHeader,
   TableHeaderCell,
   TableRow,
+  type TableRowProps,
 } from './Table/Table';
 export { TextArea } from './TextArea/TextArea';
 export { TextField } from './TextField/TextField';

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -641,8 +641,8 @@ export function getComponents(bp: keyof typeof breakpoints) {
     },
     icon: {
       size: {
-        extraSmall: rem('12px'),
-        small: rem('16px'),
+        extraSmall: rem('16px'),
+        small: rem('18px'),
         medium: rem('20px'),
         large: rem('24px'),
         extraLarge: rem('28px'),

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -430,7 +430,7 @@ const core = {
   mainExtraDark: colors.blue['700'],
   hover: {
     overlay: 'rgba(0, 0, 0, 0.0300)',
-    overlayContrast: 'rgba(255, 255, 255, 0.0500)',
+    overlayContrast: 'rgba(255, 255, 255, 0.1000)',
   },
   divider: colors.neutral['200'],
   cornerRadius: rem(0),

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -657,7 +657,7 @@ export function getComponents(bp: keyof typeof breakpoints) {
           focus: colors.neutral['100'],
           active: colors.neutral['200'],
           disabled: colors.neutral['400'],
-          overlay: 'rgba(255, 255, 255, 0.1000)',
+          overlay: core.hover.overlayContrast,
         },
         default: colors.neutral['700'],
         hover: colors.neutral['500'],

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -657,7 +657,7 @@ export function getComponents(bp: keyof typeof breakpoints) {
           hover: colors.neutral['100'],
           focus: colors.neutral['100'],
           active: colors.neutral['200'],
-          disabled: colors.neutral['300'],
+          disabled: colors.neutral['400'],
           overlay: 'rgba(255, 255, 255, 0.1000)',
         },
         default: colors.neutral['700'],

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -343,8 +343,7 @@ const colors = {
   red: {
     '100': '#eb5e58',
     '200': '#c83e36',
-    '300': '#da2321',
-    '400': '#ae1e20',
+    '300': '#ae1e20',
   },
 
   pink: {
@@ -418,7 +417,7 @@ const core = {
   background: colors.neutral.white,
   backgroundDisabled: colors.neutral['100'],
   contrast: colors.neutral.white,
-  error: colors.red['400'],
+  error: colors.red['300'],
   mainLight: colors.blue['300'],
   main: colors.blue['400'],
   mainDark: colors.blue['500'],
@@ -442,7 +441,7 @@ const core = {
     focus: colors.blue['400'],
     active: colors.blue['300'],
     disabled: colors.neutral['300'],
-    error: colors.red['400'],
+    error: colors.red['300'],
     visited: colors.blue['300'],
   },
   // Figma's "Input-states" variable collection — distinct from "Primary-states"

--- a/src/theme/themeVariables.ts
+++ b/src/theme/themeVariables.ts
@@ -435,7 +435,7 @@ const core = {
   divider: colors.neutral['200'],
   cornerRadius: rem(0),
   strokeWeight: rem('2px'),
-  dropshadow: colors.neutral['400'],
+  dropshadow: 'rgba(0, 0, 0, 0.5000)',
   states: {
     default: colors.blue['400'],
     hover: colors.blue['600'],


### PR DESCRIPTION
## Summary
- Fixes #85: corrects all 8 Figma/code token value mismatches (dropshadow, icon xs/sm sizes, IconButton contrast-disabled color, hover overlay contrast, plus a structural cleanup of the red palette — no visible change there, since the color itself was already fixed in 0.5.0).
- Fixes #82: SearchField's trigger icon now scales with the responsive control size.
- Fixes #48: TableRow selection is now a controlled prop instead of DOM mutation (**breaking change** — see CHANGELOG for the migration snippet).
- Fixes #45: Pagination renders `ChevronRightIcon` directly instead of a rotated `ChevronLeftIcon` (no visible change, removes a fragile implicit coupling).

Part of the [v1.0.0 milestone](https://github.com/Tampere/Tampere-design-system/milestone/1).

## Process notes
Built with subagent-driven development: a fresh implementer + independent task review per commit, plus a final whole-branch review (opus) before this PR. Along the way, two pre-existing bugs unrelated to this branch's scope were found and filed separately rather than fixed here:
- #91 — IconButton's `Dark` story never actually renders the dark variant (same prop-spread-order bug class as one fixed on this branch for the `Disabled` story)
- #92 — the package's raw `themeVariables` JS export still returns pre-Figma-fix values (rendered CSS output is correct; only the raw export lags)

## Test plan
- [x] `npm test` passes (157/157)
- [x] `tsc --noEmit`, `npm run build`, `npm run build-storybook` all clean
- [x] `eslint`/`prettier` clean
- [ ] Storybook reviewed for: Accordion + DateField popover shadow, IconButton small/disabled states, SearchField trigger icon at a narrow breakpoint, and the new `Table` `SelectableRows` story demonstrating the controlled API