### PR TITLE
fix(#90): IconButton touch-target/focus rework + new LabeledIconButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `IconButton` now guarantees a 24x24px minimum touch target (WCAG 2.2 AA, SC 2.5.8) at every size ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - `IconButton`'s focus-visible state now shows the same background overlay as hover/active, matching the Figma design (previously outline-only) ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - Corrected a stale `iconButton` background-overlay token value (`#f1eeeb` → `#f7f7f9`) that didn't match Figma ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
-- `IconButton` and `LabeledIconButton` no longer paint the hover background overlay on a disabled button — a disabled `<button>` still matches CSS `:hover` in Chromium/Firefox, so a hovered disabled button previously showed the hover state ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- `IconButton` and `LabeledIconButton` no longer paint the hover background overlay on a disabled button — a disabled `<button>` still matches CSS `:hover` (a widely-known cross-browser behavior, verified here in this project's Chromium test environment), so a hovered disabled button previously showed the hover state ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 
 ## [0.7.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `IconButton`'s Storybook `Dark` story (now `Inverted`) actually renders the variant it's named after — an explicit prop placed before `{...args}` was previously clobbered by the meta's default args ([#91](https://github.com/Tampere/Tampere-design-system/issues/91)).
 - `Modal`'s close button always has an accessible name now, regardless of what the consumer passes ([#94](https://github.com/Tampere/Tampere-design-system/issues/94)).
 - `Pagination`'s prev/next chevron buttons always have an accessible name now, regardless of what the consumer passes ([#95](https://github.com/Tampere/Tampere-design-system/issues/95)).
+- `LabeledIconButton` no longer lets a consumer's `aria-label`/`aria-labelledby` silently override the visible `label` as the accessible name — TypeScript exempts hyphenated JSX attributes from excess-property checks, so excluding them from the prop type alone didn't stop this at actual call sites; now also stripped at runtime ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- `LabeledIconButton` now accepts standard button attributes (`id`, `title`, `onFocus`, `onMouseEnter`, etc.) that were previously typed away entirely ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 
 ## [0.7.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - `LabeledIconButton` component — an icon with a text label underneath, sharing `IconButton`'s state-color tokens ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- Two new component tokens on `vars`: `iconButton.minTouchTarget` (the 24px WCAG touch-target floor) and `labeledIconButton.spacing` (gap between icon and label) ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 
 ### Fixed
 
 - `IconButton` now guarantees a 24x24px minimum touch target (WCAG 2.2 AA, SC 2.5.8) at every size ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - `IconButton`'s focus-visible state now shows the same background overlay as hover/active, matching the Figma design (previously outline-only) ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - Corrected a stale `iconButton` background-overlay token value (`#f1eeeb` → `#f7f7f9`) that didn't match Figma ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- `IconButton` and `LabeledIconButton` no longer paint the hover background overlay on a disabled button — a disabled `<button>` still matches CSS `:hover` in Chromium/Firefox, so a hovered disabled button previously showed the hover state ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 
 ## [0.7.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: breaking changes bump the minor version).
 
+## [Unreleased]
+
+### Added
+
+- `LabeledIconButton` component — an icon with a text label underneath, sharing `IconButton`'s state-color tokens ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+
+### Fixed
+
+- `IconButton` now guarantees a 24x24px minimum touch target (WCAG 2.2 AA, SC 2.5.8) at every size ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- `IconButton`'s focus-visible state now shows the same background overlay as hover/active, matching the Figma design (previously outline-only) ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- Corrected a stale `iconButton` background-overlay token value (`#f1eeeb` → `#f7f7f9`) that didn't match Figma ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+
 ## [0.7.0] - 2026-08-14
 
 ### Upgrade notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Upgrade notes
+
+- **Breaking: `IconButton`'s `variant` prop renamed `light`/`dark` → `default`/`inverted`**, matching Figma's own naming and fixing the inverted-from-intuition naming (`variant="light"` rendered a _dark_-surface icon) ([#105](https://github.com/Tampere/Tampere-design-system/issues/105)).
+
+  | Old               | New                  |
+  | ----------------- | -------------------- |
+  | `variant="light"` | `variant="inverted"` |
+  | `variant="dark"`  | `variant="default"`  |
+
+  `LabeledIconButton`'s `variant` prop uses the same `default`/`inverted` naming — no migration needed there, since it was still unreleased.
+
+  Also corrects `IconButton`'s default value: it silently defaulted to the inverted/light-icon variant with no rationale in the code or history, and no internal consumer ever relied on it (every usage in this library passes `variant` explicitly). Both components now default to `variant="default"`. If you render either component without an explicit `variant` and relied on the old (undocumented) light-icon default, pass `variant="inverted"` explicitly.
+
+- **Breaking: `Modal`'s `closeButtonProps` now requires an `'aria-label'`.** Previously optional with no fallback, so a consumer that omitted it shipped a close button with no accessible name — an axe-critical `button-name` violation ([#94](https://github.com/Tampere/Tampere-design-system/issues/94)). Pass `closeButtonProps={{ 'aria-label': '...' }}` explicitly.
+- **Breaking: `Pagination`'s `leftButtonLabel`/`rightButtonLabel` are now required.** Same reasoning as `Modal` above — previously optional with no fallback, so omitting them shipped prev/next chevrons with no accessible name ([#95](https://github.com/Tampere/Tampere-design-system/issues/95)).
+
 ### Added
 
 - `LabeledIconButton` component — an icon with a text label underneath, sharing `IconButton`'s state-color tokens ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
@@ -17,6 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `IconButton`'s focus-visible state now shows the same background overlay as hover/active, matching the Figma design (previously outline-only) ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - Corrected a stale `iconButton` background-overlay token value (`#f1eeeb` → `#f7f7f9`) that didn't match Figma ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
 - `IconButton` and `LabeledIconButton` no longer paint the hover background overlay on a disabled button — a disabled `<button>` still matches CSS `:hover` (a widely-known cross-browser behavior, verified here in this project's Chromium test environment), so a hovered disabled button previously showed the hover state ([#90](https://github.com/Tampere/Tampere-design-system/issues/90)).
+- `IconButton`/`LabeledIconButton`'s demo stories now pair each variant with a Figma-accurate background (plain for `default`, a dark strip for `inverted`) — the previous `Dark`/`Light` stories had the pairing backwards, which is what led to filing #105 in the first place ([#105](https://github.com/Tampere/Tampere-design-system/issues/105)).
+- `IconButton`'s Storybook `Dark` story (now `Inverted`) actually renders the variant it's named after — an explicit prop placed before `{...args}` was previously clobbered by the meta's default args ([#91](https://github.com/Tampere/Tampere-design-system/issues/91)).
+- `Modal`'s close button always has an accessible name now, regardless of what the consumer passes ([#94](https://github.com/Tampere/Tampere-design-system/issues/94)).
+- `Pagination`'s prev/next chevron buttons always have an accessible name now, regardless of what the consumer passes ([#95](https://github.com/Tampere/Tampere-design-system/issues/95)).
 
 ## [0.7.0] - 2026-08-14
 

--- a/src/components/DateField/DateField.tsx
+++ b/src/components/DateField/DateField.tsx
@@ -434,7 +434,7 @@ export function DateField({
               showClear ? (
                 <IconButton
                   size="sm"
-                  variant="dark"
+                  variant="default"
                   aria-label={clearButtonLabel}
                   onClick={handleClear}
                 >

--- a/src/components/DateField/DateFieldCalendar.tsx
+++ b/src/components/DateField/DateFieldCalendar.tsx
@@ -174,7 +174,7 @@ export function DateFieldCalendar({
       <div className={calendarHeader}>
         <IconButton
           aria-label={prevMonthLabel}
-          variant="dark"
+          variant="default"
           size="sm"
           disabled={prevDisabled}
           onClick={() => {
@@ -217,7 +217,7 @@ export function DateFieldCalendar({
         </div>
         <IconButton
           aria-label={nextMonthLabel}
-          variant="dark"
+          variant="default"
           size="sm"
           disabled={nextDisabled}
           onClick={() => {

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -59,7 +59,7 @@ function stateBlock(background: string) {
       '&:hover': { background },
       '&:focus-visible': { background, borderRadius: cornerRadius, ...focusRing },
       '&:active': { background },
-      '&:disabled': { cursor: 'default' },
+      '&:disabled': { background: 'none', cursor: 'default' },
     },
   });
 }

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -64,20 +64,24 @@ function stateBlock(background: string) {
   });
 }
 
-const light = stateBlock(iconButtonBackground.light);
-const dark = stateBlock(iconButtonBackground.dark);
+const inverted = stateBlock(iconButtonBackground.inverted);
+const defaultVariant = stateBlock(iconButtonBackground.default);
 
-globalStyle(`${light}:hover svg path`, { fill: iconButtonForeground.light.hover });
-globalStyle(`${light}:focus-visible svg path`, { fill: iconButtonForeground.light.focus });
-globalStyle(`${light}:active svg path`, { fill: iconButtonForeground.light.active });
-globalStyle(`${light}:disabled svg path`, { fill: iconButtonForeground.light.disabled });
+globalStyle(`${inverted}:hover svg path`, { fill: iconButtonForeground.inverted.hover });
+globalStyle(`${inverted}:focus-visible svg path`, { fill: iconButtonForeground.inverted.focus });
+globalStyle(`${inverted}:active svg path`, { fill: iconButtonForeground.inverted.active });
+globalStyle(`${inverted}:disabled svg path`, { fill: iconButtonForeground.inverted.disabled });
 
-globalStyle(`${dark}:hover svg path`, { fill: iconButtonForeground.dark.hover });
-globalStyle(`${dark}:focus-visible svg path`, { fill: iconButtonForeground.dark.focus });
-globalStyle(`${dark}:active svg path`, { fill: iconButtonForeground.dark.active });
-globalStyle(`${dark}:disabled svg path`, { fill: iconButtonForeground.dark.disabled });
+globalStyle(`${defaultVariant}:hover svg path`, { fill: iconButtonForeground.default.hover });
+globalStyle(`${defaultVariant}:focus-visible svg path`, {
+  fill: iconButtonForeground.default.focus,
+});
+globalStyle(`${defaultVariant}:active svg path`, { fill: iconButtonForeground.default.active });
+globalStyle(`${defaultVariant}:disabled svg path`, {
+  fill: iconButtonForeground.default.disabled,
+});
 
 export const iconRoot = styleVariants({
-  light: [root, light],
-  dark: [root, dark],
+  default: [root, defaultVariant],
+  inverted: [root, inverted],
 });

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -16,6 +16,8 @@ const root = style({
   alignItems: 'center',
   justifyContent: 'center',
   aspectRatio: '1 / 1',
+  minWidth: iconButton.minTouchTarget,
+  minHeight: iconButton.minTouchTarget,
   background: 'none',
   border: 'none',
   cursor: 'pointer',

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '../../theme';
+import { iconButtonForeground, iconButtonBackground } from './iconButtonState.css.ts';
 
 const {
   theme: {
@@ -52,71 +53,29 @@ globalStyle(`${root}[data-size="xl"] svg`, {
   height: icon.size.extraLarge,
 });
 
-// Light theme states
-const light = style({
-  selectors: {
-    '&:hover': {
-      background: iconButton.states.contrast.overlay,
+function stateBlock(background: string) {
+  return style({
+    selectors: {
+      '&:hover': { background },
+      '&:focus-visible': { background, borderRadius: cornerRadius, ...focusRing },
+      '&:active': { background },
+      '&:disabled': { cursor: 'default' },
     },
-    '&:focus-visible': {
-      background: iconButton.states.contrast.overlay,
-      borderRadius: cornerRadius,
-      ...focusRing,
-    },
-    '&:active': {
-      background: iconButton.states.contrast.overlay,
-    },
-    '&:disabled': {
-      cursor: 'default',
-    },
-  },
-});
+  });
+}
 
-globalStyle(`${light}:hover svg path`, {
-  fill: iconButton.states.contrast.hover,
-});
-globalStyle(`${light}:focus-visible svg path`, {
-  fill: iconButton.states.contrast.focus,
-});
-globalStyle(`${light}:active svg path`, {
-  fill: iconButton.states.contrast.active,
-});
-globalStyle(`${light}:disabled svg path`, {
-  fill: iconButton.states.contrast.disabled,
-});
+const light = stateBlock(iconButtonBackground.light);
+const dark = stateBlock(iconButtonBackground.dark);
 
-// Dark theme states
-const dark = style({
-  selectors: {
-    '&:hover': {
-      background: iconButton.states.overlay,
-    },
-    '&:focus-visible': {
-      background: iconButton.states.overlay,
-      borderRadius: cornerRadius,
-      ...focusRing,
-    },
-    '&:active': {
-      background: iconButton.states.overlay,
-    },
-    '&:disabled': {
-      cursor: 'default',
-    },
-  },
-});
+globalStyle(`${light}:hover svg path`, { fill: iconButtonForeground.light.hover });
+globalStyle(`${light}:focus-visible svg path`, { fill: iconButtonForeground.light.focus });
+globalStyle(`${light}:active svg path`, { fill: iconButtonForeground.light.active });
+globalStyle(`${light}:disabled svg path`, { fill: iconButtonForeground.light.disabled });
 
-globalStyle(`${dark}:hover svg path`, {
-  fill: iconButton.states.hover,
-});
-globalStyle(`${dark}:focus-visible svg path`, {
-  fill: iconButton.states.focus,
-});
-globalStyle(`${dark}:active svg path`, {
-  fill: iconButton.states.active,
-});
-globalStyle(`${dark}:disabled svg path`, {
-  fill: iconButton.states.disabled,
-});
+globalStyle(`${dark}:hover svg path`, { fill: iconButtonForeground.dark.hover });
+globalStyle(`${dark}:focus-visible svg path`, { fill: iconButtonForeground.dark.focus });
+globalStyle(`${dark}:active svg path`, { fill: iconButtonForeground.dark.active });
+globalStyle(`${dark}:disabled svg path`, { fill: iconButtonForeground.dark.disabled });
 
 export const iconRoot = styleVariants({
   light: [root, light],

--- a/src/components/IconButton/IconButton.css.ts
+++ b/src/components/IconButton/IconButton.css.ts
@@ -59,6 +59,7 @@ const light = style({
       background: iconButton.states.contrast.overlay,
     },
     '&:focus-visible': {
+      background: iconButton.states.contrast.overlay,
       borderRadius: cornerRadius,
       ...focusRing,
     },
@@ -91,6 +92,7 @@ const dark = style({
       background: iconButton.states.overlay,
     },
     '&:focus-visible': {
+      background: iconButton.states.overlay,
       borderRadius: cornerRadius,
       ...focusRing,
     },

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -4,11 +4,12 @@ import { within, userEvent } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { IconButton } from './IconButton';
 import { SearchIcon } from '../../icons/SearchIcon';
+import { vars } from '../../theme';
 
 const meta = {
   argTypes: {
     children: { control: 'text' },
-    variant: { control: 'text' },
+    variant: { control: { type: 'select' }, options: ['default', 'inverted'] },
     size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     disabled: { control: 'boolean' },
     onClick: { action: 'clicked' },
@@ -16,7 +17,7 @@ const meta = {
   },
   args: {
     children: '<Icon />',
-    variant: 'light',
+    variant: 'default',
     size: 'md',
     disabled: false,
     'aria-label': 'Search',
@@ -27,27 +28,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Dark: Story = {
+export const Default: Story = {
   render: (args) => (
-    <Box style={{ backgroundColor: 'grey', width: 'fit-content' }}>
-      <IconButton size="md" {...args} variant="dark">
+    <IconButton size="md" {...args} variant="default">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+};
+
+export const Inverted: Story = {
+  render: (args) => (
+    <Box style={{ backgroundColor: vars.brand.blue.mainDark, width: 'fit-content' }}>
+      <IconButton size="md" {...args} variant="inverted">
         <SearchIcon fill="white" />
       </IconButton>
     </Box>
   ),
 };
 
-export const Light: Story = {
-  render: (args) => (
-    <IconButton size="md" {...args} variant="light">
-      <SearchIcon fill="black" />
-    </IconButton>
-  ),
-};
-
 export const Disabled: Story = {
   render: (args) => (
-    <IconButton size="md" {...args} variant="light" disabled>
+    <IconButton size="md" {...args} variant="inverted" disabled>
       <SearchIcon fill="gray" />
     </IconButton>
   ),
@@ -64,20 +65,28 @@ export const Disabled: Story = {
 };
 
 export const Colored: Story = {
+  // Backgrounds match Figma's Icon-button "Colored" reference frame exactly
+  // (node 13574:322): Blue/500, Turquoise/200, Green/500, Red/200 — not
+  // arbitrary CSS color keywords.
   render: (args) => (
     <Flex>
-      <Box style={{ background: 'red', padding: '1rem' }}>
-        <IconButton size="md" {...args} variant="light">
+      <Box style={{ background: vars.primitives.colors.blue['500'], padding: '1rem' }}>
+        <IconButton size="md" {...args} variant="inverted">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
-      <Box style={{ background: 'green', padding: '1rem' }}>
-        <IconButton size="md" {...args} variant="light">
+      <Box style={{ background: vars.primitives.colors.turquoise['200'], padding: '1rem' }}>
+        <IconButton size="md" {...args} variant="inverted">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
-      <Box style={{ background: 'blue', padding: '1rem' }}>
-        <IconButton size="md" {...args} variant="light">
+      <Box style={{ background: vars.primitives.colors.green['500'], padding: '1rem' }}>
+        <IconButton size="md" {...args} variant="inverted">
+          <SearchIcon fill="white" />
+        </IconButton>
+      </Box>
+      <Box style={{ background: vars.primitives.colors.red['200'], padding: '1rem' }}>
+        <IconButton size="md" {...args} variant="inverted">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
@@ -92,7 +101,7 @@ export const SmallSizeIconMatchesToken: Story = {
   // The rendered icon inside a "sm" IconButton must be sized from
   // components.icon.size.small (Figma: 18px), not a stale 16px value.
   render: (args) => (
-    <IconButton {...args} size="sm" variant="light">
+    <IconButton {...args} size="sm" variant="inverted">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -113,7 +122,7 @@ export const ExtraSmallSizeIconMatchesToken: Story = {
   // components.icon.size.extraSmall (Figma: 16px), not fall back to the raw
   // icon's own default size for lack of a data-size="xs" style rule.
   render: (args) => (
-    <IconButton {...args} size="xs" variant="light">
+    <IconButton {...args} size="xs" variant="inverted">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -134,7 +143,7 @@ export const LargeSizeIconMatchesToken: Story = {
   // components.icon.size.large (Figma: 24px) on both axes — not stretched by
   // pairing a mismatched height token.
   render: (args) => (
-    <IconButton {...args} size="lg" variant="light">
+    <IconButton {...args} size="lg" variant="inverted">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -153,7 +162,7 @@ export const ExtraSmallSizeMeetsTouchTarget: Story = {
   // WCAG 2.2 AA (SC 2.5.8): the rendered button box must be >= 24x24 CSS px
   // even though the "xs" glyph itself is only 16px.
   render: (args) => (
-    <IconButton {...args} size="xs" variant="light">
+    <IconButton {...args} size="xs" variant="inverted">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -171,7 +180,7 @@ export const LargeSizeGrowsPastTouchTarget: Story = {
   // "lg" (24px glyph + 2x2px padding = 28px) must render at 28x28, not be
   // clamped down to the 24px floor.
   render: (args) => (
-    <IconButton {...args} size="lg" variant="light">
+    <IconButton {...args} size="lg" variant="inverted">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -191,7 +200,7 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
   // for #90 (contradicts the outline-only assumption in the earlier design
   // doc).
   render: (args) => (
-    <IconButton {...args} size="md" variant="dark">
+    <IconButton {...args} size="md" variant="default">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -203,7 +212,7 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
     await expect(style.outlineStyle).toBe('solid');
     // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
     // (iconButton.states.overlay) — exact match, not just "some color", so a
-    // future swap of the light/dark overlay tokens would fail this test.
+    // future swap of the default/inverted overlay tokens would fail this test.
     await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
   },
 };
@@ -222,7 +231,7 @@ export const DisabledDoesNotShowHoverBackground: Story = {
   // on the CSS rule itself (no background at all on `:disabled`), which
   // holds regardless of whether `:hover` is also active.
   render: (args) => (
-    <IconButton {...args} size="md" variant="dark" disabled>
+    <IconButton {...args} size="md" variant="default" disabled>
       <SearchIcon fill="black" />
     </IconButton>
   ),

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -183,3 +183,24 @@ export const LargeSizeGrowsPastTouchTarget: Story = {
     await expect(height).toBe('28px');
   },
 };
+
+export const FocusVisibleHasBackgroundAndOutline: Story = {
+  tags: ['!dev', '!autodocs'],
+  // Figma's Focus state binds both an outline AND the same background
+  // overlay used by Hover/Active — verified against the live design file
+  // for #90 (contradicts the outline-only assumption in the earlier design
+  // doc).
+  render: (args) => (
+    <IconButton {...args} size="md" variant="dark">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    button.focus();
+    const style = getComputedStyle(button);
+    await expect(style.outlineStyle).toBe('solid');
+    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -201,17 +201,22 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
     button.focus();
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
-    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
+    // (iconButton.states.overlay) — exact match, not just "some color", so a
+    // future swap of the light/dark overlay tokens would fail this test.
+    await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
   },
 };
 
 export const DisabledDoesNotShowHoverBackground: Story = {
   tags: ['!dev', '!autodocs'],
-  // A disabled <button> still matches the CSS `:hover` pseudo-class in
-  // Chromium/Firefox (only pointer *events* are suppressed, not the
-  // pseudo-class), so `stateBlock()`'s `:disabled` selector must explicitly
-  // reset `background: 'none'` or a hovered disabled button would incorrectly
-  // paint the hover overlay. Uses `userEvent.hover()` as a best-effort
+  // A disabled <button> still matches the CSS `:hover` pseudo-class in this
+  // project's Chromium test environment (a widely-known cross-browser CSS
+  // behavior, but only Chromium is exercised by this suite) — only pointer
+  // *events* are suppressed, not the pseudo-class — so `stateBlock()`'s
+  // `:disabled` selector must explicitly reset `background: 'none'` or a
+  // hovered disabled button would incorrectly paint the hover overlay. Uses
+  // `userEvent.hover()` as a best-effort
   // trigger — it doesn't reliably simulate real OS-level `:hover` in this
   // repo's Playwright/Chromium test environment, but the assertion below is
   // on the CSS rule itself (no background at all on `:disabled`), which

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within } from '@storybook/testing-library';
+import { within, userEvent } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { IconButton } from './IconButton';
 import { SearchIcon } from '../../icons/SearchIcon';
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof meta>;
 export const Dark: Story = {
   render: (args) => (
     <Box style={{ backgroundColor: 'grey', width: 'fit-content' }}>
-      <IconButton variant="dark" size="md" {...args}>
+      <IconButton size="md" {...args} variant="dark">
         <SearchIcon fill="white" />
       </IconButton>
     </Box>
@@ -39,7 +39,7 @@ export const Dark: Story = {
 
 export const Light: Story = {
   render: (args) => (
-    <IconButton variant="light" size="md" {...args}>
+    <IconButton size="md" {...args} variant="light">
       <SearchIcon fill="black" />
     </IconButton>
   ),
@@ -47,7 +47,7 @@ export const Light: Story = {
 
 export const Disabled: Story = {
   render: (args) => (
-    <IconButton variant="light" size="md" {...args} disabled>
+    <IconButton size="md" {...args} variant="light" disabled>
       <SearchIcon fill="gray" />
     </IconButton>
   ),
@@ -67,17 +67,17 @@ export const Colored: Story = {
   render: (args) => (
     <Flex>
       <Box style={{ background: 'red', padding: '1rem' }}>
-        <IconButton variant="light" size="md" {...args}>
+        <IconButton size="md" {...args} variant="light">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
       <Box style={{ background: 'green', padding: '1rem' }}>
-        <IconButton variant="light" size="md" {...args}>
+        <IconButton size="md" {...args} variant="light">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
       <Box style={{ background: 'blue', padding: '1rem' }}>
-        <IconButton variant="light" size="md" {...args}>
+        <IconButton size="md" {...args} variant="light">
           <SearchIcon fill="white" />
         </IconButton>
       </Box>
@@ -202,5 +202,30 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
     await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};
+
+export const DisabledDoesNotShowHoverBackground: Story = {
+  tags: ['!dev', '!autodocs'],
+  // A disabled <button> still matches the CSS `:hover` pseudo-class in
+  // Chromium/Firefox (only pointer *events* are suppressed, not the
+  // pseudo-class), so `stateBlock()`'s `:disabled` selector must explicitly
+  // reset `background: 'none'` or a hovered disabled button would incorrectly
+  // paint the hover overlay. Uses `userEvent.hover()` as a best-effort
+  // trigger — it doesn't reliably simulate real OS-level `:hover` in this
+  // repo's Playwright/Chromium test environment, but the assertion below is
+  // on the CSS rule itself (no background at all on `:disabled`), which
+  // holds regardless of whether `:hover` is also active.
+  render: (args) => (
+    <IconButton {...args} size="md" variant="dark" disabled>
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await userEvent.hover(button);
+    const style = getComputedStyle(button);
+    await expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   },
 };

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -147,3 +147,39 @@ export const LargeSizeIconMatchesToken: Story = {
     await expect(height).toBe('24px');
   },
 };
+
+export const ExtraSmallSizeMeetsTouchTarget: Story = {
+  tags: ['!dev', '!autodocs'],
+  // WCAG 2.2 AA (SC 2.5.8): the rendered button box must be >= 24x24 CSS px
+  // even though the "xs" glyph itself is only 16px.
+  render: (args) => (
+    <IconButton {...args} size="xs" variant="light">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    const { width, height } = getComputedStyle(button);
+    await expect(parseFloat(width)).toBeGreaterThanOrEqual(24);
+    await expect(parseFloat(height)).toBeGreaterThanOrEqual(24);
+  },
+};
+
+export const LargeSizeGrowsPastTouchTarget: Story = {
+  tags: ['!dev', '!autodocs'],
+  // "lg" (24px glyph + 2x2px padding = 28px) must render at 28x28, not be
+  // clamped down to the 24px floor.
+  render: (args) => (
+    <IconButton {...args} size="lg" variant="light">
+      <SearchIcon fill="black" />
+    </IconButton>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    const { width, height } = getComputedStyle(button);
+    await expect(width).toBe('28px');
+    await expect(height).toBe('28px');
+  },
+};

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -217,6 +217,30 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
   },
 };
 
+export const InvertedVariantFocusVisibleHasBackground: Story = {
+  tags: ['!dev', '!autodocs'],
+  // The story above only exercises `variant="default"` — the `inverted`
+  // variant's overlay (iconButtonBackground.inverted, shared with
+  // LabeledIconButton) previously had no interactive-state color coverage.
+  render: (args) => (
+    <Box style={{ backgroundColor: vars.brand.blue.mainDark, width: 'fit-content' }}>
+      <IconButton {...args} size="md" variant="inverted">
+        <SearchIcon fill="white" />
+      </IconButton>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    button.focus();
+    const style = getComputedStyle(button);
+    await expect(style.outlineStyle).toBe('solid');
+    // iconButtonBackground.inverted = iconButton.states.contrast.overlay =
+    // rgba(255, 255, 255, 0.1) — exact match, not just "some color".
+    await expect(style.backgroundColor).toBe('rgba(255, 255, 255, 0.1)');
+  },
+};
+
 export const DisabledDoesNotShowHoverBackground: Story = {
   tags: ['!dev', '!autodocs'],
   // A disabled <button> still matches the CSS `:hover` pseudo-class in this

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -3,7 +3,7 @@ import { ActionIcon, type ActionIconProps, createPolymorphicComponent } from '@m
 import { mergeClassNames } from '../../utils';
 import { iconWrapper, iconRoot } from './IconButton.css.ts';
 
-type IconButtonVariant = 'light' | 'dark';
+type IconButtonVariant = 'default' | 'inverted';
 type IconButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface Props extends ActionIconProps, PropsWithChildren {
@@ -15,7 +15,7 @@ export interface Props extends ActionIconProps, PropsWithChildren {
   };
 }
 
-function IconButtonComponent({ variant = 'light', size, classNames, ...props }: Props) {
+function IconButtonComponent({ variant = 'default', size, classNames, ...props }: Props) {
   const defaultClassNames = {
     root: iconRoot[variant],
     icon: iconWrapper,

--- a/src/components/IconButton/iconButtonState.css.ts
+++ b/src/components/IconButton/iconButtonState.css.ts
@@ -6,24 +6,24 @@ const {
   },
 } = vars;
 
-// The `variant` prop name ("light"/"dark") intentionally does not match the
-// token sub-object name it maps to below — this is describing the icon's
-// own rendered color, not the token collection's naming:
-//   - variant="light": the icon renders light/white-ish, for placement on a
-//     colored or dark surface — maps to the `contrast.*` token sub-object.
-//   - variant="dark": the icon renders dark-gray, for placement on a plain
-//     light surface — maps to the plain (non-`contrast`) tokens.
-// A future third variant should preserve this "light variant -> contrast
+// The `variant` prop name ("default"/"inverted") does not match the token
+// sub-object name it maps to below — this is describing the icon's own
+// rendered color, not the token collection's naming:
+//   - variant="inverted": the icon renders light/white-ish, for placement on
+//     a colored or dark surface — maps to the `contrast.*` token sub-object.
+//   - variant="default": the icon renders dark-gray, for placement on a
+//     plain light surface — maps to the plain (non-`contrast`) tokens.
+// A future third variant should preserve this "inverted variant -> contrast
 // tokens" pairing rather than assuming the names line up directly.
 export const iconButtonForeground = {
-  light: {
+  inverted: {
     default: iconButton.states.contrast.default,
     hover: iconButton.states.contrast.hover,
     focus: iconButton.states.contrast.focus,
     active: iconButton.states.contrast.active,
     disabled: iconButton.states.contrast.disabled,
   },
-  dark: {
+  default: {
     default: iconButton.states.default,
     hover: iconButton.states.hover,
     focus: iconButton.states.focus,
@@ -33,6 +33,6 @@ export const iconButtonForeground = {
 } as const;
 
 export const iconButtonBackground = {
-  light: iconButton.states.contrast.overlay,
-  dark: iconButton.states.overlay,
+  inverted: iconButton.states.contrast.overlay,
+  default: iconButton.states.overlay,
 } as const;

--- a/src/components/IconButton/iconButtonState.css.ts
+++ b/src/components/IconButton/iconButtonState.css.ts
@@ -6,6 +6,15 @@ const {
   },
 } = vars;
 
+// The `variant` prop name ("light"/"dark") intentionally does not match the
+// token sub-object name it maps to below — this is describing the icon's
+// own rendered color, not the token collection's naming:
+//   - variant="light": the icon renders light/white-ish, for placement on a
+//     colored or dark surface — maps to the `contrast.*` token sub-object.
+//   - variant="dark": the icon renders dark-gray, for placement on a plain
+//     light surface — maps to the plain (non-`contrast`) tokens.
+// A future third variant should preserve this "light variant -> contrast
+// tokens" pairing rather than assuming the names line up directly.
 export const iconButtonForeground = {
   light: {
     default: iconButton.states.contrast.default,

--- a/src/components/IconButton/iconButtonState.css.ts
+++ b/src/components/IconButton/iconButtonState.css.ts
@@ -1,0 +1,29 @@
+import { vars } from '../../theme';
+
+const {
+  theme: {
+    components: { iconButton },
+  },
+} = vars;
+
+export const iconButtonForeground = {
+  light: {
+    default: iconButton.states.contrast.default,
+    hover: iconButton.states.contrast.hover,
+    focus: iconButton.states.contrast.focus,
+    active: iconButton.states.contrast.active,
+    disabled: iconButton.states.contrast.disabled,
+  },
+  dark: {
+    default: iconButton.states.default,
+    hover: iconButton.states.hover,
+    focus: iconButton.states.focus,
+    active: iconButton.states.active,
+    disabled: iconButton.states.disabled,
+  },
+} as const;
+
+export const iconButtonBackground = {
+  light: iconButton.states.contrast.overlay,
+  dark: iconButton.states.overlay,
+} as const;

--- a/src/components/LabeledIconButton/LabeledIconButton.css.ts
+++ b/src/components/LabeledIconButton/LabeledIconButton.css.ts
@@ -29,7 +29,15 @@ export const root = style({
   },
 });
 
-export const iconWrapper = style({});
+// Mirrors the `<Flex direction="column" align="center">` this wrapper used
+// to render — a plain <span> is used instead (not Mantine's <Flex>, which
+// defaults to a <div>) because a <div> is invalid inside <button> phrasing
+// content (see Button.tsx's <Flex component="span"> for the same reason).
+export const iconWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+});
 
 globalStyle(`${iconWrapper} svg`, {
   width: icon.size.large,
@@ -50,7 +58,7 @@ function variantStyle(foreground: (typeof iconButtonForeground)['light'], backgr
       '&:hover': { background, color: foreground.hover },
       '&:focus-visible': { background, color: foreground.focus, ...focusRing },
       '&:active': { background, color: foreground.active },
-      '&:disabled': { color: foreground.disabled },
+      '&:disabled': { background: 'none', color: foreground.disabled },
     },
   });
 }

--- a/src/components/LabeledIconButton/LabeledIconButton.css.ts
+++ b/src/components/LabeledIconButton/LabeledIconButton.css.ts
@@ -1,11 +1,12 @@
 import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '../../theme';
-import { iconButtonForeground } from '../IconButton/iconButtonState.css.ts';
+import { iconButtonForeground, iconButtonBackground } from '../IconButton/iconButtonState.css.ts';
 
 const {
   theme: {
     cornerRadius,
     components: { icon, typography, labeledIconButton },
+    focusRing,
   },
 } = vars;
 const gap = labeledIconButton.spacing;
@@ -42,18 +43,19 @@ export const label = style({
   lineHeight: '100%',
 });
 
-const light = style({
-  color: iconButtonForeground.light.default,
-  selectors: {
-    '&:disabled': { color: iconButtonForeground.light.disabled },
-  },
-});
+function variantStyle(foreground: (typeof iconButtonForeground)['light'], background: string) {
+  return style({
+    color: foreground.default,
+    selectors: {
+      '&:hover': { background, color: foreground.hover },
+      '&:focus-visible': { background, color: foreground.focus, ...focusRing },
+      '&:active': { background, color: foreground.active },
+      '&:disabled': { color: foreground.disabled },
+    },
+  });
+}
 
-const dark = style({
-  color: iconButtonForeground.dark.default,
-  selectors: {
-    '&:disabled': { color: iconButtonForeground.dark.disabled },
-  },
+export const variants = styleVariants({
+  light: [variantStyle(iconButtonForeground.light, iconButtonBackground.light)],
+  dark: [variantStyle(iconButtonForeground.dark, iconButtonBackground.dark)],
 });
-
-export const variants = styleVariants({ light: [light], dark: [dark] });

--- a/src/components/LabeledIconButton/LabeledIconButton.css.ts
+++ b/src/components/LabeledIconButton/LabeledIconButton.css.ts
@@ -1,0 +1,59 @@
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+import { iconButtonForeground } from '../IconButton/iconButtonState.css.ts';
+
+const {
+  theme: {
+    cornerRadius,
+    components: { icon, typography, labeledIconButton },
+  },
+} = vars;
+const gap = labeledIconButton.spacing;
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap,
+  padding: gap,
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  borderRadius: cornerRadius,
+  selectors: {
+    '&:disabled': {
+      cursor: 'default',
+    },
+  },
+});
+
+export const iconWrapper = style({});
+
+globalStyle(`${iconWrapper} svg`, {
+  width: icon.size.large,
+  height: icon.size.large,
+});
+
+export const label = style({
+  fontSize: typography.caption.fontSize,
+  fontFamily: typography.caption.fontFamily,
+  fontWeight: typography.caption.fontWeight,
+  lineHeight: '100%',
+});
+
+const light = style({
+  color: iconButtonForeground.light.default,
+  selectors: {
+    '&:disabled': { color: iconButtonForeground.light.disabled },
+  },
+});
+
+const dark = style({
+  color: iconButtonForeground.dark.default,
+  selectors: {
+    '&:disabled': { color: iconButtonForeground.dark.disabled },
+  },
+});
+
+export const variants = styleVariants({ light: [light], dark: [dark] });

--- a/src/components/LabeledIconButton/LabeledIconButton.css.ts
+++ b/src/components/LabeledIconButton/LabeledIconButton.css.ts
@@ -51,7 +51,7 @@ export const label = style({
   lineHeight: '100%',
 });
 
-function variantStyle(foreground: (typeof iconButtonForeground)['light'], background: string) {
+function variantStyle(foreground: (typeof iconButtonForeground)['default'], background: string) {
   return style({
     color: foreground.default,
     selectors: {
@@ -64,6 +64,6 @@ function variantStyle(foreground: (typeof iconButtonForeground)['light'], backgr
 }
 
 export const variants = styleVariants({
-  light: [variantStyle(iconButtonForeground.light, iconButtonBackground.light)],
-  dark: [variantStyle(iconButtonForeground.dark, iconButtonBackground.dark)],
+  inverted: [variantStyle(iconButtonForeground.inverted, iconButtonBackground.inverted)],
+  default: [variantStyle(iconButtonForeground.default, iconButtonBackground.default)],
 });

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -15,7 +15,13 @@ const meta = {
   args: {
     icon: <AddIcon />,
     label: 'Label',
-    variant: 'light',
+    // 'dark' so the Default story is legible against Storybook's default
+    // light canvas background (see LabeledIconButton.tsx: the 'light' variant
+    // is meant for use on dark/colored surfaces) — Task 8 previously
+    // hardcoded `variant="dark"` directly in Default's render function
+    // instead, which made the Controls panel's variant selector inert for
+    // that story. Setting it here keeps Controls live.
+    variant: 'dark',
     disabled: false,
   },
   component: LabeledIconButton,
@@ -25,7 +31,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
 };
 
 export const Disabled: Story = {
@@ -47,15 +53,18 @@ export const Dark: Story = {
 
 export const Colored: Story = {
   render: (args) => (
+    // Demos the 'light' variant specifically (legible against saturated
+    // backgrounds) — explicit here since `meta.args.variant` defaults to
+    // 'dark' (see Default's comment above).
     <MantineFlex gap="md">
       <Box style={{ background: 'red', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} />
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
       </Box>
       <Box style={{ background: 'green', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} />
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
       </Box>
       <Box style={{ background: 'blue', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} />
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
       </Box>
     </MantineFlex>
   ),
@@ -73,12 +82,20 @@ export const RendersLabelText: Story = {
 export const InteractionAppliesBackgroundAndColor: Story = {
   tags: ['!dev', '!autodocs'],
   /**
-   * Verifies that interactive states (hover/focus/active) apply the background overlay.
-   * Uses userEvent.pointer() to simulate a mouse press, which triggers the :active state,
-   * because userEvent.hover() does not reliably trigger real :hover pseudo-class in
-   * Playwright/Chromium test environment (synthetic pointer events don't move the OS cursor).
-   * Since :hover, :focus-visible, and :active all apply the same background token,
-   * this test verifies the interactive background-swap behavior across all states.
+   * Verifies that the background overlay applies during a `userEvent.pointer()`
+   * mouse-down press. This most likely exercises `:focus-visible`, not `:active`
+   * as an earlier version of this comment claimed: `@testing-library/user-event`
+   * calls `focus.focusElement(target)` internally as part of simulating a
+   * pointer press, which focuses the button and can trigger `:focus-visible`
+   * before/instead of a genuine `:active` state. That makes this story a
+   * near-duplicate of `FocusVisibleHasBackgroundAndOutline` below, and leaves
+   * real `:hover`/`:active` coverage as a known gap — `userEvent.hover()` does
+   * not reliably trigger the real `:hover` pseudo-class in this repo's
+   * Playwright/Chromium test environment (synthetic pointer events don't move
+   * the OS cursor), and simulating genuine `:active` (mouse held down without
+   * moving focus) isn't currently exercised either. Kept as-is rather than
+   * removed since it still asserts the background-overlay behavior end to end
+   * via a different interaction path than the sibling focus-visible story.
    */
   render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
   play: async ({ canvasElement }) => {
@@ -113,5 +130,67 @@ export const MeetsTouchTarget: Story = {
     const { width, height } = getComputedStyle(button);
     await expect(parseFloat(width)).toBeGreaterThanOrEqual(24);
     await expect(parseFloat(height)).toBeGreaterThanOrEqual(24);
+  },
+};
+
+export const LightVariantFocusVisibleHasBackground: Story = {
+  tags: ['!dev', '!autodocs'],
+  // All of the interactive-state stories above exercise `variant="dark"`
+  // only — the entire `light` variant (`iconButtonBackground.light` =
+  // rgba(255,255,255,0.1), `iconButtonForeground.light.*`) previously had no
+  // interactive-state coverage at all. Rendered against a dark-ish backdrop
+  // so the (semi-transparent white) overlay is meaningful, mirroring the
+  // `Dark`/`Colored` stories' pattern above.
+  render: (args) => (
+    <Box style={{ backgroundColor: 'grey', width: 'fit-content', padding: '1rem' }}>
+      <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    button.focus();
+    const style = getComputedStyle(button);
+    await expect(style.outlineStyle).toBe('solid');
+    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};
+
+export const IconMatchesSizeToken: Story = {
+  tags: ['!dev', '!autodocs'],
+  // The rendered icon must be sized from components.icon.size.large (Figma:
+  // 24px) via the `globalStyle('${iconWrapper} svg', ...)` rule — mirrors the
+  // per-size token-matching tests in IconButton.stories.tsx (e.g.
+  // `LargeSizeIconMatchesToken`), which LabeledIconButton previously lacked
+  // entirely.
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const svg = canvas.getByRole('button').querySelector('svg') as SVGElement;
+    await expect(svg).toBeTruthy();
+    const { width, height } = getComputedStyle(svg);
+    await expect(width).toBe('24px');
+    await expect(height).toBe('24px');
+  },
+};
+
+export const DisabledDoesNotShowHoverBackground: Story = {
+  tags: ['!dev', '!autodocs'],
+  // A disabled <button> still matches the CSS `:hover` pseudo-class in
+  // Chromium/Firefox (only pointer *events* are suppressed, not the
+  // pseudo-class), so `variantStyle()`'s `:disabled` selector must explicitly
+  // reset `background: 'none'` or a hovered disabled button would incorrectly
+  // paint the hover overlay. Uses `userEvent.hover()` as a best-effort
+  // trigger — see the docblock on `InteractionAppliesBackgroundAndColor`
+  // above for why real `:hover` isn't reliably reproduced in this repo's
+  // Playwright/Chromium environment — but the assertion is on the CSS rule
+  // itself (no background at all on `:disabled`), which holds regardless.
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" disabled />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    await userEvent.hover(button);
+    const style = getComputedStyle(button);
+    await expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   },
 };

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -25,7 +25,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
 };
 
 export const Disabled: Story = {

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -217,6 +217,26 @@ export const IconMatchesSizeToken: Story = {
   },
 };
 
+export const AriaLabelPropCannotOverrideVisibleLabel: Story = {
+  tags: ['!dev', '!autodocs'],
+  // Regression test: TypeScript exempts hyphenated JSX attributes
+  // ('aria-label'/'aria-labelledby') from excess-property checks, so this
+  // call site compiles even though LabeledIconButtonProps excludes both —
+  // the type alone can't stop a caller from passing 'aria-label'. The
+  // component must therefore strip it at runtime so the visible `label`
+  // stays the accessible name.
+  render: (args) => (
+    <LabeledIconButton {...args} icon={<AddIcon />} aria-label="Should not be used" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Label' })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Should not be used' })
+    ).not.toBeInTheDocument();
+  },
+};
+
 export const DisabledDoesNotShowHoverBackground: Story = {
   tags: ['!dev', '!autodocs'],
   // A disabled <button> still matches the CSS `:hover` pseudo-class in this

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -1,4 +1,4 @@
-import { within } from '@storybook/testing-library';
+import { within, userEvent } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { LabeledIconButton } from './LabeledIconButton';
@@ -42,5 +42,43 @@ export const RendersLabelText: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Favorite')).toBeInTheDocument();
+  },
+};
+
+export const HoverAppliesBackgroundAndColor: Story = {
+  tags: ['!dev', '!autodocs'],
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    await userEvent.pointer({ keys: '[MouseLeft>]', target: button });
+    const style = getComputedStyle(button);
+    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};
+
+export const FocusVisibleHasBackgroundAndOutline: Story = {
+  tags: ['!dev', '!autodocs'],
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    button.focus();
+    const style = getComputedStyle(button);
+    await expect(style.outlineStyle).toBe('solid');
+    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+};
+
+export const MeetsTouchTarget: Story = {
+  tags: ['!dev', '!autodocs'],
+  // Icon + label + padding inherently exceed the 24px AA floor; no min-size needed.
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    const { width, height } = getComputedStyle(button);
+    await expect(parseFloat(width)).toBeGreaterThanOrEqual(24);
+    await expect(parseFloat(height)).toBeGreaterThanOrEqual(24);
   },
 };

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -4,24 +4,28 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Box, Flex as MantineFlex } from '@mantine/core';
 import { LabeledIconButton } from './LabeledIconButton';
 import { AddIcon } from '../../icons/AddIcon';
+import { EditIcon } from '../../icons/EditIcon';
+import { DownloadIcon } from '../../icons/DownloadIcon';
+import { TrashcanIcon } from '../../icons/TrashcanIcon';
+import { vars } from '../../theme';
 
 const meta = {
   argTypes: {
     icon: { control: false },
     label: { control: 'text' },
-    variant: { control: { type: 'select' }, options: ['light', 'dark'] },
+    variant: { control: { type: 'select' }, options: ['default', 'inverted'] },
     disabled: { control: 'boolean' },
   },
   args: {
     icon: <AddIcon />,
     label: 'Label',
-    // 'dark' so the Default story is legible against Storybook's default
-    // light canvas background (see LabeledIconButton.tsx: the 'light' variant
-    // is meant for use on dark/colored surfaces) — Task 8 previously
-    // hardcoded `variant="dark"` directly in Default's render function
-    // instead, which made the Controls panel's variant selector inert for
-    // that story. Setting it here keeps Controls live.
-    variant: 'dark',
+    // 'default' so the Default story is legible against Storybook's default
+    // light canvas background (see LabeledIconButton.tsx: the 'default'
+    // variant is meant for use on plain light surfaces) — Task 8 previously
+    // hardcoded the variant directly in Default's render function instead,
+    // which made the Controls panel's variant selector inert for that story.
+    // Setting it here keeps Controls live.
+    variant: 'default',
     disabled: false,
   },
   component: LabeledIconButton,
@@ -34,6 +38,16 @@ export const Default: Story = {
   render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
 };
 
+export const Inverted: Story = {
+  render: (args) => (
+    <Box
+      style={{ backgroundColor: vars.brand.blue.mainDark, width: 'fit-content', padding: '1rem' }}
+    >
+      <LabeledIconButton {...args} variant="inverted" icon={<AddIcon />} />
+    </Box>
+  ),
+};
+
 export const Disabled: Story = {
   render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} disabled />,
   play: async ({ canvasElement }) => {
@@ -43,29 +57,41 @@ export const Disabled: Story = {
   },
 };
 
-export const Dark: Story = {
+export const Colored: Story = {
   render: (args) => (
-    <Box style={{ backgroundColor: 'grey', width: 'fit-content', padding: '1rem' }}>
-      <LabeledIconButton {...args} variant="dark" icon={<AddIcon />} />
-    </Box>
+    // Demos the 'inverted' variant specifically (legible against saturated
+    // backgrounds) — explicit here since `meta.args.variant` defaults to
+    // 'default' (see Default's comment above). Backgrounds match Figma's
+    // Icon-button "Colored" reference frame exactly (node 13574:322):
+    // Blue/500, Turquoise/200, Green/500, Red/200 — not arbitrary CSS color
+    // keywords.
+    <MantineFlex gap="md">
+      <Box style={{ background: vars.primitives.colors.blue['500'], padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="inverted" />
+      </Box>
+      <Box style={{ background: vars.primitives.colors.turquoise['200'], padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="inverted" />
+      </Box>
+      <Box style={{ background: vars.primitives.colors.green['500'], padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="inverted" />
+      </Box>
+      <Box style={{ background: vars.primitives.colors.red['200'], padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} variant="inverted" />
+      </Box>
+    </MantineFlex>
   ),
 };
 
-export const Colored: Story = {
-  render: (args) => (
-    // Demos the 'light' variant specifically (legible against saturated
-    // backgrounds) — explicit here since `meta.args.variant` defaults to
-    // 'dark' (see Default's comment above).
+export const ActionToolbar: Story = {
+  // Real-world composition matching Figma's "Action toolbar" reference frame
+  // (node 13576:340): a row of `default`-variant LabeledIconButtons, each
+  // with its own icon and label rather than the meta's shared `AddIcon`/
+  // 'Label' args.
+  render: () => (
     <MantineFlex gap="md">
-      <Box style={{ background: 'red', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
-      </Box>
-      <Box style={{ background: 'green', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
-      </Box>
-      <Box style={{ background: 'blue', padding: '1rem' }}>
-        <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
-      </Box>
+      <LabeledIconButton variant="default" icon={<EditIcon />} label="Edit" />
+      <LabeledIconButton variant="default" icon={<DownloadIcon />} label="Download" />
+      <LabeledIconButton variant="default" icon={<TrashcanIcon />} label="Delete" />
     </MantineFlex>
   ),
 };
@@ -97,22 +123,22 @@ export const InteractionAppliesBackgroundAndColor: Story = {
    * removed since it still asserts the background-overlay behavior end to end
    * via a different interaction path than the sibling focus-visible story.
    */
-  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="default" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: 'Label' });
     await userEvent.pointer({ keys: '[MouseLeft>]', target: button });
     const style = getComputedStyle(button);
     // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
-    // (iconButton.states.overlay, dark variant) — exact match rather than
-    // "some color", so a light/dark overlay-token swap fails this test.
+    // (iconButton.states.overlay, default variant) — exact match rather than
+    // "some color", so a default/inverted overlay-token swap fails this test.
     await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
   },
 };
 
 export const FocusVisibleHasBackgroundAndOutline: Story = {
   tags: ['!dev', '!autodocs'],
-  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="default" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: 'Label' });
@@ -120,10 +146,11 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
     // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
-    // (iconButton.states.overlay, dark variant) — exact match.
+    // (iconButton.states.overlay, default variant) — exact match.
     await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
-    // `color` is untested elsewhere on LabeledIconButton — dark variant focus
-    // foreground = iconButton.states.focus = colors.neutral['500'] (#686872).
+    // `color` is untested elsewhere on LabeledIconButton — default variant
+    // focus foreground = iconButton.states.focus = colors.neutral['500']
+    // (#686872).
     await expect(style.color).toBe('rgb(104, 104, 114)');
   },
 };
@@ -141,17 +168,17 @@ export const MeetsTouchTarget: Story = {
   },
 };
 
-export const LightVariantFocusVisibleHasBackground: Story = {
+export const InvertedVariantFocusVisibleHasBackground: Story = {
   tags: ['!dev', '!autodocs'],
-  // All of the interactive-state stories above exercise `variant="dark"`
-  // only — the entire `light` variant (`iconButtonBackground.light` =
-  // rgba(255,255,255,0.1), `iconButtonForeground.light.*`) previously had no
-  // interactive-state coverage at all. Rendered against a dark-ish backdrop
-  // so the (semi-transparent white) overlay is meaningful, mirroring the
-  // `Dark`/`Colored` stories' pattern above.
+  // All of the interactive-state stories above exercise `variant="default"`
+  // only — the entire `inverted` variant (`iconButtonBackground.inverted` =
+  // rgba(255,255,255,0.1), `iconButtonForeground.inverted.*`) previously had
+  // no interactive-state coverage at all. Rendered against a dark-ish
+  // backdrop so the (semi-transparent white) overlay is meaningful,
+  // mirroring the `Inverted`/`Colored` stories' pattern above.
   render: (args) => (
     <Box style={{ backgroundColor: 'grey', width: 'fit-content', padding: '1rem' }}>
-      <LabeledIconButton {...args} icon={<AddIcon />} variant="light" />
+      <LabeledIconButton {...args} icon={<AddIcon />} variant="inverted" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -160,13 +187,13 @@ export const LightVariantFocusVisibleHasBackground: Story = {
     button.focus();
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
-    // iconButtonBackground.light = hover.overlayContrast = rgba(255, 255,
+    // iconButtonBackground.inverted = hover.overlayContrast = rgba(255, 255,
     // 255, 0.1) — `background-color` reports the declared (uncomposited)
     // rgba value, not a value composited against the backdrop, so this is
     // an exact match rather than "some color".
     await expect(style.backgroundColor).toBe('rgba(255, 255, 255, 0.1)');
-    // `color` is untested elsewhere on the light/contrast variant — light
-    // variant focus foreground = iconButton.states.contrast.focus =
+    // `color` is untested elsewhere on the inverted/contrast variant —
+    // inverted variant focus foreground = iconButton.states.contrast.focus =
     // colors.neutral['100'] (#f2f2f4).
     await expect(style.color).toBe('rgb(242, 242, 244)');
   },
@@ -203,7 +230,7 @@ export const DisabledDoesNotShowHoverBackground: Story = {
   // above for why real `:hover` isn't reliably reproduced in this repo's
   // Playwright/Chromium environment — but the assertion is on the CSS rule
   // itself (no background at all on `:disabled`), which holds regardless.
-  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" disabled />,
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="default" disabled />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: 'Label' });

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -45,8 +45,16 @@ export const RendersLabelText: Story = {
   },
 };
 
-export const HoverAppliesBackgroundAndColor: Story = {
+export const InteractionAppliesBackgroundAndColor: Story = {
   tags: ['!dev', '!autodocs'],
+  /**
+   * Verifies that interactive states (hover/focus/active) apply the background overlay.
+   * Uses userEvent.pointer() to simulate a mouse press, which triggers the :active state,
+   * because userEvent.hover() does not reliably trigger real :hover pseudo-class in
+   * Playwright/Chromium test environment (synthetic pointer events don't move the OS cursor).
+   * Since :hover, :focus-visible, and :active all apply the same background token,
+   * this test verifies the interactive background-swap behavior across all states.
+   */
   render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} variant="dark" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -83,14 +83,14 @@ export const InteractionAppliesBackgroundAndColor: Story = {
   tags: ['!dev', '!autodocs'],
   /**
    * Verifies that the background overlay applies during a `userEvent.pointer()`
-   * mouse-down press. This most likely exercises `:focus-visible`, not `:active`
-   * as an earlier version of this comment claimed: `@testing-library/user-event`
-   * calls `focus.focusElement(target)` internally as part of simulating a
-   * pointer press, which focuses the button and can trigger `:focus-visible`
-   * before/instead of a genuine `:active` state. That makes this story a
-   * near-duplicate of `FocusVisibleHasBackgroundAndOutline` below, and leaves
-   * real `:hover`/`:active` coverage as a known gap — `userEvent.hover()` does
-   * not reliably trigger the real `:hover` pseudo-class in this repo's
+   * mouse-down press. This exercises `:focus-visible`, not `:active`:
+   * `@testing-library/user-event` calls `focus.focusElement(target)` internally
+   * as part of simulating a pointer press, which focuses the button and
+   * triggers `:focus-visible` before/instead of a genuine `:active` state.
+   * That makes this story a near-duplicate of
+   * `FocusVisibleHasBackgroundAndOutline` below, and leaves real
+   * `:hover`/`:active` coverage as a known gap — `userEvent.hover()` does not
+   * reliably trigger the real `:hover` pseudo-class in this repo's
    * Playwright/Chromium test environment (synthetic pointer events don't move
    * the OS cursor), and simulating genuine `:active` (mouse held down without
    * moving focus) isn't currently exercised either. Kept as-is rather than
@@ -103,7 +103,10 @@ export const InteractionAppliesBackgroundAndColor: Story = {
     const button = canvas.getByRole('button', { name: 'Label' });
     await userEvent.pointer({ keys: '[MouseLeft>]', target: button });
     const style = getComputedStyle(button);
-    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
+    // (iconButton.states.overlay, dark variant) — exact match rather than
+    // "some color", so a light/dark overlay-token swap fails this test.
+    await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
   },
 };
 
@@ -116,7 +119,12 @@ export const FocusVisibleHasBackgroundAndOutline: Story = {
     button.focus();
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
-    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50']
+    // (iconButton.states.overlay, dark variant) — exact match.
+    await expect(style.backgroundColor).toBe('rgb(247, 247, 249)');
+    // `color` is untested elsewhere on LabeledIconButton — dark variant focus
+    // foreground = iconButton.states.focus = colors.neutral['500'] (#686872).
+    await expect(style.color).toBe('rgb(104, 104, 114)');
   },
 };
 
@@ -152,7 +160,15 @@ export const LightVariantFocusVisibleHasBackground: Story = {
     button.focus();
     const style = getComputedStyle(button);
     await expect(style.outlineStyle).toBe('solid');
-    await expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    // iconButtonBackground.light = hover.overlayContrast = rgba(255, 255,
+    // 255, 0.1) — `background-color` reports the declared (uncomposited)
+    // rgba value, not a value composited against the backdrop, so this is
+    // an exact match rather than "some color".
+    await expect(style.backgroundColor).toBe('rgba(255, 255, 255, 0.1)');
+    // `color` is untested elsewhere on the light/contrast variant — light
+    // variant focus foreground = iconButton.states.contrast.focus =
+    // colors.neutral['100'] (#f2f2f4).
+    await expect(style.color).toBe('rgb(242, 242, 244)');
   },
 };
 
@@ -176,9 +192,11 @@ export const IconMatchesSizeToken: Story = {
 
 export const DisabledDoesNotShowHoverBackground: Story = {
   tags: ['!dev', '!autodocs'],
-  // A disabled <button> still matches the CSS `:hover` pseudo-class in
-  // Chromium/Firefox (only pointer *events* are suppressed, not the
-  // pseudo-class), so `variantStyle()`'s `:disabled` selector must explicitly
+  // A disabled <button> still matches the CSS `:hover` pseudo-class in this
+  // project's Chromium test environment (a widely-known cross-browser CSS
+  // behavior, but only Chromium is exercised by this suite) — only pointer
+  // *events* are suppressed, not the pseudo-class — so `variantStyle()`'s
+  // `:disabled` selector must explicitly
   // reset `background: 'none'` or a hovered disabled button would incorrectly
   // paint the hover overlay. Uses `userEvent.hover()` as a best-effort
   // trigger — see the docblock on `InteractionAppliesBackgroundAndColor`

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -1,6 +1,7 @@
 import { within, userEvent } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Box, Flex as MantineFlex } from '@mantine/core';
 import { LabeledIconButton } from './LabeledIconButton';
 import { AddIcon } from '../../icons/AddIcon';
 
@@ -34,6 +35,30 @@ export const Disabled: Story = {
     const button = canvas.getByRole('button', { name: 'Label' });
     await expect(button).toBeDisabled();
   },
+};
+
+export const Dark: Story = {
+  render: (args) => (
+    <Box style={{ backgroundColor: 'grey', width: 'fit-content', padding: '1rem' }}>
+      <LabeledIconButton {...args} variant="dark" icon={<AddIcon />} />
+    </Box>
+  ),
+};
+
+export const Colored: Story = {
+  render: (args) => (
+    <MantineFlex gap="md">
+      <Box style={{ background: 'red', padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} />
+      </Box>
+      <Box style={{ background: 'green', padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} />
+      </Box>
+      <Box style={{ background: 'blue', padding: '1rem' }}>
+        <LabeledIconButton {...args} icon={<AddIcon />} />
+      </Box>
+    </MantineFlex>
+  ),
 };
 
 export const RendersLabelText: Story = {

--- a/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.stories.tsx
@@ -1,0 +1,46 @@
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LabeledIconButton } from './LabeledIconButton';
+import { AddIcon } from '../../icons/AddIcon';
+
+const meta = {
+  argTypes: {
+    icon: { control: false },
+    label: { control: 'text' },
+    variant: { control: { type: 'select' }, options: ['light', 'dark'] },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    icon: <AddIcon />,
+    label: 'Label',
+    variant: 'light',
+    disabled: false,
+  },
+  component: LabeledIconButton,
+} satisfies Meta<typeof LabeledIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} />,
+};
+
+export const Disabled: Story = {
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} disabled />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Label' });
+    await expect(button).toBeDisabled();
+  },
+};
+
+export const RendersLabelText: Story = {
+  tags: ['!dev', '!autodocs'],
+  render: (args) => <LabeledIconButton {...args} icon={<AddIcon />} label="Favorite" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Favorite')).toBeInTheDocument();
+  },
+};

--- a/src/components/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.tsx
@@ -1,9 +1,10 @@
 import { forwardRef } from 'react';
 import cx from 'clsx';
-import { Flex, UnstyledButton, type UnstyledButtonProps } from '@mantine/core';
+import { UnstyledButton, type UnstyledButtonProps } from '@mantine/core';
 import { root, iconWrapper, label as labelStyle, variants } from './LabeledIconButton.css.ts';
 
-export interface LabeledIconButtonProps extends Omit<UnstyledButtonProps, 'children'> {
+export interface LabeledIconButtonProps
+  extends Omit<UnstyledButtonProps, 'children'>, React.AriaAttributes {
   icon: React.ReactNode;
   label: string;
   variant?: 'light' | 'dark';
@@ -21,9 +22,7 @@ export const LabeledIconButton = forwardRef<HTMLButtonElement, LabeledIconButton
         disabled={disabled}
         className={cx(root, variants[variant], className)}
       >
-        <Flex direction="column" align="center" className={iconWrapper}>
-          {icon}
-        </Flex>
+        <span className={iconWrapper}>{icon}</span>
         <span className={labelStyle}>{label}</span>
       </UnstyledButton>
     );

--- a/src/components/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.tsx
@@ -12,13 +12,13 @@ export interface LabeledIconButtonProps
     Omit<React.AriaAttributes, 'aria-label' | 'aria-labelledby'> {
   icon: React.ReactNode;
   label: string;
-  variant?: 'light' | 'dark';
+  variant?: 'default' | 'inverted';
   disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export const LabeledIconButton = forwardRef<HTMLButtonElement, LabeledIconButtonProps>(
-  ({ icon, label, variant = 'light', disabled, onClick, className, ...props }, ref) => {
+  ({ icon, label, variant = 'default', disabled, onClick, className, ...props }, ref) => {
     return (
       <UnstyledButton
         ref={ref}

--- a/src/components/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.tsx
@@ -1,0 +1,33 @@
+import { forwardRef } from 'react';
+import cx from 'clsx';
+import { Flex, UnstyledButton, type UnstyledButtonProps } from '@mantine/core';
+import { root, iconWrapper, label as labelStyle, variants } from './LabeledIconButton.css.ts';
+
+export interface LabeledIconButtonProps extends Omit<UnstyledButtonProps, 'children'> {
+  icon: React.ReactNode;
+  label: string;
+  variant?: 'light' | 'dark';
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+export const LabeledIconButton = forwardRef<HTMLButtonElement, LabeledIconButtonProps>(
+  ({ icon, label, variant = 'light', disabled, onClick, className, ...props }, ref) => {
+    return (
+      <UnstyledButton
+        ref={ref}
+        {...props}
+        onClick={onClick}
+        disabled={disabled}
+        className={cx(root, variants[variant], className)}
+      >
+        <Flex direction="column" align="center" className={iconWrapper}>
+          {icon}
+        </Flex>
+        <span className={labelStyle}>{label}</span>
+      </UnstyledButton>
+    );
+  }
+);
+
+LabeledIconButton.displayName = 'LabeledIconButton';

--- a/src/components/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.tsx
@@ -4,7 +4,12 @@ import { UnstyledButton, type UnstyledButtonProps } from '@mantine/core';
 import { root, iconWrapper, label as labelStyle, variants } from './LabeledIconButton.css.ts';
 
 export interface LabeledIconButtonProps
-  extends Omit<UnstyledButtonProps, 'children'>, React.AriaAttributes {
+  extends
+    Omit<UnstyledButtonProps, 'children'>,
+    // Excludes 'aria-label'/'aria-labelledby' — the visible `label` prop
+    // below is always this component's accessible name, and letting a
+    // consumer pass either would silently override that invariant.
+    Omit<React.AriaAttributes, 'aria-label' | 'aria-labelledby'> {
   icon: React.ReactNode;
   label: string;
   variant?: 'light' | 'dark';

--- a/src/components/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/components/LabeledIconButton/LabeledIconButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
 import cx from 'clsx';
 import { UnstyledButton, type UnstyledButtonProps } from '@mantine/core';
 import { root, iconWrapper, label as labelStyle, variants } from './LabeledIconButton.css.ts';
@@ -8,8 +8,18 @@ export interface LabeledIconButtonProps
     Omit<UnstyledButtonProps, 'children'>,
     // Excludes 'aria-label'/'aria-labelledby' — the visible `label` prop
     // below is always this component's accessible name, and letting a
-    // consumer pass either would silently override that invariant.
-    Omit<React.AriaAttributes, 'aria-label' | 'aria-labelledby'> {
+    // consumer pass either would silently override that invariant. Note this
+    // Omit only blocks typed object construction: TS exempts hyphenated JSX
+    // attribute names from excess-property checks, so a JSX call site would
+    // still compile past it — the runtime strip below is what actually
+    // enforces the invariant.
+    // 'style' is dropped here — UnstyledButtonProps (via Mantine's Box)
+    // already declares it with a different (CSS-variable-friendly) type, and
+    // intersecting both would conflict.
+    Omit<
+      ComponentPropsWithoutRef<'button'>,
+      'children' | 'style' | 'aria-label' | 'aria-labelledby'
+    > {
   icon: React.ReactNode;
   label: string;
   variant?: 'default' | 'inverted';
@@ -23,6 +33,8 @@ export const LabeledIconButton = forwardRef<HTMLButtonElement, LabeledIconButton
       <UnstyledButton
         ref={ref}
         {...props}
+        aria-label={undefined}
+        aria-labelledby={undefined}
         onClick={onClick}
         disabled={disabled}
         className={cx(root, variants[variant], className)}

--- a/src/components/LabeledIconButton/index.ts
+++ b/src/components/LabeledIconButton/index.ts
@@ -1,0 +1,1 @@
+export * from './LabeledIconButton';

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useArgs } from '@storybook/client-api';
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 import { Modal } from './Modal';
 import { Button } from '../Button';
 
@@ -51,6 +53,29 @@ export const Primary: Story = {
         </Modal>
       </>
     );
+  },
+};
+
+export const CloseButtonHasAccessibleName: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
+  // Regression test for #94: closeButtonProps had no fallback aria-label, so
+  // a consumer that omitted it shipped a close button with no accessible
+  // name — an axe-critical button-name violation. Rendered already-`opened`
+  // (rather than toggled via a click) to avoid depending on Mantine's
+  // mount/transition timing.
+  args: {
+    title: 'Modal title',
+    children: 'Modal content',
+    opened: true,
+    closeButtonProps: { 'aria-label': 'Close modal' },
+    onClose: () => {},
+  },
+  play: async () => {
+    const body = within(document.body);
+    const closeButton = await body.findByRole('button', { name: 'Close modal' });
+    await expect(closeButton).toBeInTheDocument();
   },
 };
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,10 +1,13 @@
-import { Flex, Modal as MantineModal, type ModalProps } from '@mantine/core';
+import { Flex, Modal as MantineModal, type ModalProps as MantineModalProps } from '@mantine/core';
 import { CloseIcon } from '../../icons/CloseIcon';
 import { mergeClassNames } from '../../utils';
 import { IconButton } from '../IconButton';
 import { header, modalCloseButton, modalHeaderTitle, padding } from './Modal.css';
 
-export interface Props extends Omit<ModalProps, 'withCloseButton' | 'closeButtonProps'> {
+export interface ModalProps extends Omit<
+  MantineModalProps,
+  'withCloseButton' | 'closeButtonProps'
+> {
   // Only 'aria-label' is ever read from this prop below — the full Mantine
   // CloseButtonProps shape isn't forwarded to the rendered IconButton, so the
   // type is narrowed to what's actually used. Required (not optional): this
@@ -15,7 +18,7 @@ export interface Props extends Omit<ModalProps, 'withCloseButton' | 'closeButton
   closeButtonProps: { 'aria-label': string };
 }
 
-export function Modal(props: Props) {
+export function Modal(props: ModalProps) {
   const { classNames, title, children, onClose, closeButtonProps, ...rest } = props;
 
   const defaultClassNames = {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,7 +4,18 @@ import { mergeClassNames } from '../../utils';
 import { IconButton } from '../IconButton';
 import { header, modalCloseButton, modalHeaderTitle, padding } from './Modal.css';
 
-export function Modal(props: Omit<ModalProps, 'withCloseButton'>) {
+export interface Props extends Omit<ModalProps, 'withCloseButton' | 'closeButtonProps'> {
+  // Only 'aria-label' is ever read from this prop below — the full Mantine
+  // CloseButtonProps shape isn't forwarded to the rendered IconButton, so the
+  // type is narrowed to what's actually used. Required (not optional): this
+  // component always renders a close button, so it must always have an
+  // accessible name (see #94 — Modal shipped with no fallback label, so
+  // consumers who omitted this prop got an axe-critical button-name
+  // violation).
+  closeButtonProps: { 'aria-label': string };
+}
+
+export function Modal(props: Props) {
   const { classNames, title, children, onClose, closeButtonProps, ...rest } = props;
 
   const defaultClassNames = {
@@ -23,12 +34,12 @@ export function Modal(props: Omit<ModalProps, 'withCloseButton'>) {
         <Flex className={header}>
           <MantineModal.Title>{title}</MantineModal.Title>
           <IconButton
-            variant="dark"
+            variant="default"
             size={'lg'}
             onClick={() => {
               onClose();
             }}
-            aria-label={closeButtonProps?.['aria-label']}
+            aria-label={closeButtonProps['aria-label']}
           >
             <CloseIcon />
           </IconButton>

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -17,6 +17,8 @@ const meta = {
     pageCount: 5,
     activePageIndex: 0,
     maxVisiblePages: 5,
+    leftButtonLabel: 'Edellinen sivu',
+    rightButtonLabel: 'Seuraava sivu',
   },
   component: Pagination,
 } satisfies Meta<typeof Pagination>;
@@ -30,6 +32,8 @@ export const Primary: Story = {
     activePageIndex: 0,
     onPageChange: () => {},
     maxVisiblePages: 5,
+    leftButtonLabel: 'Edellinen sivu',
+    rightButtonLabel: 'Seuraava sivu',
   },
 
   render: (args) => {
@@ -47,6 +51,8 @@ export const Primary: Story = {
         }
         pageCount={args.pageCount}
         maxVisiblePages={args.maxVisiblePages}
+        leftButtonLabel={args.leftButtonLabel}
+        rightButtonLabel={args.rightButtonLabel}
       />
     );
   },
@@ -75,5 +81,31 @@ export const ChevronsPointCorrectDirections: Story = {
     // incidental CSS transform that happens to produce the same pixels.
     await expect(leftPath.getAttribute('d')).toContain('M15.207 20.207');
     await expect(rightPath.getAttribute('d')).toContain('M8.79297 3.79297');
+  },
+};
+
+export const ChevronsHaveAccessibleNames: Story = {
+  // Test-only: carries a `play` assertion, not documentation, so it's hidden
+  // from the sidebar (`!dev`) and autodocs page (`!autodocs`).
+  tags: ['!dev', '!autodocs'],
+  // Regression test for #95: leftButtonLabel/rightButtonLabel were optional
+  // with no fallback, so a consumer that omitted them (like this story's own
+  // Primary previously did) shipped chevrons with no accessible name — an
+  // axe-critical button-name violation. Now required at the type level; this
+  // asserts the runtime behavior actually holds.
+  args: {
+    pageCount: 5,
+    activePageIndex: 2,
+    onPageChange: () => {},
+    leftButtonLabel: 'Edellinen sivu',
+    rightButtonLabel: 'Seuraava sivu',
+  },
+  render: (args) => <Pagination {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const left = canvas.getByLabelText('Edellinen sivu');
+    const right = canvas.getByLabelText('Seuraava sivu');
+    await expect(left).toBeInTheDocument();
+    await expect(right).toBeInTheDocument();
   },
 };

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -11,11 +11,16 @@ interface Props {
   /** Function to assign an aria-label to each page button item */
   getAriaLabelForButton?: (pageIndex: number) => string;
   maxVisiblePages?: number;
-  leftButtonLabel?: string;
-  rightButtonLabel?: string;
+  /** Accessible name for the previous-page chevron button. */
+  leftButtonLabel: string;
+  /** Accessible name for the next-page chevron button. */
+  rightButtonLabel: string;
 }
 
-interface ListItemProps extends Props {
+interface ListItemProps extends Pick<
+  Props,
+  'getAriaLabelForButton' | 'activePageIndex' | 'onPageChange'
+> {
   index: number;
 }
 
@@ -102,8 +107,6 @@ export function Pagination({
                 key={index}
                 index={index}
                 getAriaLabelForButton={getAriaLabelForButton}
-                pageCount={pageCount}
-                maxVisiblePages={maxVisiblePages}
                 activePageIndex={activePageIndex}
                 onPageChange={(newPageIndex) => {
                   onPageChange(newPageIndex);

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -80,7 +80,7 @@ export function Pagination({
         }}
         className={leftButton}
         size="lg"
-        variant="dark"
+        variant="default"
       >
         <ChevronLeftIcon />
       </IconButton>
@@ -121,7 +121,7 @@ export function Pagination({
         }}
         className={rightButton}
         size="lg"
-        variant="dark"
+        variant="default"
       >
         <ChevronRightIcon />
       </IconButton>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -62,13 +62,18 @@ function SelectRightSection({
   return (
     <Flex className={rightSectionContainer}>
       {displayClearButton && (
-        <IconButton aria-label={clearButtonLabel} variant="dark" onClick={onClearClick} size={'sm'}>
+        <IconButton
+          aria-label={clearButtonLabel}
+          variant="default"
+          onClick={onClearClick}
+          size={'sm'}
+        >
           <CloseIcon />
         </IconButton>
       )}
       <IconButton
         aria-label={dropDownOpened ? collapseButtonLabel : expandButtonLabel}
-        variant="dark"
+        variant="default"
         onMouseDown={(e) => e.nativeEvent.stopPropagation()}
         onClick={toggleDropdown}
         size={'sm'}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -130,7 +130,7 @@ export const TextField = ({
                 onClearButtonClick?.();
               }}
               size={'sm'}
-              variant="dark"
+              variant="default"
             >
               <CloseIcon />
             </IconButton>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -3,6 +3,10 @@ export { Breadcrumbs } from './Breadcrumbs/Breadcrumbs';
 export { Button } from './Button/Button';
 export { Checkbox } from './Checkbox/Checkbox';
 export { IconButton } from './IconButton/IconButton';
+export {
+  LabeledIconButton,
+  type LabeledIconButtonProps,
+} from './LabeledIconButton/LabeledIconButton';
 export { LoadingSpinner } from './LoadingSpinner/LoadingSpinner';
 export { Modal } from './Modal/Modal';
 export { NavigationLink } from './NavigationLink/NavigationLink';

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -88,6 +88,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -103,7 +104,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -149,6 +150,9 @@ exports[`Token Values Match Snapshot > lg 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.5rem * var(--mantine-scale))",
@@ -403,6 +407,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -418,7 +423,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -464,6 +469,9 @@ exports[`Token Values Match Snapshot > md 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.25rem * var(--mantine-scale))",
@@ -718,6 +726,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -733,7 +742,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -779,6 +788,9 @@ exports[`Token Values Match Snapshot > sm 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.25rem * var(--mantine-scale))",
@@ -1447,6 +1459,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       },
       "iconButton": {
         "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+        "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
         "padding": "calc(0.125rem * var(--mantine-scale))",
         "states": {
           "active": "#9999a0",
@@ -1462,7 +1475,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
           "disabled": "#9999a0",
           "focus": "#686872",
           "hover": "#686872",
-          "overlay": "#f1eeeb",
+          "overlay": "#f7f7f9",
         },
       },
       "input": {
@@ -1508,6 +1521,9 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
           },
         },
         "highlightFontWeight": "600",
+      },
+      "labeledIconButton": {
+        "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "link": {
         "spacing": "calc(0.25rem * var(--mantine-scale))",
@@ -1763,6 +1779,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -1778,7 +1795,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -1824,6 +1841,9 @@ exports[`Token Values Match Snapshot > xl 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.5rem * var(--mantine-scale))",
@@ -2078,6 +2098,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -2093,7 +2114,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -2139,6 +2160,9 @@ exports[`Token Values Match Snapshot > xs 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.25rem * var(--mantine-scale))",
@@ -2393,6 +2417,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     },
     "iconButton": {
       "cornerRadius": "calc(0.25rem * var(--mantine-scale))",
+      "minTouchTarget": "calc(1.5rem * var(--mantine-scale))",
       "padding": "calc(0.125rem * var(--mantine-scale))",
       "states": {
         "active": "#9999a0",
@@ -2408,7 +2433,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
         "disabled": "#9999a0",
         "focus": "#686872",
         "hover": "#686872",
-        "overlay": "#f1eeeb",
+        "overlay": "#f7f7f9",
       },
     },
     "input": {
@@ -2454,6 +2479,9 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
         },
       },
       "highlightFontWeight": "600",
+    },
+    "labeledIconButton": {
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
       "spacing": "calc(0.5rem * var(--mantine-scale))",

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -228,6 +228,10 @@ export function getTheme(bp: BreakpointKey) {
     },
     iconButton: {
       padding: rem('2px'),
+      // Unused by IconButton/LabeledIconButton's interactive-state backgrounds —
+      // those correctly use the top-level 0px cornerRadius (verified against
+      // Figma's Effects/Corner-radius/Default = 0 for this component family).
+      // Do not wire this in without re-checking Figma.
       cornerRadius: rem('4px'),
       minTouchTarget: rem('24px'),
       states: {

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -229,6 +229,7 @@ export function getTheme(bp: BreakpointKey) {
     iconButton: {
       padding: rem('2px'),
       cornerRadius: rem('4px'),
+      minTouchTarget: rem('24px'),
       states: {
         contrast: {
           default: colors.neutral.white,
@@ -243,8 +244,16 @@ export function getTheme(bp: BreakpointKey) {
         focus: colors.neutral['500'],
         active: colors.neutral['400'],
         disabled: colors.neutral['400'],
-        overlay: colors.neutral.warm['100'],
+        // Figma Background/Hover|Focus|Active = #f7f7f9 = colors.neutral['50'].
+        // (colors.neutral.warm['100'] = #f1eeeb was the wrong token here — that
+        // warm tint belongs to the Select "selected item" highlight instead.)
+        overlay: colors.neutral['50'],
       },
+    },
+    labeledIconButton: {
+      // Figma Spacing/1 = 8, a fixed constant (not per-breakpoint) — same
+      // precedent as forms.fieldset.spacing above.
+      spacing: primitives.spacing['1'],
     },
     input: {
       font: {


### PR DESCRIPTION
## Summary

Closes #90.

- **IconButton**: guarantees a 24×24px minimum touch target (WCAG 2.2 AA, SC 2.5.8) at every size, and its focus-visible state now shows the same background overlay as hover/active (previously outline-only) — verified against the live Figma file for #90, which contradicted the issue's original "background-only, no outline" assumption; the correct fix was to *add* the missing background, not remove the outline.
- **LabeledIconButton**: new component (icon + text label, vertical layout), reusing IconButton's state-color tokens via a new shared `iconButtonState.css.ts` fragment so both stay visually in sync. Light/dark variants, all interactive states, no `size` prop (fixed 24px icon).
- Corrected a pre-existing stale token value (`iconButton.states.overlay`: `#f1eeeb` → `#f7f7f9`) that didn't match Figma — found necessary while implementing the focus-background fix.
- Fixed a related bug: disabled IconButton/LabeledIconButton previously still showed the hover background overlay when hovered (disabled `<button>`s still match CSS `:hover`).
- Fixed a pre-existing `IconButton.stories.tsx` prop-spread-order bug that silently overrode several stories' explicit `variant` prop, hiding this PR's own token fix from Storybook.

## Process

Implemented via a written design spec + implementation plan, executed task-by-task with a fresh subagent per task, per-task spec/quality review, a final whole-branch review + one fix wave, and then a second independent multi-agent PR review pass (code quality, test coverage, comment accuracy, type design) before opening this PR — see CHANGELOG for the full behavior-change list.

One test-coverage gap found via mutation testing (interaction-state color assertions checked only "not transparent," not the exact expected color) has been fixed; a few smaller items were deferred as follow-ups rather than expanding this PR's scope further (see conversation/ledger for details — happy to file follow-up issues on request).

## Test plan

- [x] `npm test` — 175/175 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run prettier:check` / `eslint` — clean
- [x] `npm run build-storybook` — succeeds
- [x] Visually verified against the Figma file for #90 (touch-target sizes, focus background+outline, LabeledIconButton layout/spacing/typography, light/dark color mapping) via real-browser Playwright rendering, not just story assertions
- [x] Manually re-checked the 6 internal `IconButton` call sites using `size="sm"` (TextField, Select ×2, DateField, DateFieldCalendar ×2) at a narrow (320px) viewport for layout regressions from the 22→24px growth — none found