### PR TITLE
fix: use POSIX test syntax in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$branch" == "main" ]]; then
+if [ "$branch" = "main" ]; then
   echo "Direct push to main is not allowed"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- `.husky/pre-push` used bash's `[[ ]]` test syntax, but git invokes hook scripts with `/bin/sh` (dash on this system), which doesn't support it — the main-branch guard silently errored (`[[: not found`) instead of running, on every push.
- Swapped to the POSIX-compatible `[ "$branch" = "main" ]`, matching the style of the repo's other one-line hooks.

## Test plan
- [x] Ran the hook directly with `sh .husky/pre-push` on a non-main branch — exits 0, no error.
- [x] Simulated `branch=main` — prints "Direct push to main is not allowed" and exits 1.
- [x] Pushed this branch and confirmed the remote copy has the fix (`git show origin/fix/pre-push-hook-posix:.husky/pre-push`).