### PR TITLE
feat(#49): add TextLink component

### DIFF
--- a/src/components/TextLink/TextLink.css.ts
+++ b/src/components/TextLink/TextLink.css.ts
@@ -8,9 +8,16 @@ const {
 export const externalIcon = style({
   display: 'inline-block',
   verticalAlign: 'middle',
+  // Nudges the icon up to visually balance it against the underline — the
+  // icon's viewBox has no internal padding, so at `middle` alignment its
+  // bottom edge otherwise hangs below the underline. `position: relative`
+  // shifts it purely visually; the element still reserves its original box
+  // for layout, so line-height is unaffected even in wrapped paragraphs.
+  position: 'relative',
+  top: '-0.2em',
   width: '1em',
   height: '1em',
-  marginLeft: components.link.spacing,
+  marginLeft: components.link.iconSpacing,
 });
 
 type Size = Exclude<keyof typeof components.typography, 'margin'>;

--- a/src/components/TextLink/TextLink.css.ts
+++ b/src/components/TextLink/TextLink.css.ts
@@ -1,0 +1,55 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: { components, states, focusRing },
+} = vars;
+
+export const externalIcon = style({
+  display: 'inline-block',
+  verticalAlign: 'middle',
+  width: '1em',
+  height: '1em',
+  marginLeft: components.link.spacing,
+});
+
+type Size = Exclude<keyof typeof components.typography, 'margin'>;
+
+function sizeStyle(size: Size) {
+  const { fontFamily, fontSize, fontWeight, lineHeight } = components.typography[size];
+  return { fontFamily, fontSize, fontWeight, lineHeight };
+}
+
+export const size = styleVariants({
+  h1: sizeStyle('h1'),
+  h2: sizeStyle('h2'),
+  h3: sizeStyle('h3'),
+  h4: sizeStyle('h4'),
+  h5: sizeStyle('h5'),
+  subheader: sizeStyle('subheader'),
+  p1: sizeStyle('p1'),
+  p2: sizeStyle('p2'),
+  caption: sizeStyle('caption'),
+});
+
+// `:hover` isn't asserted in stories — synthetic pointer events don't move the
+// OS cursor in this repo's Playwright/Chromium test environment, so `:hover`
+// can't be reliably exercised (same known gap as LabeledIconButton.stories.tsx).
+export const link = styleVariants({
+  unvisited: {
+    color: states.default,
+    textDecoration: 'underline',
+    selectors: {
+      '&:hover': { color: states.hover, textDecoration: 'none' },
+      '&:focus-visible': { ...focusRing, color: states.focus, textDecoration: 'underline' },
+    },
+  },
+  visited: {
+    color: states.visited,
+    textDecoration: 'underline',
+    selectors: {
+      '&:hover': { color: states.visited, textDecoration: 'none' },
+      '&:focus-visible': { ...focusRing, color: states.visited, textDecoration: 'underline' },
+    },
+  },
+});

--- a/src/components/TextLink/TextLink.css.ts
+++ b/src/components/TextLink/TextLink.css.ts
@@ -10,9 +10,7 @@ export const externalIcon = style({
   verticalAlign: 'middle',
   // Nudges the icon up to visually balance it against the underline — the
   // icon's viewBox has no internal padding, so at `middle` alignment its
-  // bottom edge otherwise hangs below the underline. `position: relative`
-  // shifts it purely visually; the element still reserves its original box
-  // for layout, so line-height is unaffected even in wrapped paragraphs.
+  // bottom edge otherwise hangs below the underline.
   position: 'relative',
   top: components.link.iconVerticalOffset,
   width: components.link.iconSize,
@@ -34,7 +32,17 @@ export const visuallyHidden = style({
   border: '0',
 });
 
-export type TextLinkSize = Exclude<keyof typeof components.typography, 'margin'>;
+// Typography scale keys shaped like a font style (excludes e.g. `margin`,
+// which is a bare spacing value, not a font record) — structural rather than
+// naming `margin` explicitly, so a future non-font-style key is excluded
+// automatically instead of silently becoming a valid TextLink size.
+export type TextLinkSize = {
+  [K in keyof typeof components.typography]: (typeof components.typography)[K] extends {
+    fontFamily: string;
+  }
+    ? K
+    : never;
+}[keyof typeof components.typography];
 
 function sizeStyle(size: TextLinkSize) {
   const { fontFamily, fontSize, fontWeight, lineHeight } = components.typography[size];

--- a/src/components/TextLink/TextLink.css.ts
+++ b/src/components/TextLink/TextLink.css.ts
@@ -14,15 +14,29 @@ export const externalIcon = style({
   // shifts it purely visually; the element still reserves its original box
   // for layout, so line-height is unaffected even in wrapped paragraphs.
   position: 'relative',
-  top: '-0.2em',
-  width: '1em',
-  height: '1em',
+  top: components.link.iconVerticalOffset,
+  width: components.link.iconSize,
+  height: components.link.iconSize,
   marginLeft: components.link.iconSpacing,
 });
 
-type Size = Exclude<keyof typeof components.typography, 'margin'>;
+// Screen-reader-only text — visually hidden but still announced. Mirrors
+// DateField.css.ts's `visuallyHidden` (no shared helper exists yet).
+export const visuallyHidden = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: '0',
+});
 
-function sizeStyle(size: Size) {
+export type TextLinkSize = Exclude<keyof typeof components.typography, 'margin'>;
+
+function sizeStyle(size: TextLinkSize) {
   const { fontFamily, fontSize, fontWeight, lineHeight } = components.typography[size];
   return { fontFamily, fontSize, fontWeight, lineHeight };
 }
@@ -46,17 +60,37 @@ export const link = styleVariants({
   unvisited: {
     color: states.default,
     textDecoration: 'underline',
+    textDecorationThickness: components.link.underlineThickness,
     selectors: {
-      '&:hover': { color: states.hover, textDecoration: 'none' },
-      '&:focus-visible': { ...focusRing, color: states.focus, textDecoration: 'underline' },
+      '&:hover': {
+        color: states.hover,
+        textDecoration: 'underline',
+        textDecorationThickness: components.link.hoverUnderlineThickness,
+      },
+      '&:focus-visible': {
+        ...focusRing,
+        color: states.focus,
+        textDecoration: 'underline',
+        textDecorationThickness: components.link.hoverUnderlineThickness,
+      },
     },
   },
   visited: {
     color: states.visited,
     textDecoration: 'underline',
+    textDecorationThickness: components.link.underlineThickness,
     selectors: {
-      '&:hover': { color: states.visited, textDecoration: 'none' },
-      '&:focus-visible': { ...focusRing, color: states.visited, textDecoration: 'underline' },
+      '&:hover': {
+        color: states.visited,
+        textDecoration: 'underline',
+        textDecorationThickness: components.link.hoverUnderlineThickness,
+      },
+      '&:focus-visible': {
+        ...focusRing,
+        color: states.visited,
+        textDecoration: 'underline',
+        textDecorationThickness: components.link.hoverUnderlineThickness,
+      },
     },
   },
 });

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
-import { TextLink } from './TextLink';
+import { Typography } from '../Typography';
+import { TextLink, type TextLinkSize } from './TextLink';
 
 const meta = {
   component: TextLink,
@@ -65,8 +66,9 @@ export const Visited: Story = {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
     const style = getComputedStyle(link);
-    // Figma "Default, visited" = text/link-visited = #5f93c6 = states.visited
-    await expect(style.color).toBe('rgb(95, 147, 198)');
+    // states.visited = brand.blue.mainExtraDark = #172f5a (darkened from
+    // Figma's #5f93c6 to meet WCAG AA contrast — see theme.ts)
+    await expect(style.color).toBe('rgb(23, 47, 90)');
     await expect(style.textDecorationLine).toBe('underline');
   },
 };
@@ -83,27 +85,44 @@ export const OpenExternal: Story = {
   },
 };
 
+const ALL_SIZES = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'subheader',
+  'p1',
+  'p2',
+  'caption',
+] as const satisfies readonly TextLinkSize[];
+
 export const Sizes: Story = {
   tags: docExample,
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'flex-start' }}>
-      <TextLink {...args} size="h1" href="#h1">
-        Heading-sized link
-      </TextLink>
-      <TextLink {...args} size="caption" href="#caption">
-        Caption-sized link
-      </TextLink>
+      {ALL_SIZES.map((size) => (
+        <TextLink {...args} key={size} size={size} openExternal href={`#${size}`}>
+          {size.toUpperCase()} sized link
+        </TextLink>
+      ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const h1Link = canvas.getByRole('link', { name: 'Heading-sized link' });
-    const captionLink = canvas.getByRole('link', { name: 'Caption-sized link' });
-    const h1Size = parseFloat(getComputedStyle(h1Link).fontSize);
-    const captionSize = parseFloat(getComputedStyle(captionLink).fontSize);
-    // h1 must render larger than caption at the same breakpoint — proves
-    // `size` actually drives the typography token rather than a fixed value.
-    await expect(h1Size).toBeGreaterThan(captionSize);
+    const fontSizes: number[] = [];
+    for (const size of ALL_SIZES) {
+      const link = canvas.getByRole('link', { name: `${size.toUpperCase()} sized link` });
+      await expect(link.querySelector('svg')).not.toBeNull();
+      fontSizes.push(parseFloat(getComputedStyle(link).fontSize));
+    }
+    // Every size must render no larger than the previous one — proves `size`
+    // drives the typography token across the whole scale (not just the two
+    // extremes) and that the icon renders at each of them. Non-strict: e.g.
+    // `subheader` and `p1` share a font size by design at every breakpoint.
+    for (let i = 1; i < fontSizes.length; i++) {
+      await expect(fontSizes[i]).toBeLessThanOrEqual(fontSizes[i - 1]);
+    }
   },
 };
 
@@ -126,6 +145,115 @@ export const WithCustomLink: Story = {
     const style = getComputedStyle(link);
     // The renderLink escape hatch still receives TextLink's link styling.
     await expect(style.color).toBe('rgb(41, 84, 154)');
+  },
+};
+
+export const InParagraph: Story = {
+  tags: docExample,
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 480 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <Typography variant="p1">
+          Tampereen kaupungin palveluista, kuten varhaiskasvatuksesta, terveyspalveluista ja
+          asumisen tuista, löydät ajantasaista tietoa kootusti{' '}
+          <TextLink {...args} size="p1" href="#lisatietoa">
+            verkkosivuiltamme
+          </TextLink>
+          , joilta voit myös varata ajan asiointiin, seurata kaupungin päätöksentekoa ja lähettää
+          palautetta suoraan vastuuvirkailijalle.
+        </Typography>
+        <Typography variant="p2">
+          Jos tarvitset henkilökohtaista opastusta esimerkiksi asumistuen hakemisessa tai
+          rakennusluvan täyttämisessä, voit helposti{' '}
+          <TextLink {...args} size="p2" href="#varaa-aika">
+            varata ajan neuvontapalveluun
+          </TextLink>{' '}
+          arkisin kello 9–16 välillä, jolloin asiantuntijamme auttaa sinua täyttämään tarvittavat
+          lomakkeet ja vastaa kysymyksiisi.
+        </Typography>
+        <Typography variant="caption">
+          Ennen yhteydenottoa asiakaspalveluun kannattaa aina tarkistaa ensin, löytyykö vastaus
+          kysymykseesi jo kootusti sivustomme{' '}
+          <TextLink {...args} size="caption" href="#ukk">
+            usein kysytyt kysymykset
+          </TextLink>{' '}
+          -osiosta, johon on koottu vastaukset asumiseen, varhaiskasvatukseen ja terveyspalveluihin
+          liittyviin yleisimpiin kysymyksiin.
+        </Typography>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <Typography variant="p1">
+          Kaupungin osallistumis- ja vaikuttamismahdollisuuksista, kuten asukasraadeista, kyselyistä
+          ja osallistuvasta budjetoinnista, kerrotaan tarkemmin{' '}
+          <TextLink {...args} size="p1" openExternal href="https://tampere.fi">
+            Tampere.fi-sivustolla
+          </TextLink>
+          , jonne on koottu myös ohjeet oman aloitteen jättämiseen ja kaupungin päätöksenteon
+          seuraamiseen.
+        </Typography>
+        <Typography variant="p2">
+          Tarkemmat ohjeet lomakkeiden täyttämiseen, liitteiden lisäämiseen ja hakemuksen tilan
+          seurantaan löydät kaupungin{' '}
+          <TextLink {...args} size="p2" openExternal href="https://tampere.fi/asiointi">
+            asiointipalvelusta
+          </TextLink>
+          , jonka kautta hoidat suurimman osan asioinneista ilman erillistä käyntiä virastossa.
+        </Typography>
+        <Typography variant="caption">
+          Palvelun käyttöehdot, tietosuojaseloste ja saavutettavuusseloste löytyvät
+          kokonaisuudessaan{' '}
+          <TextLink {...args} size="caption" openExternal href="https://tampere.fi/kayttoehdot">
+            Tampere.fi-sivuilta
+          </TextLink>
+          , joilta löydät myös ohjeet mahdollisen saavutettavuuspalautteen jättämiseen.
+        </Typography>
+      </div>
+      <Typography variant="p1">
+        Jos olet jo aiemmin tutustunut palveluun ja täyttänyt tarvittavat esitiedot, voit jatkaa
+        asiointia suoraan sieltä, mistä jäit, tai{' '}
+        <TextLink {...args} size="p1" visited href="#palvelu">
+          palaa palvelun etusivulle
+        </TextLink>{' '}
+        nähdäksesi kaikki saatavilla olevat vaihtoehdot ja aloittaaksesi uuden asian käsittelyn
+        alusta.
+      </Typography>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Every link's size must match its surrounding paragraph's typography
+    // scale, across both regular and external links, at every body-copy size.
+    const regularLinkNames = [
+      'verkkosivuiltamme',
+      'varata ajan neuvontapalveluun',
+      'usein kysytyt kysymykset',
+    ];
+    for (const name of regularLinkNames) {
+      const link = canvas.getByRole('link', { name });
+      const paragraph = link.closest('p');
+      await expect(paragraph).not.toBeNull();
+      await expect(getComputedStyle(link).fontSize).toBe(getComputedStyle(paragraph!).fontSize);
+    }
+
+    const externalLinkNames = [
+      'Tampere.fi-sivustolla',
+      'asiointipalvelusta',
+      'Tampere.fi-sivuilta',
+    ];
+    for (const name of externalLinkNames) {
+      const link = canvas.getByRole('link', { name });
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link.querySelector('svg')).not.toBeNull();
+      const paragraph = link.closest('p');
+      await expect(paragraph).not.toBeNull();
+      await expect(getComputedStyle(link).fontSize).toBe(getComputedStyle(paragraph!).fontSize);
+    }
+
+    const visitedLink = canvas.getByRole('link', { name: 'palaa palvelun etusivulle' });
+    // states.visited = brand.blue.mainExtraDark = #172f5a (darkened from
+    // Figma's #5f93c6 to meet WCAG AA contrast — see theme.ts)
+    await expect(getComputedStyle(visitedLink).color).toBe('rgb(23, 47, 90)');
   },
 };
 

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -86,6 +86,26 @@ export const OpenExternal: Story = {
   },
 };
 
