### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (pre-1.0: breaking changes bump the minor version).
 
-## [Unreleased]
+## [0.6.0] - 2026-08-12
+
+**Storybook:** https://tampere.github.io/Tampere-design-system/
 
 ### Upgrade notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tampere/treds",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tampere/treds",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "clsx": "^2.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/Tampere/Tampere-design-system.git"
   },
   "private": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Finalizes the CHANGELOG's `[Unreleased]` section (v1.0.0 fidelity fixes: #85, #82, #48, #45) as `[0.6.0]` and bumps the package version — bumping the minor version per this repo's pre-1.0 convention, since the batch includes two breaking changes (TableRow controlled selection, red-palette restructuring).

Merged as a regular merge (not squash) so the `v0.6.0` tag's commit SHA lands on `main` unchanged.