### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: breaking changes bump the minor version).
 
-## [Unreleased]
+## [0.8.0] - 2026-08-18
 
 ### Upgrade notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tampere/treds",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tampere/treds",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "clsx": "^2.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/Tampere/Tampere-design-system.git"
   },
   "private": false,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Finalizes the CHANGELOG and bumps the version for the v0.8.0 release (IconButton touch-target/focus rework, new LabeledIconButton component, and Modal/Pagination accessible-name fixes — closes #90, #105, #94, #95, all already merged to `main` via PR #104).

Merge with a regular merge commit (not squash) so the `v0.8.0` tag stays reachable from `main`.