+export const MergesRelWithOpenExternal: Story = {
+  // `openExternal` adds `noopener noreferrer` without discarding a caller's `rel`.
+  args: { openExternal: true, rel: 'nofollow' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /^Tekstilinkki/ });
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer nofollow');
+  },
+};
+
+export const ForwardsAnchorProps: Story = {
+  // Arbitrary anchor props (not just href/size/visited/openExternal) reach the DOM.
+  args: { 'aria-label': 'Custom label', id: 'custom-link' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Custom label' });
+    await expect(link).toHaveAttribute('id', 'custom-link');
+  },
+};
+
 const ALL_SIZES = [
   'h1',
   'h2',
@@ -112,12 +132,15 @@ export const Sizes: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const fontSizes: number[] = [];
+    const iconWidths: number[] = [];
     for (const size of ALL_SIZES) {
       const link = canvas.getByRole('link', {
         name: new RegExp(`^${size.toUpperCase()} sized link`),
       });
-      await expect(link.querySelector('svg')).not.toBeNull();
+      const icon = link.querySelector('svg');
+      await expect(icon).not.toBeNull();
       fontSizes.push(parseFloat(getComputedStyle(link).fontSize));
+      iconWidths.push(parseFloat(getComputedStyle(icon!).width));
     }
     // Every size must render no larger than the previous one — proves `size`
     // drives the typography token across the whole scale (not just the two
@@ -126,11 +149,20 @@ export const Sizes: Story = {
     for (let i = 1; i < fontSizes.length; i++) {
       await expect(fontSizes[i]).toBeLessThanOrEqual(fontSizes[i - 1]);
     }
+    // Icon is em-sized, so it must scale down alongside the text (this was
+    // the bug fixed in 0ab5efa — the icon used to stay a fixed pixel size).
+    for (let i = 1; i < iconWidths.length; i++) {
+      await expect(iconWidths[i]).toBeLessThanOrEqual(iconWidths[i - 1]);
+    }
   },
 };
 
 export const WithCustomLink: Story = {
   tags: docExample,
+  // renderLink fully replaces the rendered `<a>`, so `href`/`children` (both
+  // set by meta.args for the other doc examples) would otherwise trip
+  // TextLink's own dev warnings about ignored props — see WarnsWhen* below.
+  args: { href: undefined, children: undefined },
   render: (args) => (
     <TextLink
       {...args}
@@ -294,12 +326,19 @@ export const WarnsWithoutDestination: Story = {
   // Neither `href` nor `renderLink` given — the link has no destination.
   args: { href: undefined },
   beforeEach: captureConsoleErrors,
-  play: async () => {
+  play: async ({ canvasElement }) => {
     await waitFor(() =>
       expect(
         capturedConsoleErrors.some((m) => /provide either `href` or `renderLink`/.test(m))
       ).toBe(true)
     );
+    // Document the actual (broken) resulting DOM: an `<a>` with no `href`
+    // has no accessible "link" role and isn't keyboard-focusable.
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('link')).toBeNull();
+    const anchor = canvasElement.querySelector('a');
+    await expect(anchor).not.toBeNull();
+    await expect(anchor).not.toHaveAttribute('href');
   },
 };
 
@@ -308,6 +347,7 @@ export const WarnsWhenHrefIgnoredByRenderLink: Story = {
   render: (args) => (
     <TextLink
       {...args}
+      children={undefined}
       renderLink={(className) => (
         <a href="#custom" className={className}>
           Custom link component
@@ -329,6 +369,36 @@ export const WarnsWhenOpenExternalIgnoredByRenderLink: Story = {
   render: (args) => (
     <TextLink
       {...args}
+      href={undefined}
+      children={undefined}
+      renderLink={(className) => (
+        <a href="#custom" className={className}>
+          Custom link component
+        </a>
+      )}
+    />
+  ),
+  beforeEach: captureConsoleErrors,
+  play: async ({ canvasElement }) => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`openExternal` has no effect/.test(m))).toBe(true)
+    );
+    // The custom element really doesn't get target/rel/icon applied to it.
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Custom link component' });
+    await expect(link).not.toHaveAttribute('target');
+    await expect(link).not.toHaveAttribute('rel');
+    await expect(link.querySelector('svg')).toBeNull();
+  },
+};
+
+export const WarnsWhenExtrasIgnoredByRenderLink: Story = {
+  // `children` (and other spread anchor props) given alongside `renderLink`
+  // — silently dropped, since renderLink fully replaces the rendered `<a>`.
+  render: (args) => (
+    <TextLink
+      {...args}
+      href={undefined}
       renderLink={(className) => (
         <a href="#custom" className={className}>
           Custom link component
@@ -339,7 +409,18 @@ export const WarnsWhenOpenExternalIgnoredByRenderLink: Story = {
   beforeEach: captureConsoleErrors,
   play: async () => {
     await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /`openExternal` has no effect/.test(m))).toBe(true)
+      expect(capturedConsoleErrors.some((m) => /other anchor props are ignored/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenTargetIgnoredByOpenExternal: Story = {
+  // `openExternal` + explicit `target` given — `openExternal` always wins.
+  args: { openExternal: true, target: '_self' },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`target` is ignored/.test(m))).toBe(true)
     );
   },
 };

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
+import { TextLink } from './TextLink';
+
+const meta = {
+  component: TextLink,
+  // Most TextLink stories are browser test specs (they have a `play` fn), not
+  // documentation. Default every story to test-only: still run by the vitest
+  // addon (the `test` tag is untouched) but hidden from the sidebar (`!dev`) and
+  // the autodocs page (`!autodocs`) so the docs stay a small, curated set. The
+  // documentation examples below opt back in with `tags: docExample`.
+  tags: ['!dev', '!autodocs'],
+  argTypes: {
+    href: { control: 'text', description: 'Link destination URL' },
+    size: {
+      control: { type: 'select' },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'subheader', 'p1', 'p2', 'caption'],
+      description: 'Typography scale the link renders at',
+    },
+    visited: { control: 'boolean', description: 'Whether the link has been visited' },
+    openExternal: {
+      control: 'boolean',
+      description: 'Shows an external-link icon and opens in a new tab',
+    },
+    children: { control: 'text', description: 'Link text' },
+  },
+  args: {
+    href: '#',
+    children: 'Tekstilinkki',
+    size: 'p1',
+    visited: false,
+    openExternal: false,
+  },
+} satisfies Meta<typeof TextLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Re-adds the visibility tags that `meta` strips, marking a story as a
+// documentation example shown in both the sidebar and the autodocs page.
+const docExample = ['dev', 'autodocs'];
+
+// ── Documentation examples (visible in sidebar + autodocs) ───────────────────
+// These cover every distinct visual state; the interactive behaviours (focus,
+// keyboard nav) are discoverable by interacting with them, so the
+// behavioural/a11y stories further down stay test-only to keep docs focused.
+
+export const Default: Story = {
+  tags: docExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
+    const style = getComputedStyle(link);
+    // Figma "Default, unvisited" = text/link = #29549a = states.default
+    await expect(style.color).toBe('rgb(41, 84, 154)');
+    await expect(style.textDecorationLine).toBe('underline');
+  },
+};
+
+export const Visited: Story = {
+  tags: docExample,
+  args: { visited: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
+    const style = getComputedStyle(link);
+    // Figma "Default, visited" = text/link-visited = #5f93c6 = states.visited
+    await expect(style.color).toBe('rgb(95, 147, 198)');
+    await expect(style.textDecorationLine).toBe('underline');
+  },
+};
+
+export const OpenExternal: Story = {
+  tags: docExample,
+  args: { openExternal: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(link.querySelector('svg')).not.toBeNull();
+  },
+};
+
+export const Sizes: Story = {
+  tags: docExample,
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'flex-start' }}>
+      <TextLink {...args} size="h1" href="#h1">
+        Heading-sized link
+      </TextLink>
+      <TextLink {...args} size="caption" href="#caption">
+        Caption-sized link
+      </TextLink>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const h1Link = canvas.getByRole('link', { name: 'Heading-sized link' });
+    const captionLink = canvas.getByRole('link', { name: 'Caption-sized link' });
+    const h1Size = parseFloat(getComputedStyle(h1Link).fontSize);
+    const captionSize = parseFloat(getComputedStyle(captionLink).fontSize);
+    // h1 must render larger than caption at the same breakpoint — proves
+    // `size` actually drives the typography token rather than a fixed value.
+    await expect(h1Size).toBeGreaterThan(captionSize);
+  },
+};
+
+export const WithCustomLink: Story = {
+  tags: docExample,
+  render: (args) => (
+    <TextLink
+      {...args}
+      renderLink={(className) => (
+        <a href="#custom" className={className}>
+          Custom link component
+        </a>
+      )}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Custom link component' });
+    await expect(link).toHaveAttribute('href', '#custom');
+    const style = getComputedStyle(link);
+    // The renderLink escape hatch still receives TextLink's link styling.
+    await expect(style.color).toBe('rgb(41, 84, 154)');
+  },
+};
+
+// ── Test-only specs (hidden from sidebar/autodocs, still run as browser tests) ─
+
+export const FocusVisible: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
+    (link as HTMLAnchorElement).focus();
+    const style = getComputedStyle(link);
+    // Figma "Focus, unvisited" = primary-states/focus = #29549a = states.focus
+    await expect(style.color).toBe('rgb(41, 84, 154)');
+    await expect(style.textDecorationLine).toBe('underline');
+    await expect(style.outlineStyle).toBe('solid');
+  },
+};

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within } from '@storybook/testing-library';
+import { within, waitFor } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Typography } from '../Typography';
 import { TextLink, type TextLinkSize } from './TextLink';
@@ -56,6 +56,7 @@ export const Default: Story = {
     // Figma "Default, unvisited" = text/link = #29549a = states.default
     await expect(style.color).toBe('rgb(41, 84, 154)');
     await expect(style.textDecorationLine).toBe('underline');
+    await expect(link).toHaveAttribute('href', '#');
   },
 };
 
@@ -66,8 +67,7 @@ export const Visited: Story = {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
     const style = getComputedStyle(link);
-    // states.visited = brand.blue.mainExtraDark = #172f5a (darkened from
-    // Figma's #5f93c6 to meet WCAG AA contrast — see theme.ts)
+    // states.visited — see theme.ts for the WCAG AA contrast rationale.
     await expect(style.color).toBe('rgb(23, 47, 90)');
     await expect(style.textDecorationLine).toBe('underline');
   },
@@ -78,10 +78,11 @@ export const OpenExternal: Story = {
   args: { openExternal: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const link = canvas.getByRole('link', { name: 'Tekstilinkki' });
+    const link = canvas.getByRole('link', { name: /^Tekstilinkki/ });
     await expect(link).toHaveAttribute('target', '_blank');
     await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     await expect(link.querySelector('svg')).not.toBeNull();
+    await expect(link).toHaveAccessibleName(/avautuu uuteen välilehteen/);
   },
 };
 
@@ -112,7 +113,9 @@ export const Sizes: Story = {
     const canvas = within(canvasElement);
     const fontSizes: number[] = [];
     for (const size of ALL_SIZES) {
-      const link = canvas.getByRole('link', { name: `${size.toUpperCase()} sized link` });
+      const link = canvas.getByRole('link', {
+        name: new RegExp(`^${size.toUpperCase()} sized link`),
+      });
       await expect(link.querySelector('svg')).not.toBeNull();
       fontSizes.push(parseFloat(getComputedStyle(link).fontSize));
     }
@@ -242,7 +245,7 @@ export const InParagraph: Story = {
       'Tampere.fi-sivuilta',
     ];
     for (const name of externalLinkNames) {
-      const link = canvas.getByRole('link', { name });
+      const link = canvas.getByRole('link', { name: new RegExp(`^${name}`) });
       await expect(link).toHaveAttribute('target', '_blank');
       await expect(link.querySelector('svg')).not.toBeNull();
       const paragraph = link.closest('p');
@@ -251,8 +254,7 @@ export const InParagraph: Story = {
     }
 
     const visitedLink = canvas.getByRole('link', { name: 'palaa palvelun etusivulle' });
-    // states.visited = brand.blue.mainExtraDark = #172f5a (darkened from
-    // Figma's #5f93c6 to meet WCAG AA contrast — see theme.ts)
+    // states.visited — see theme.ts for the WCAG AA contrast rationale.
     await expect(getComputedStyle(visitedLink).color).toBe('rgb(23, 47, 90)');
   },
 };
@@ -269,5 +271,75 @@ export const FocusVisible: Story = {
     await expect(style.color).toBe('rgb(41, 84, 154)');
     await expect(style.textDecorationLine).toBe('underline');
     await expect(style.outlineStyle).toBe('solid');
+  },
+};
+
+// ── Dev-warning tests (verifies the console.error guards in TextLink.tsx) ────
+
+// Captures console.error calls for the dev-warning tests below.
+let capturedConsoleErrors: string[] = [];
+
+const captureConsoleErrors = () => {
+  capturedConsoleErrors = [];
+  const original = console.error;
+  console.error = (...messageArgs: unknown[]) => {
+    capturedConsoleErrors.push(String(messageArgs[0]));
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+export const WarnsWithoutDestination: Story = {
+  // Neither `href` nor `renderLink` given — the link has no destination.
+  args: { href: undefined },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(
+        capturedConsoleErrors.some((m) => /provide either `href` or `renderLink`/.test(m))
+      ).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenHrefIgnoredByRenderLink: Story = {
+  // Both `href` and `renderLink` given — `href` is silently dropped.
+  render: (args) => (
+    <TextLink
+      {...args}
+      renderLink={(className) => (
+        <a href="#custom" className={className}>
+          Custom link component
+        </a>
+      )}
+    />
+  ),
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`href` is ignored/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenOpenExternalIgnoredByRenderLink: Story = {
+  // `openExternal` + `renderLink` given — target/rel/icon are silently dropped.
+  args: { openExternal: true },
+  render: (args) => (
+    <TextLink
+      {...args}
+      renderLink={(className) => (
+        <a href="#custom" className={className}>
+          Custom link component
+        </a>
+      )}
+    />
+  ),
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`openExternal` has no effect/.test(m))).toBe(true)
+    );
   },
 };

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -18,11 +18,13 @@ export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   visited?: boolean;
   openExternal?: boolean;
   className?: string;
+  /** Visually-hidden suffix announced when `openExternal` is set. */
+  openExternalLabel?: string;
   /**
    * Escape hatch for router-integrated links (e.g. React Router's `Link`).
    * When provided, it fully replaces the rendered `<a>` — `href`,
-   * `openExternal` (and the target/rel/icon it would otherwise add), and any
-   * other anchor props are NOT applied. Add them to the custom element
+   * `openExternal` (and the target/rel/icon it would otherwise add), `children`,
+   * and any other anchor props are NOT applied. Add them to the custom element
    * yourself if you need them.
    */
   renderLink?: (className: string) => ReactElement;
@@ -33,6 +35,7 @@ export function TextLink({
   size = 'p1',
   visited = false,
   openExternal = false,
+  openExternalLabel = ' (avautuu uuteen välilehteen)',
   children,
   className,
   renderLink,
@@ -44,25 +47,35 @@ export function TextLink({
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') return;
+
     if (!href && !renderLink) {
       console.error(
         'TextLink: provide either `href` or `renderLink` so the link has a destination.'
       );
     }
-    if (href && renderLink) {
-      console.error(
-        'TextLink: `href` is ignored when `renderLink` is provided — remove one of them.'
-      );
-    }
-  }, [href, renderLink]);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'production' && openExternal && renderLink) {
+    if (renderLink) {
+      if (href) {
+        console.error(
+          'TextLink: `href` is ignored when `renderLink` is provided — remove one of them.'
+        );
+      }
+      if (openExternal) {
+        console.error(
+          'TextLink: `openExternal` has no effect when `renderLink` is provided — target, rel, and the external-link icon are only applied to the default `<a>` render. Add them to your custom link element instead.'
+        );
+      }
+      if (children != null || target || rel || Object.keys(props).length > 0) {
+        console.error(
+          'TextLink: `children` and other anchor props are ignored when `renderLink` is provided — add them to your custom link element instead.'
+        );
+      }
+    } else if (openExternal && target) {
       console.error(
-        'TextLink: `openExternal` has no effect when `renderLink` is provided — target, rel, and the external-link icon are only applied to the default `<a>` render. Add them to your custom link element instead.'
+        'TextLink: `target` is ignored when `openExternal` is set — openExternal always opens the link in a new tab.'
       );
     }
-  }, [openExternal, renderLink]);
+  }, [href, renderLink, openExternal, children, target, rel, props]);
 
   if (renderLink) {
     return renderLink(classes);
@@ -73,7 +86,7 @@ export function TextLink({
       href={href}
       className={classes}
       target={openExternal ? '_blank' : target}
-      rel={openExternal ? 'noopener noreferrer' : rel}
+      rel={openExternal ? cx('noopener noreferrer', rel) : rel}
       {...props}
     >
       {children}
@@ -83,7 +96,7 @@ export function TextLink({
               line, separate from the last word of link text. */}
           {'⁠'}
           <OpenExternalLinkIcon aria-hidden className={externalIcon} />
-          <span className={visuallyHidden}> (avautuu uuteen välilehteen)</span>
+          <span className={visuallyHidden}>{openExternalLabel}</span>
         </>
       )}
     </a>

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -1,0 +1,45 @@
+import type { AnchorHTMLAttributes, ReactElement } from 'react';
+import cx from 'clsx';
+import { OpenExternalLinkIcon } from '../../icons';
+import { size as sizeStyles, link, externalIcon } from './TextLink.css';
+
+export type TextLinkSize = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'subheader' | 'p1' | 'p2' | 'caption';
+
+export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string;
+  size?: TextLinkSize;
+  visited?: boolean;
+  openExternal?: boolean;
+  className?: string;
+  renderLink?: (className: string) => ReactElement;
+}
+
+export function TextLink({
+  href,
+  size = 'p1',
+  visited = false,
+  openExternal = false,
+  children,
+  className,
+  renderLink,
+  ...props
+}: TextLinkProps) {
+  const classes = cx(sizeStyles[size], visited ? link.visited : link.unvisited, className);
+
+  if (renderLink) {
+    return renderLink(classes);
+  }
+
+  return (
+    <a
+      href={href}
+      className={classes}
+      target={openExternal ? '_blank' : undefined}
+      rel={openExternal ? 'noopener noreferrer' : undefined}
+      {...props}
+    >
+      {children}
+      {openExternal && <OpenExternalLinkIcon aria-hidden className={externalIcon} />}
+    </a>
+  );
+}

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -1,9 +1,16 @@
 import type { AnchorHTMLAttributes, ReactElement } from 'react';
+import { useEffect } from 'react';
 import cx from 'clsx';
 import { OpenExternalLinkIcon } from '../../icons';
-import { size as sizeStyles, link, externalIcon } from './TextLink.css';
+import {
+  size as sizeStyles,
+  link,
+  externalIcon,
+  visuallyHidden,
+  type TextLinkSize,
+} from './TextLink.css';
 
-export type TextLinkSize = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'subheader' | 'p1' | 'p2' | 'caption';
+export type { TextLinkSize };
 
 export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href?: string;
@@ -11,6 +18,13 @@ export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   visited?: boolean;
   openExternal?: boolean;
   className?: string;
+  /**
+   * Escape hatch for router-integrated links (e.g. React Router's `Link`).
+   * When provided, it fully replaces the rendered `<a>` — `href`,
+   * `openExternal` (and the target/rel/icon it would otherwise add), and any
+   * other anchor props are NOT applied. Add them to the custom element
+   * yourself if you need them.
+   */
   renderLink?: (className: string) => ReactElement;
 }
 
@@ -22,9 +36,33 @@ export function TextLink({
   children,
   className,
   renderLink,
+  target,
+  rel,
   ...props
 }: TextLinkProps) {
   const classes = cx(sizeStyles[size], visited ? link.visited : link.unvisited, className);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    if (!href && !renderLink) {
+      console.error(
+        'TextLink: provide either `href` or `renderLink` so the link has a destination.'
+      );
+    }
+    if (href && renderLink) {
+      console.error(
+        'TextLink: `href` is ignored when `renderLink` is provided — remove one of them.'
+      );
+    }
+  }, [href, renderLink]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && openExternal && renderLink) {
+      console.error(
+        'TextLink: `openExternal` has no effect when `renderLink` is provided — target, rel, and the external-link icon are only applied to the default `<a>` render. Add them to your custom link element instead.'
+      );
+    }
+  }, [openExternal, renderLink]);
 
   if (renderLink) {
     return renderLink(classes);
@@ -34,12 +72,20 @@ export function TextLink({
     <a
       href={href}
       className={classes}
-      target={openExternal ? '_blank' : undefined}
-      rel={openExternal ? 'noopener noreferrer' : undefined}
+      target={openExternal ? '_blank' : target}
+      rel={openExternal ? 'noopener noreferrer' : rel}
       {...props}
     >
       {children}
-      {openExternal && <OpenExternalLinkIcon aria-hidden className={externalIcon} />}
+      {openExternal && (
+        <>
+          {/* U+2060 word joiner: keeps the icon from wrapping onto its own
+              line, separate from the last word of link text. */}
+          {'⁠'}
+          <OpenExternalLinkIcon aria-hidden className={externalIcon} />
+          <span className={visuallyHidden}> (avautuu uuteen välilehteen)</span>
+        </>
+      )}
     </a>
   );
 }

--- a/src/components/TextLink/index.ts
+++ b/src/components/TextLink/index.ts
@@ -1,0 +1,1 @@
+export * from './TextLink';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -30,3 +30,4 @@ export { TextField } from './TextField/TextField';
 export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider';
 export { Typography } from './Typography/Typography';
 export { DateField, type DateFieldProps, type DateFieldClassNames } from './DateField';
+export { TextLink, type TextLinkProps, type TextLinkSize } from './TextLink/TextLink';

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -155,8 +155,12 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1.25rem * var(--mantine-scale))",
@@ -475,8 +479,12 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1.125rem * var(--mantine-scale))",
@@ -795,8 +803,12 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -1529,8 +1541,12 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "link": {
+        "hoverUnderlineThickness": "0.125em",
+        "iconSize": "1em",
         "iconSpacing": "0.25em",
+        "iconVerticalOffset": "-0.2em",
         "spacing": "calc(0.25rem * var(--mantine-scale))",
+        "underlineThickness": "0.1em",
       },
       "list": {
         "fontSize": "calc(1.125rem * var(--mantine-scale))",
@@ -1850,8 +1866,12 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1.25rem * var(--mantine-scale))",
@@ -2170,8 +2190,12 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -2490,8 +2514,12 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "hoverUnderlineThickness": "0.125em",
+      "iconSize": "1em",
       "iconSpacing": "0.25em",
+      "iconVerticalOffset": "-0.2em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "underlineThickness": "0.1em",
     },
     "list": {
       "fontSize": "calc(1.25rem * var(--mantine-scale))",

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -155,6 +155,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "list": {
@@ -306,7 +307,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {
@@ -474,6 +475,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
     },
     "list": {
@@ -625,7 +627,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {
@@ -793,6 +795,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
     },
     "list": {
@@ -944,7 +947,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {
@@ -1526,6 +1529,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "link": {
+        "iconSpacing": "0.25em",
         "spacing": "calc(0.25rem * var(--mantine-scale))",
       },
       "list": {
@@ -1677,7 +1681,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       "error": "#ae1e20",
       "focus": "#29549a",
       "hover": "#1d3a6c",
-      "visited": "#5f93c6",
+      "visited": "#172f5a",
     },
     "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
     "text": {
@@ -1846,6 +1850,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "list": {
@@ -1997,7 +2002,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {
@@ -2165,6 +2170,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.25rem * var(--mantine-scale))",
     },
     "list": {
@@ -2316,7 +2322,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {
@@ -2484,6 +2490,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "link": {
+      "iconSpacing": "0.25em",
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "list": {
@@ -2635,7 +2642,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     "error": "#ae1e20",
     "focus": "#29549a",
     "hover": "#1d3a6c",
-    "visited": "#5f93c6",
+    "visited": "#172f5a",
   },
   "strokeWeight": "calc(0.125rem * var(--mantine-scale))",
   "text": {

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -303,6 +303,20 @@ export function getTheme(bp: BreakpointKey) {
       // TextLink's `size` spans the full Typography scale (h1…caption), so
       // the icon gap must scale with whatever size is in use, not just bp.
       iconSpacing: '0.25em',
+      // Same reasoning: em-based so the icon scales with `size` like the text
+      // around it. `iconVerticalOffset` nudges it up to visually balance
+      // against the underline (see the usage site for why).
+      iconSize: '1em',
+      iconVerticalOffset: '-0.2em',
+      // Same reasoning as iconSpacing: em-based, and set explicitly rather
+      // than left at the browser's auto/from-font default, because that
+      // default scales with font *weight* as well as size — on the bold
+      // h1…h5 styles it's already fairly thick, which made the hover/focus
+      // increase below barely register. Fixing the rest-state thickness
+      // keeps the hover/focus increase visually consistent across every
+      // size and weight in the scale.
+      underlineThickness: '0.1em',
+      hoverUnderlineThickness: '0.125em',
     },
     list: {
       fontSize: bpTokens.typography.size.p1,

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -309,12 +309,12 @@ export function getTheme(bp: BreakpointKey) {
       iconSize: '1em',
       iconVerticalOffset: '-0.2em',
       // Same reasoning as iconSpacing: em-based, and set explicitly rather
-      // than left at the browser's auto/from-font default, because that
-      // default scales with font *weight* as well as size — on the bold
-      // h1…h5 styles it's already fairly thick, which made the hover/focus
-      // increase below barely register. Fixing the rest-state thickness
-      // keeps the hover/focus increase visually consistent across every
-      // size and weight in the scale.
+      // than left at the browser's auto/from-font default — empirically,
+      // the auto thickness appeared heavier on the bold h1…h5 weights than
+      // on p1/p2/caption, which made the hover/focus increase below barely
+      // register. Fixing the rest-state thickness keeps the hover/focus
+      // increase visually consistent across every size and weight in the
+      // scale.
       underlineThickness: '0.1em',
       hoverUnderlineThickness: '0.125em',
     },

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -27,7 +27,10 @@ const states = {
   active: brand.blue.mainLight,
   disabled: colors.neutral['300'],
   error: colors.red['300'],
-  visited: brand.blue.mainLight,
+  // Figma's "text/link-visited" (brand.blue.mainLight, #5f93c6) only reaches
+  // 3.24:1 against white — fails WCAG AA (4.5:1) for normal text. Uses the
+  // darkest blue brand stop instead, which clears AA with margin to spare.
+  visited: brand.blue.mainExtraDark,
 } as const;
 
 // Figma's "Input-states" variable collection — distinct from "Primary-states"
@@ -294,7 +297,13 @@ export function getTheme(bp: BreakpointKey) {
         disabled: colors.neutral['50'],
       },
     },
-    link: { spacing: bpTokens.spacing.xxs },
+    link: {
+      spacing: bpTokens.spacing.xxs,
+      // em-based (not breakpoint-driven, unlike `spacing` above) because
+      // TextLink's `size` spans the full Typography scale (h1…caption), so
+      // the icon gap must scale with whatever size is in use, not just bp.
+      iconSpacing: '0.25em',
+    },
     list: {
       fontSize: bpTokens.typography.size.p1,
       lineHeight: bpTokens.components.list.lineHeight,


### PR DESCRIPTION
## Summary
- Adds `TextLink`, a polymorphic link component (bare `<a>` + `renderLink` render-prop, matching `NavigationLink`'s convention) with a `size` prop spanning the full Typography scale (`h1…caption`), `visited`/`openExternal` states, and an external-link icon.
- Icon-to-text gap is tokenized as an `em`-based value (`components.link.iconSpacing`) so it scales with `size` rather than only the breakpoint.
- Fixes a latent WCAG AA contrast failure in the Figma-sourced `states.visited` token (was 3.24:1 against white; now 13.2:1 via `brand.blue.mainExtraDark`), found via axe in Storybook.

## Test plan
- [x] `npm test` — 187/187 passing
- [x] `tsc --noEmit`, `npm run eslint`, `npm run prettier:check` all clean
- [x] Verified in Storybook via Playwright: `Sizes`, `Visited`, `InParagraph` Interactions panels green; `Visited` story's Accessibility panel shows 0 violations / 4 passes (previously 1 serious contrast violation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)