### PR TITLE
feat(#51): add Chip component

### DIFF
--- a/src/components/Chip/Chip.css.ts
+++ b/src/components/Chip/Chip.css.ts
@@ -110,12 +110,15 @@ export const filterLabel = style({
     '&:not([data-disabled]):active': { border: `${strokeWeight} solid ${states.active}` },
     '&:not([data-checked]):not([data-disabled]):active': { color: states.active },
     // Disabled differs by checked state in Figma: checked+disabled is a
-    // flat `states.disabled` fill with no border at all (not a gray border
-    // over the leftover selected-tint background); unchecked+disabled
+    // flat `states.disabled` fill with no *visible* border (not a gray
+    // border over the leftover selected-tint background); unchecked+disabled
     // keeps the white background with just a gray border, same as every
-    // other unchecked state.
+    // other unchecked state. The border here is transparent rather than
+    // `none` — `box-sizing: border-box` means dropping the border entirely
+    // shrinks the pill by 2 × the border width, making a selected chip
+    // visibly narrower the moment it becomes disabled.
     '&[data-checked][data-disabled]': {
-      border: 'none',
+      border: `${strokeWeight} solid transparent`,
       backgroundColor: states.disabled,
       color: text.disabled,
     },

--- a/src/components/Chip/Chip.css.ts
+++ b/src/components/Chip/Chip.css.ts
@@ -47,6 +47,17 @@ export const filterLabel = style({
       backgroundColor: components.item.background.selected.default,
       color: text.primary,
     },
+    // Neither `:hover` nor `:active` is asserted in tests — synthetic
+    // pointer/mouse events (userEvent.pointer, fireEvent.mouseDown) don't
+    // produce genuine browser hover/active state in this repo's
+    // Playwright/Chromium test environment (verified: both were tried and
+    // neither changes the computed style). Documented gap, same as
+    // TextLink/LabeledIconButton's `:hover`.
+    '&:not([data-disabled]):hover': { border: `${strokeWeight} solid ${states.hover}` },
+    '&[data-checked]:not([data-disabled]):hover': {
+      backgroundColor: components.item.background.selected.hover,
+    },
+    '&:not([data-disabled]):active': { border: `${strokeWeight} solid ${states.active}` },
     '&[data-disabled]': {
       border: `${strokeWeight} solid ${states.disabled}`,
       color: text.disabled,

--- a/src/components/Chip/Chip.css.ts
+++ b/src/components/Chip/Chip.css.ts
@@ -13,8 +13,11 @@ const labelFont = {
 
 // Mantine's Chip sets total height via `--chip-size` directly (no vertical
 // padding of its own) and font-size via `--chip-fz` — these two, plus
-// `--chip-radius`/`--chip-padding`/`--chip-spacing`, apply unconditionally on
-// the base label rule. `--chip-bd`/`--chip-bg`/`--chip-color` do NOT — Mantine
+// `--chip-radius`/`--chip-padding`, apply unconditionally on the base label
+// rule (`--chip-spacing` instead only feeds Mantine's built-in `iconWrapper`
+// child's width calc, not the label itself — set below so that calc lands on
+// our own spacing token rather than Mantine's default).
+// `--chip-bd`/`--chip-bg`/`--chip-color` do NOT apply unconditionally — Mantine
 // only reads those under an explicit `variant` (outline/filled), which we
 // don't use, so border/background/text color are set directly below via
 // `filterLabel`'s own `data-checked`/`data-disabled` selectors instead.
@@ -35,6 +38,11 @@ export const filterRoot = style({
     '--chip-padding': components.chip.padding.horizontal,
     '--chip-checked-padding': components.chip.padding.horizontal,
     '--chip-spacing': components.chip.spacing,
+    // Without this, Mantine's `iconWrapper` (the checkmark/selectedIcon slot)
+    // still derives its `max-width` from Mantine's own unset 12px default,
+    // clipping our 18px icon (`chipIcon`'s width/height override alone isn't
+    // enough — `max-width` is a separate property Mantine sets from this var).
+    '--chip-icon-size': components.chip.iconSize,
   },
 });
 
@@ -59,9 +67,14 @@ export const filterLabel = style({
   gap: components.chip.spacing,
   selectors: {
     // Both attribute selectors below add a class + attribute (0,2,0), which
-    // beats Mantine's own plain `.label` base rule (0,1,0) regardless of
-    // stylesheet order — Mantine wraps its own attribute selectors in
-    // `:where()` specifically so consumer overrides like this always win.
+    // reliably beats Mantine's own plain, unconditional `.label` base rule
+    // (0,1,0) regardless of stylesheet order. The `&[data-checked]` override
+    // specifically is a different case: Mantine's own checked-state rule is
+    // `:not([data-disabled]):where([data-checked])`, which computes to the
+    // same (0,2,0) — a genuine specificity tie, currently broken in our favor
+    // by import order (Mantine's base CSS is imported before this component's
+    // Vanilla Extract styles). That ordering is the fragile part; if it ever
+    // changes, this checked-state override could silently stop winning.
     //
     // Unchecked ("Outlined" in Figma) tracks `states.*` for BOTH border and
     // text/icon color together — Figma's Outlined variant always uses the
@@ -86,6 +99,11 @@ export const filterLabel = style({
     // TextLink/LabeledIconButton's `:hover`.
     '&:not([data-disabled]):hover': { border: `${strokeWeight} solid ${states.hover}` },
     '&:not([data-checked]):not([data-disabled]):hover': { color: states.hover },
+    // `selected.hover` and `selected.default` currently resolve to the same
+    // raw value, so this is a visual no-op today — kept distinct (not
+    // collapsed to `selected.default`) because the two tokens mean different
+    // things and may diverge, same as `tagFill` vs `background.disabled` in
+    // theme.ts.
     '&[data-checked]:not([data-disabled]):hover': {
       backgroundColor: components.item.background.selected.hover,
     },
@@ -135,10 +153,12 @@ export const tagDismissIcon = style({
 // regardless of that icon component's own default width.
 //
 // `inline-flex`/`verticalAlign` (not block `flex`) so this stays correct
-// even outside a flex parent: it's always a direct flex child in practice
-// (Mantine's own flex `label` when checked, `filterIconRow` below when
-// showing a leading icon), but a block-level flex box would break out of
-// plain inline flow and float above the text if that ever weren't true.
+// across all three usage contexts: a genuine flex child of Mantine's own
+// flex `label` (checked case), a genuine flex child of `tagRoot`'s flex row
+// (tag-role leading icon), and — unlike the other two — a child of
+// `filterIconOverlay` below, which is absolutely positioned and therefore
+// not in flex/inline flow at all, making `verticalAlign` inert there but
+// harmless (the overlay's own `top`/`transform` handle its positioning).
 export const chipIcon = style({
   width: components.chip.iconSize,
   height: components.chip.iconSize,

--- a/src/components/Chip/Chip.css.ts
+++ b/src/components/Chip/Chip.css.ts
@@ -1,8 +1,8 @@
-import { style } from '@vanilla-extract/css';
+import { style, globalStyle } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 
 const {
-  theme: { components, states, inputStates, text, focusRing, strokeWeight },
+  theme: { components, states, text, focusRing, strokeWeight, background },
 } = vars;
 
 const labelFont = {
@@ -18,29 +18,60 @@ const labelFont = {
 // only reads those under an explicit `variant` (outline/filled), which we
 // don't use, so border/background/text color are set directly below via
 // `filterLabel`'s own `data-checked`/`data-disabled` selectors instead.
+//
+// `--chip-checked-padding` is a separate var Mantine swaps in for
+// `padding-inline` under `[data-checked]` (its own default: a smaller
+// sm-tier 10px, meant for its own default `icon`+built-in checkmark
+// layout) — without setting it too, the checked state silently falls
+// back to that unrelated Mantine default instead of our own horizontal
+// padding, producing a visibly different left/right padding than every
+// other (unchecked) chip. Figma's reference frame uses the same padding
+// regardless of checked state, so this matches `--chip-padding` exactly.
 export const filterRoot = style({
   vars: {
     '--chip-size': components.chip.height,
     '--chip-fz': components.chip.label.fontSize,
     '--chip-radius': components.chip.cornerRadius,
     '--chip-padding': components.chip.padding.horizontal,
+    '--chip-checked-padding': components.chip.padding.horizontal,
     '--chip-spacing': components.chip.spacing,
   },
 });
 
 export const filterInput = style({});
 
+// Wraps the whole filter-role chip so the leading-icon overlay below (a
+// sibling of MantineChip, not nested inside its label) has a positioning
+// context. A <span>, not <div>, so `.closest('div')`-based test queries
+// (which walk up to Mantine's own root div) are unaffected.
+export const filterWrapper = style({
+  position: 'relative',
+  display: 'inline-flex',
+});
+
 export const filterLabel = style({
   ...labelFont,
+  // Spaces the built-in checkmark/selectedIcon from the label text — only
+  // takes effect when checked, since that's the one state where Mantine
+  // renders the icon wrapper and the text span as direct flex children of
+  // this element. The leading-icon (unchecked) case reserves its own room
+  // via `filterLabelWithLeadingIcon`'s `paddingLeft` instead (see below).
+  gap: components.chip.spacing,
   selectors: {
     // Both attribute selectors below add a class + attribute (0,2,0), which
     // beats Mantine's own plain `.label` base rule (0,1,0) regardless of
     // stylesheet order — Mantine wraps its own attribute selectors in
     // `:where()` specifically so consumer overrides like this always win.
+    //
+    // Unchecked ("Outlined" in Figma) tracks `states.*` for BOTH border and
+    // text/icon color together — Figma's Outlined variant always uses the
+    // same primary-blue token for both, unlike the checked ("Default")
+    // variant, whose text stays a constant `text.primary` regardless of
+    // interaction state.
     '&:not([data-checked])': {
-      border: `${strokeWeight} solid ${inputStates.default}`,
-      backgroundColor: 'transparent',
-      color: text.primary,
+      border: `${strokeWeight} solid ${states.default}`,
+      backgroundColor: background.default,
+      color: states.default,
     },
     '&[data-checked]': {
       border: `${strokeWeight} solid ${states.default}`,
@@ -54,11 +85,23 @@ export const filterLabel = style({
     // neither changes the computed style). Documented gap, same as
     // TextLink/LabeledIconButton's `:hover`.
     '&:not([data-disabled]):hover': { border: `${strokeWeight} solid ${states.hover}` },
+    '&:not([data-checked]):not([data-disabled]):hover': { color: states.hover },
     '&[data-checked]:not([data-disabled]):hover': {
       backgroundColor: components.item.background.selected.hover,
     },
     '&:not([data-disabled]):active': { border: `${strokeWeight} solid ${states.active}` },
-    '&[data-disabled]': {
+    '&:not([data-checked]):not([data-disabled]):active': { color: states.active },
+    // Disabled differs by checked state in Figma: checked+disabled is a
+    // flat `states.disabled` fill with no border at all (not a gray border
+    // over the leftover selected-tint background); unchecked+disabled
+    // keeps the white background with just a gray border, same as every
+    // other unchecked state.
+    '&[data-checked][data-disabled]': {
+      border: 'none',
+      backgroundColor: states.disabled,
+      color: text.disabled,
+    },
+    '&:not([data-checked])[data-disabled]': {
       border: `${strokeWeight} solid ${states.disabled}`,
       color: text.disabled,
     },
@@ -84,4 +127,84 @@ export const tagRoot = style({
 
 export const tagDismissIcon = style({
   color: text.secondary,
+});
+
+// Shared fixed-size slot for both the built-in checkmark/selectedIcon
+// (via MantineChip's `iconWrapper` classNames slot) and the leading `icon`
+// prop, so whichever icon a consumer passes renders identically sized
+// regardless of that icon component's own default width.
+//
+// `inline-flex`/`verticalAlign` (not block `flex`) so this stays correct
+// even outside a flex parent: it's always a direct flex child in practice
+// (Mantine's own flex `label` when checked, `filterIconRow` below when
+// showing a leading icon), but a block-level flex box would break out of
+// plain inline flow and float above the text if that ever weren't true.
+export const chipIcon = style({
+  width: components.chip.iconSize,
+  height: components.chip.iconSize,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  verticalAlign: 'middle',
+  flexShrink: 0,
+});
+
+// CSS width/height on the root <svg> element override its own width/height
+// presentation attributes, so this normalizes any icon to fill the slot
+// above instead of rendering at its own default size and getting cropped
+// by Mantine's overflow-hidden iconWrapper (the previous behaviour, since
+// `--chip-icon-size` was never set and defaulted to Mantine's 12px `sm` tier).
+globalStyle(`${chipIcon} svg`, {
+  width: '100%',
+  height: '100%',
+});
+
+// Reserves room for `filterIconOverlay` below when showing a leading icon,
+// so the label text doesn't render underneath it. The *value* fully
+// replaces `--chip-padding`'s padding-left (CSS longhands don't add), so
+// it must restate the base padding, not just the icon+gap delta.
+//
+// This whole overlay approach (rather than nesting the icon inside
+// Mantine's `children`) exists because nesting it hit a real, visible bug:
+// Mantine wraps `children` in its own plain, non-flex <span>, which
+// inherits `label`'s font metrics as its line-box strut. An inline
+// flex-row icon+text wrapper placed inside that span is positioned via
+// `vertical-align`, which aligns to a font-metric-derived point (half the
+// x-height above the baseline) rather than true geometric center — visibly
+// different from the checked/checkmark case, where Mantine renders the
+// icon and text as genuine flex siblings of `label` with no such
+// baseline math involved. Rendering the icon as an absolutely-positioned
+// overlay (via `filterWrapper`) sidesteps inline layout entirely: its
+// vertical position is computed the same way regardless of font metrics,
+// and the label text renders through the exact same code path as the
+// plain-text (no-icon) case, guaranteeing identical text positioning too.
+export const filterLabelWithLeadingIcon = style({
+  paddingLeft: `calc(${components.chip.padding.horizontal} + ${components.chip.iconSize} + ${components.chip.spacing})`,
+});
+
+// `left` accounts for the label's own border width: this overlay is
+// positioned relative to `filterWrapper` (outside the label, at the pill's
+// outer edge), but content inside the label starts after both the border
+// *and* the padding, since the label uses `box-sizing: border-box`.
+//
+// Color tracks the same `states.*` progression as the label text (see
+// `filterLabel`'s `:not([data-checked])` rules above) — being a sibling of
+// `label`, not a descendant, this icon can't just inherit `currentColor`
+// from it, so the same default/hover/active/disabled colors are restated
+// here against `filterWrapper`'s own hover/active pseudo-state and its
+// React-driven `data-disabled` (mirroring `tagRoot`'s pattern, since
+// there's no `data-checked` to key off — this overlay only ever renders
+// when unchecked in the first place, so that case doesn't apply here).
+export const filterIconOverlay = style({
+  position: 'absolute',
+  top: '50%',
+  left: `calc(${strokeWeight} + ${components.chip.padding.horizontal})`,
+  transform: 'translateY(-50%)',
+  pointerEvents: 'none',
+  color: states.default,
+  selectors: {
+    [`${filterWrapper}:not([data-disabled]):hover &`]: { color: states.hover },
+    [`${filterWrapper}:not([data-disabled]):active &`]: { color: states.active },
+    [`${filterWrapper}[data-disabled] &`]: { color: text.disabled },
+  },
 });

--- a/src/components/Chip/Chip.css.ts
+++ b/src/components/Chip/Chip.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: { components, states, inputStates, text, focusRing, strokeWeight },
+} = vars;
+
+const labelFont = {
+  fontFamily: components.chip.label.fontFamily,
+  fontWeight: components.chip.label.fontWeight,
+  lineHeight: components.chip.label.lineHeight,
+};
+
+// Mantine's Chip sets total height via `--chip-size` directly (no vertical
+// padding of its own) and font-size via `--chip-fz` — these two, plus
+// `--chip-radius`/`--chip-padding`/`--chip-spacing`, apply unconditionally on
+// the base label rule. `--chip-bd`/`--chip-bg`/`--chip-color` do NOT — Mantine
+// only reads those under an explicit `variant` (outline/filled), which we
+// don't use, so border/background/text color are set directly below via
+// `filterLabel`'s own `data-checked`/`data-disabled` selectors instead.
+export const filterRoot = style({
+  vars: {
+    '--chip-size': components.chip.height,
+    '--chip-fz': components.chip.label.fontSize,
+    '--chip-radius': components.chip.cornerRadius,
+    '--chip-padding': components.chip.padding.horizontal,
+    '--chip-spacing': components.chip.spacing,
+  },
+});
+
+export const filterInput = style({});
+
+export const filterLabel = style({
+  ...labelFont,
+  selectors: {
+    // Both attribute selectors below add a class + attribute (0,2,0), which
+    // beats Mantine's own plain `.label` base rule (0,1,0) regardless of
+    // stylesheet order — Mantine wraps its own attribute selectors in
+    // `:where()` specifically so consumer overrides like this always win.
+    '&:not([data-checked])': {
+      border: `${strokeWeight} solid ${inputStates.default}`,
+      backgroundColor: 'transparent',
+      color: text.primary,
+    },
+    '&[data-checked]': {
+      border: `${strokeWeight} solid ${states.default}`,
+      backgroundColor: components.item.background.selected.default,
+      color: text.primary,
+    },
+    '&[data-disabled]': {
+      border: `${strokeWeight} solid ${states.disabled}`,
+      color: text.disabled,
+    },
+    [`${filterInput}:focus-visible + &`]: { ...focusRing },
+  },
+});
+
+export const tagRoot = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: components.chip.height,
+  borderRadius: components.chip.cornerRadius,
+  paddingInline: components.chip.padding.horizontal,
+  gap: components.chip.spacing,
+  backgroundColor: components.chip.tagFill,
+  color: text.primary,
+  ...labelFont,
+  fontSize: components.chip.label.fontSize,
+  selectors: {
+    '&[data-disabled]': { color: text.disabled },
+  },
+});
+
+export const tagDismissIcon = style({
+  color: text.secondary,
+});

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -82,22 +82,6 @@ export const Disabled: Story = {
   ),
 };
 
-// Visible in the sidebar for manual comparison, but not a canonical
-// documented state, so it's kept out of the autodocs page.
-export const SelectedVsWithLeadingIcon: Story = {
-  tags: ['dev'],
-  render: () => (
-    <div style={{ display: 'flex', gap: 16 }}>
-      <Chip checked onChange={() => {}}>
-        Ratikat
-      </Chip>
-      <Chip checked={false} onChange={() => {}} icon={<FavouritesOutlinedIcon />}>
-        Suosikki
-      </Chip>
-    </div>
-  ),
-};
-
 // ── Test-only specs (hidden from sidebar/autodocs, still run as browser tests) ─
 
 export const FilterChipTogglesOnClick: Story = {

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -118,6 +118,38 @@ export const FilterChipTogglesOnClick: Story = {
     await expect(chip).not.toBeChecked();
     await userEvent.click(chip);
     await expect(chip).toBeChecked();
+    await userEvent.click(chip);
+    await expect(chip).not.toBeChecked();
+  },
+};
+
+const keyboardToggleSpy = fn();
+export const FilterChipTogglesViaKeyboard: Story = {
+  render: () => {
+    function Wrapper() {
+      const [checked, setChecked] = useState(false);
+      return (
+        <Chip
+          checked={checked}
+          onChange={(next) => {
+            setChecked(next);
+            keyboardToggleSpy(next);
+          }}
+        >
+          Bussit
+        </Chip>
+      );
+    }
+    return <Wrapper />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByRole('checkbox', { name: 'Bussit' });
+    chip.focus();
+    await expect(chip).toHaveFocus();
+    await userEvent.keyboard(' ');
+    await expect(chip).toBeChecked();
+    await expect(keyboardToggleSpy).toHaveBeenCalledWith(true);
   },
 };
 
@@ -232,9 +264,33 @@ export const FilterChipCheckedDisabledColors: Story = {
     // Figma's checked+disabled ("Default"+"Disabled") is a flat
     // States/Disabled fill (#c9c9ce) with NO border — distinct from
     // unchecked+disabled, which keeps a white background with a gray
-    // border instead (see `Disabled` story above).
+    // border instead (see `FilterChipUncheckedDisabledColors` below).
     await expect(style.backgroundColor).toBe('rgb(201, 201, 206)');
     await expect(style.borderStyle).toBe('none');
+    await expect(style.color).toBe('rgb(104, 104, 114)');
+  },
+};
+
+export const FilterChipUncheckedDisabledColors: Story = {
+  render: () => (
+    <Chip checked={false} onChange={() => {}} disabled>
+      Poissa käytöstä
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas
+      .getByRole('checkbox', { name: 'Poissa käytöstä' })
+      .closest('div')
+      ?.querySelector('label');
+    await expect(label).not.toBeNull();
+    const style = getComputedStyle(label!);
+    // Figma's unchecked+disabled ("Outlined"+"Disabled") keeps the white
+    // resting background with just a gray States/Disabled border (#c9c9ce) —
+    // distinct from checked+disabled above, which has no border at all.
+    await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
+    await expect(style.borderStyle).toBe('solid');
+    await expect(style.borderColor).toBe('rgb(201, 201, 206)');
     await expect(style.color).toBe('rgb(104, 104, 114)');
   },
 };
@@ -299,6 +355,24 @@ export const TagChipRendersLabelAndDismiss: Story = {
   },
 };
 
+export const TagChipWithLeadingIcon: Story = {
+  render: () => (
+    <Chip
+      onRemove={() => {}}
+      removeLabel="Poista Hervanta"
+      icon={<StarFilledIcon data-testid="tag-icon" />}
+    >
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvasElement.querySelector('[data-testid="tag-icon"]')).not.toBeNull();
+    await expect(canvas.getByText('Hervanta')).not.toBeNull();
+    await expect(canvas.getByRole('button', { name: 'Poista Hervanta' })).not.toBeNull();
+  },
+};
+
 const onRemoveSpy = fn();
 export const TagChipCallsOnRemove: Story = {
   render: () => (
@@ -344,6 +418,8 @@ export const TagChipDisabledBlocksRemoval: Story = {
     await expect(dismiss).toBeDisabled();
     await userEvent.click(dismiss, { pointerEventsCheck: 0 });
     await expect(tagDisabledSpy).not.toHaveBeenCalled();
+    // Text/Disabled (#686872) — matches the filter role's disabled text color.
+    await expect(getComputedStyle(canvas.getByText('Hervanta')).color).toBe('rgb(104, 104, 114)');
   },
 };
 
@@ -437,12 +513,13 @@ export const TagChipColors: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const label = canvas.getByText('Hervanta');
-    const root = label.closest('span');
-    await expect(root).not.toBeNull();
+    // The label text is a direct child of `tagRoot` (itself a <span>), so
+    // `getByText` already returns the chip's root element — no `.closest()`
+    // walk-up needed.
+    const root = canvas.getByText('Hervanta');
     // Neutral/100 tint (#f2f2f4), Text/Primary label (#2d2d32).
-    await expect(getComputedStyle(root!).backgroundColor).toBe('rgb(242, 242, 244)');
-    await expect(getComputedStyle(label).color).toBe('rgb(45, 45, 50)');
+    await expect(getComputedStyle(root).backgroundColor).toBe('rgb(242, 242, 244)');
+    await expect(getComputedStyle(root).color).toBe('rgb(45, 45, 50)');
   },
 };
 
@@ -460,9 +537,10 @@ export const TagChipHeightTracksLabelFontSize: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const root = canvas.getByText('Hervanta').closest('span');
-    await expect(root).not.toBeNull();
-    const style = getComputedStyle(root!);
+    // See TagChipColors above — the label text's own element is already the
+    // chip's root `tagRoot` <span>.
+    const root = canvas.getByText('Hervanta');
+    const style = getComputedStyle(root);
     const fontSize = parseFloat(style.fontSize);
     const height = parseFloat(style.height);
     // 2 × 4px vertical padding + 150% line-height of the label font size.

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, userEvent } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { StarFilledIcon } from '../../icons/StarFilledIcon';
+import { FavouritesOutlinedIcon } from '../../icons/FavouritesOutlinedIcon';
 import { Chip } from './Chip';
 
 // `ChipProps` is a discriminated union (filter role vs. tag role), which
@@ -52,7 +53,7 @@ export const Selected: Story = {
 export const WithLeadingIcon: Story = {
   tags: docExample,
   render: () => (
-    <Chip checked={false} onChange={() => {}} icon={<StarFilledIcon />}>
+    <Chip checked={false} onChange={() => {}} icon={<FavouritesOutlinedIcon />}>
       Suosikki
     </Chip>
   ),
@@ -76,6 +77,22 @@ export const Disabled: Story = {
       </Chip>
       <Chip onRemove={() => {}} removeLabel="Poista Hervanta" disabled>
         Hervanta
+      </Chip>
+    </div>
+  ),
+};
+
+// Visible in the sidebar for manual comparison, but not a canonical
+// documented state, so it's kept out of the autodocs page.
+export const SelectedVsWithLeadingIcon: Story = {
+  tags: ['dev'],
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Chip checked onChange={() => {}}>
+        Ratikat
+      </Chip>
+      <Chip checked={false} onChange={() => {}} icon={<FavouritesOutlinedIcon />}>
+        Suosikki
       </Chip>
     </div>
   ),
@@ -198,6 +215,77 @@ export const FilterChipDisabledBlocksToggle: Story = {
   },
 };
 
+export const FilterChipCheckedDisabledColors: Story = {
+  render: () => (
+    <Chip checked onChange={() => {}} disabled>
+      Valittu ja poissa käytöstä
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas
+      .getByRole('checkbox', { name: 'Valittu ja poissa käytöstä' })
+      .closest('div')
+      ?.querySelector('label');
+    await expect(label).not.toBeNull();
+    const style = getComputedStyle(label!);
+    // Figma's checked+disabled ("Default"+"Disabled") is a flat
+    // States/Disabled fill (#c9c9ce) with NO border — distinct from
+    // unchecked+disabled, which keeps a white background with a gray
+    // border instead (see `Disabled` story above).
+    await expect(style.backgroundColor).toBe('rgb(201, 201, 206)');
+    await expect(style.borderStyle).toBe('none');
+    await expect(style.color).toBe('rgb(104, 104, 114)');
+  },
+};
+
+export const FilterChipLeadingIconMatchesTextColor: Story = {
+  render: () => (
+    <Chip
+      checked={false}
+      onChange={() => {}}
+      icon={<FavouritesOutlinedIcon data-testid="leading-icon" />}
+    >
+      Suosikki
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas
+      .getByRole('checkbox', { name: 'Suosikki' })
+      .closest('div')
+      ?.querySelector('label');
+    const icon = canvasElement.querySelector('[data-testid="leading-icon"]')?.parentElement;
+    await expect(label).not.toBeNull();
+    await expect(icon).not.toBeNull();
+    // The leading icon is rendered outside `label` (see `filterIconOverlay`
+    // in Chip.css.ts) so it can't just inherit the text's `currentColor` —
+    // its color is restated to track the same states.* progression as the
+    // label text, resting-state here.
+    await expect(getComputedStyle(icon!).color).toBe(getComputedStyle(label!).color);
+  },
+};
+
+const leadingIconDisabledSpy = fn();
+export const FilterChipLeadingIconDisabledColor: Story = {
+  render: () => (
+    <Chip
+      checked={false}
+      onChange={leadingIconDisabledSpy}
+      disabled
+      icon={<FavouritesOutlinedIcon data-testid="leading-icon" />}
+    >
+      Poissa käytöstä
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const icon = canvasElement.querySelector('[data-testid="leading-icon"]')?.parentElement;
+    await expect(icon).not.toBeNull();
+    // Text/Disabled (#686872) — matches the label's own disabled text color.
+    await expect(getComputedStyle(icon!).color).toBe('rgb(104, 104, 114)');
+  },
+};
+
 export const TagChipRendersLabelAndDismiss: Story = {
   render: () => (
     <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
@@ -282,12 +370,18 @@ export const FilterChipColors: Story = {
       ?.querySelector('label');
     await expect(unselectedLabel).not.toBeNull();
     await expect(selectedLabel).not.toBeNull();
-    // Unselected: outline only — Input-states/Default (neutral 600, #52525b).
-    await expect(getComputedStyle(unselectedLabel!).borderColor).toBe('rgb(82, 82, 91)');
-    // Selected: brand-blue border (Primary-states/Default, #29549a) + tinted fill
-    // (Background/Selected/Default, warm neutral #f1eeeb).
+    // Unselected ("Outlined" in Figma): border AND text both track
+    // Primary-states/Default (brand blue, #29549a) — not a neutral gray,
+    // and not the same `text.primary` color the selected chip's text uses.
+    await expect(getComputedStyle(unselectedLabel!).borderColor).toBe('rgb(41, 84, 154)');
+    await expect(getComputedStyle(unselectedLabel!).color).toBe('rgb(41, 84, 154)');
+    // Selected ("Default" in Figma): brand-blue border (Primary-states/Default,
+    // #29549a) + tinted fill (Background/Selected/Default, warm neutral
+    // #f1eeeb) + constant Text/Primary text color (#2d2d32) regardless of
+    // interaction state.
     await expect(getComputedStyle(selectedLabel!).borderColor).toBe('rgb(41, 84, 154)');
     await expect(getComputedStyle(selectedLabel!).backgroundColor).toBe('rgb(241, 238, 235)');
+    await expect(getComputedStyle(selectedLabel!).color).toBe('rgb(45, 45, 50)');
   },
 };
 

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,269 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect, fn } from 'storybook/test';
+import { StarFilledIcon } from '../../icons/StarFilledIcon';
+import { Chip } from './Chip';
+
+// `ChipProps` is a discriminated union (filter role vs. tag role), which
+// Storybook's `args`-merging typing doesn't handle well — every story below
+// renders its own hardcoded element instead of spreading `args` onto `Chip`,
+// and any onChange/onRemove spy is a plain module-scope `fn()` shared between
+// a story's `render` and `play` closures, not routed through Storybook args.
+const meta = {
+  component: Chip,
+  tags: ['!dev', '!autodocs'],
+  // Satisfies the filter-role branch of the union so `args` isn't required
+  // again on every individual story below (each overrides via its own
+  // `render`, ignoring these defaults entirely).
+  args: { checked: false, onChange: () => {}, children: 'Chip' },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FilterChipTogglesOnClick: Story = {
+  render: () => {
+    function Wrapper() {
+      const [checked, setChecked] = useState(false);
+      return (
+        <Chip checked={checked} onChange={setChecked}>
+          Bussit
+        </Chip>
+      );
+    }
+    return <Wrapper />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByRole('checkbox', { name: 'Bussit' });
+    await expect(chip).not.toBeChecked();
+    await userEvent.click(chip);
+    await expect(chip).toBeChecked();
+  },
+};
+
+const onChangeSpy = fn();
+export const FilterChipCallsOnChange: Story = {
+  render: () => (
+    <Chip checked={false} onChange={onChangeSpy}>
+      Ratikat
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByRole('checkbox', { name: 'Ratikat' });
+    await userEvent.click(chip);
+    await expect(onChangeSpy).toHaveBeenCalledWith(true);
+  },
+};
+
+export const FilterChipShowsCheckmarkWhenSelected: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div data-testid="unselected-wrapper">
+        <Chip checked={false} onChange={() => {}}>
+          Unselected
+        </Chip>
+      </div>
+      <div data-testid="selected-wrapper">
+        <Chip checked onChange={() => {}}>
+          Selected
+        </Chip>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId('unselected-wrapper').querySelector('svg')).toBeNull();
+    await expect(canvas.getByTestId('selected-wrapper').querySelector('svg')).not.toBeNull();
+  },
+};
+
+export const FilterChipAcceptsCustomSelectedIcon: Story = {
+  render: () => (
+    <Chip checked onChange={() => {}} selectedIcon={<StarFilledIcon data-testid="star-icon" />}>
+      Suosikki
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('[data-testid="star-icon"]')).not.toBeNull();
+  },
+};
+
+export const FilterChipLeadingIconHiddenWhenSelected: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div data-testid="unselected-wrapper">
+        <Chip
+          checked={false}
+          onChange={() => {}}
+          icon={<StarFilledIcon data-testid="leading-icon" />}
+        >
+          Suosikki
+        </Chip>
+      </div>
+      <div data-testid="selected-wrapper">
+        <Chip checked onChange={() => {}} icon={<StarFilledIcon data-testid="leading-icon" />}>
+          Suosikki
+        </Chip>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByTestId('unselected-wrapper').querySelector('[data-testid="leading-icon"]')
+    ).not.toBeNull();
+    await expect(
+      canvas.getByTestId('selected-wrapper').querySelector('[data-testid="leading-icon"]')
+    ).toBeNull();
+  },
+};
+
+const filterDisabledSpy = fn();
+export const FilterChipDisabledBlocksToggle: Story = {
+  render: () => (
+    <Chip checked={false} onChange={filterDisabledSpy} disabled>
+      Poissa käytöstä
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByRole('checkbox', { name: 'Poissa käytöstä' });
+    await expect(chip).toBeDisabled();
+    await userEvent.click(chip, { pointerEventsCheck: 0 });
+    await expect(filterDisabledSpy).not.toHaveBeenCalled();
+  },
+};
+
+export const TagChipRendersLabelAndDismiss: Story = {
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Hervanta')).not.toBeNull();
+    await expect(canvas.getByRole('button', { name: 'Poista Hervanta' })).not.toBeNull();
+  },
+};
+
+const onRemoveSpy = fn();
+export const TagChipCallsOnRemove: Story = {
+  render: () => (
+    <Chip onRemove={onRemoveSpy} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismiss = canvas.getByRole('button', { name: 'Poista Hervanta' });
+    await userEvent.click(dismiss);
+    await expect(onRemoveSpy).toHaveBeenCalledTimes(1);
+  },
+};
+
+const keyboardRemoveSpy = fn();
+export const TagChipDismissIsKeyboardReachable: Story = {
+  render: () => (
+    <Chip onRemove={keyboardRemoveSpy} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismiss = canvas.getByRole('button', { name: 'Poista Hervanta' });
+    dismiss.focus();
+    await expect(dismiss).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(keyboardRemoveSpy).toHaveBeenCalledTimes(1);
+  },
+};
+
+const tagDisabledSpy = fn();
+export const TagChipDisabledBlocksRemoval: Story = {
+  render: () => (
+    <Chip onRemove={tagDisabledSpy} removeLabel="Poista Hervanta" disabled>
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismiss = canvas.getByRole('button', { name: 'Poista Hervanta' });
+    await expect(dismiss).toBeDisabled();
+    await userEvent.click(dismiss, { pointerEventsCheck: 0 });
+    await expect(tagDisabledSpy).not.toHaveBeenCalled();
+  },
+};
+
+export const FilterChipColors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Chip checked={false} onChange={() => {}}>
+        Bussit
+      </Chip>
+      <Chip checked onChange={() => {}}>
+        Ratikat
+      </Chip>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const unselectedLabel = canvas
+      .getByRole('checkbox', { name: 'Bussit' })
+      .closest('div')
+      ?.querySelector('label');
+    const selectedLabel = canvas
+      .getByRole('checkbox', { name: 'Ratikat' })
+      .closest('div')
+      ?.querySelector('label');
+    await expect(unselectedLabel).not.toBeNull();
+    await expect(selectedLabel).not.toBeNull();
+    // Unselected: outline only — Input-states/Default (neutral 600, #52525b).
+    await expect(getComputedStyle(unselectedLabel!).borderColor).toBe('rgb(82, 82, 91)');
+    // Selected: brand-blue border (Primary-states/Default, #29549a) + tinted fill
+    // (Background/Selected/Default, warm neutral #f1eeeb).
+    await expect(getComputedStyle(selectedLabel!).borderColor).toBe('rgb(41, 84, 154)');
+    await expect(getComputedStyle(selectedLabel!).backgroundColor).toBe('rgb(241, 238, 235)');
+  },
+};
+
+export const FilterChipIsFullyRounded: Story = {
+  render: () => (
+    <Chip checked={false} onChange={() => {}}>
+      Bussit
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas
+      .getByRole('checkbox', { name: 'Bussit' })
+      .closest('div')
+      ?.querySelector('label');
+    await expect(label).not.toBeNull();
+    const style = getComputedStyle(label!);
+    // Fully rounded: radius is at least half the rendered height either way.
+    const radius = parseFloat(style.borderRadius);
+    const height = parseFloat(style.height);
+    await expect(radius).toBeGreaterThanOrEqual(height / 2);
+  },
+};
+
+export const TagChipColors: Story = {
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas.getByText('Hervanta');
+    const root = label.closest('span');
+    await expect(root).not.toBeNull();
+    // Neutral/100 tint (#f2f2f4), Text/Primary label (#2d2d32).
+    await expect(getComputedStyle(root!).backgroundColor).toBe('rgb(242, 242, 244)');
+    await expect(getComputedStyle(label).color).toBe('rgb(45, 45, 50)');
+  },
+};

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -153,6 +153,38 @@ export const FilterChipTogglesViaKeyboard: Story = {
   },
 };
 
+// Regression test: a filter chip with a leading `icon` used to swap its root
+// element between `<span>` (unchecked, wrapped for the icon overlay) and a
+// bare `<div>` (checked, no wrapper) on every toggle. React can't reconcile
+// different root element types, so it unmounted and remounted the whole
+// subtree — including the `<input>` — dropping keyboard focus the instant a
+// user pressed Space to select an icon chip.
+export const FilterChipWithLeadingIconKeepsFocusOnToggle: Story = {
+  render: () => {
+    function Wrapper() {
+      const [checked, setChecked] = useState(false);
+      return (
+        <Chip checked={checked} onChange={setChecked} icon={<StarFilledIcon />}>
+          Suosikki
+        </Chip>
+      );
+    }
+    return <Wrapper />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByRole('checkbox', { name: 'Suosikki' });
+    chip.focus();
+    await expect(chip).toHaveFocus();
+    await userEvent.keyboard(' ');
+    await expect(chip).toBeChecked();
+    await expect(chip).toHaveFocus();
+    await userEvent.keyboard(' ');
+    await expect(chip).not.toBeChecked();
+    await expect(chip).toHaveFocus();
+  },
+};
+
 const onChangeSpy = fn();
 export const FilterChipCallsOnChange: Story = {
   render: () => (
@@ -262,12 +294,49 @@ export const FilterChipCheckedDisabledColors: Story = {
     await expect(label).not.toBeNull();
     const style = getComputedStyle(label!);
     // Figma's checked+disabled ("Default"+"Disabled") is a flat
-    // States/Disabled fill (#c9c9ce) with NO border — distinct from
-    // unchecked+disabled, which keeps a white background with a gray
-    // border instead (see `FilterChipUncheckedDisabledColors` below).
+    // States/Disabled fill (#c9c9ce) with no *visible* border — distinct
+    // from unchecked+disabled, which keeps a white background with a gray
+    // border instead (see `FilterChipUncheckedDisabledColors` below). The
+    // border itself is present but transparent (not `none`), so the pill
+    // keeps the same box size as every other chip — see
+    // `FilterChipCheckedDisabledSizeMatchesEnabled` below.
     await expect(style.backgroundColor).toBe('rgb(201, 201, 206)');
-    await expect(style.borderStyle).toBe('none');
+    await expect(style.borderColor).toBe('rgba(0, 0, 0, 0)');
     await expect(style.color).toBe('rgb(104, 104, 114)');
+  },
+};
+
+// Regression test: checked+disabled previously dropped its border with
+// `border: 'none'` instead of a transparent border, which — combined with
+// `box-sizing: border-box` — shrank the pill by 2 × the border width the
+// moment a selected chip became disabled, visibly narrower than its
+// still-enabled siblings for identical label text.
+export const FilterChipCheckedDisabledSizeMatchesEnabled: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div data-testid="enabled-wrapper">
+        <Chip checked onChange={() => {}}>
+          Valittu
+        </Chip>
+      </div>
+      <div data-testid="disabled-wrapper">
+        <Chip checked onChange={() => {}} disabled>
+          Valittu
+        </Chip>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const enabledLabel = canvas
+      .getByTestId('enabled-wrapper')
+      .querySelector('label') as HTMLElement;
+    const disabledLabel = canvas
+      .getByTestId('disabled-wrapper')
+      .querySelector('label') as HTMLElement;
+    await expect(enabledLabel).not.toBeNull();
+    await expect(disabledLabel).not.toBeNull();
+    await expect(getComputedStyle(disabledLabel).width).toBe(getComputedStyle(enabledLabel).width);
   },
 };
 
@@ -545,5 +614,90 @@ export const TagChipHeightTracksLabelFontSize: Story = {
     const height = parseFloat(style.height);
     // 2 × 4px vertical padding + 150% line-height of the label font size.
     await expect(height).toBeCloseTo(2 * 4 + fontSize * 1.5, 0);
+  },
+};
+
+// Regression test: `className` used to land on different elements depending
+// on chip state — the outer wrapper `<span>` when a leading icon was shown,
+// but Mantine's own root `<div>` otherwise. Now that the wrapper always
+// renders (see `FilterChipWithLeadingIconKeepsFocusOnToggle` above),
+// `className` always lands on it, regardless of `icon`.
+export const FilterChipClassNameLandsOnWrapper: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div data-testid="no-icon-wrapper">
+        <Chip checked={false} onChange={() => {}} className="custom-chip">
+          Bussit
+        </Chip>
+      </div>
+      <div data-testid="with-icon-wrapper">
+        <Chip checked={false} onChange={() => {}} icon={<StarFilledIcon />} className="custom-chip">
+          Suosikki
+        </Chip>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const noIconRoot = canvas.getByTestId('no-icon-wrapper').firstElementChild;
+    const withIconRoot = canvas.getByTestId('with-icon-wrapper').firstElementChild;
+    await expect(noIconRoot).not.toBeNull();
+    await expect(withIconRoot).not.toBeNull();
+    await expect(noIconRoot!.tagName).toBe('SPAN');
+    await expect(withIconRoot!.tagName).toBe('SPAN');
+    await expect(noIconRoot!.classList.contains('custom-chip')).toBe(true);
+    await expect(withIconRoot!.classList.contains('custom-chip')).toBe(true);
+  },
+};
+
+export const TagChipClassNameLandsOnRoot: Story = {
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta" className="custom-chip">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.querySelector('.custom-chip');
+    await expect(root).not.toBeNull();
+    await expect(root?.textContent).toContain('Hervanta');
+  },
+};
+
+// Regression test: without `--chip-icon-size` wired to `components.chip.iconSize`,
+// Mantine's `iconWrapper` derived its `max-width` from its own unset 12px
+// `sm`-tier default, clipping the 18px checkmark. Pins the rendered SVG size
+// to the token value so a future Mantine upgrade or CSS-variable rename that
+// silently reintroduces the clip is caught.
+export const FilterChipIconMatchesIconSizeToken: Story = {
+  render: () => (
+    <Chip checked onChange={() => {}}>
+      Ratikat
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const icon = canvasElement.querySelector('svg');
+    await expect(icon).not.toBeNull();
+    const style = getComputedStyle(icon!);
+    await expect(style.width).toBe('18px');
+    await expect(style.height).toBe('18px');
+  },
+};
+
+export const TagChipDismissIconMatchesIconSizeToken: Story = {
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const dismiss = within(canvasElement).getByRole('button', { name: 'Poista Hervanta' });
+    const icon = dismiss.querySelector('svg');
+    await expect(icon).not.toBeNull();
+    const style = getComputedStyle(icon!);
+    // The dismiss icon isn't wired to `chipIcon`/`--chip-icon-size` directly —
+    // it's sized via `IconButton`'s own `size="sm"` slot (`icon.size.small`),
+    // which happens to equal the same 18px `chip.iconSize` token.
+    await expect(style.width).toBe('18px');
+    await expect(style.height).toBe('18px');
   },
 };

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -22,6 +22,67 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Re-adds the visibility tags that `meta` strips, marking a story as a
+// documentation example shown in both the sidebar and the autodocs page.
+const docExample = ['dev', 'autodocs'];
+
+// ── Documentation examples (visible in sidebar + autodocs) ───────────────────
+// These cover every distinct visual state; the interactive behaviours (focus,
+// keyboard toggle/removal) are discoverable by interacting with them, so the
+// behavioural/a11y stories further down stay test-only to keep docs focused.
+
+export const Default: Story = {
+  tags: docExample,
+  render: () => (
+    <Chip checked={false} onChange={() => {}}>
+      Bussit
+    </Chip>
+  ),
+};
+
+export const Selected: Story = {
+  tags: docExample,
+  render: () => (
+    <Chip checked onChange={() => {}}>
+      Ratikat
+    </Chip>
+  ),
+};
+
+export const WithLeadingIcon: Story = {
+  tags: docExample,
+  render: () => (
+    <Chip checked={false} onChange={() => {}} icon={<StarFilledIcon />}>
+      Suosikki
+    </Chip>
+  ),
+};
+
+export const RemovableTag: Story = {
+  tags: docExample,
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+};
+
+export const Disabled: Story = {
+  tags: docExample,
+  render: () => (
+    <div style={{ display: 'flex', gap: 16 }}>
+      <Chip checked={false} onChange={() => {}} disabled>
+        Bussit
+      </Chip>
+      <Chip onRemove={() => {}} removeLabel="Poista Hervanta" disabled>
+        Hervanta
+      </Chip>
+    </div>
+  ),
+};
+
+// ── Test-only specs (hidden from sidebar/autodocs, still run as browser tests) ─
+
 export const FilterChipTogglesOnClick: Story = {
   render: () => {
     function Wrapper() {
@@ -230,6 +291,29 @@ export const FilterChipColors: Story = {
   },
 };
 
+export const FilterChipHeightTracksLabelFontSize: Story = {
+  // Same viewport-independent relationship check as the tag-role equivalent
+  // below — `--chip-size` is fed from the same `components.chip.height`
+  // formula, not a fixed Mantine size step.
+  render: () => (
+    <Chip checked={false} onChange={() => {}}>
+      Bussit
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas
+      .getByRole('checkbox', { name: 'Bussit' })
+      .closest('div')
+      ?.querySelector('label');
+    await expect(label).not.toBeNull();
+    const style = getComputedStyle(label!);
+    const fontSize = parseFloat(style.fontSize);
+    const height = parseFloat(style.height);
+    await expect(height).toBeCloseTo(2 * 4 + fontSize * 1.5, 0);
+  },
+};
+
 export const FilterChipIsFullyRounded: Story = {
   render: () => (
     <Chip checked={false} onChange={() => {}}>
@@ -265,5 +349,29 @@ export const TagChipColors: Story = {
     // Neutral/100 tint (#f2f2f4), Text/Primary label (#2d2d32).
     await expect(getComputedStyle(root!).backgroundColor).toBe('rgb(242, 242, 244)');
     await expect(getComputedStyle(label).color).toBe('rgb(45, 45, 50)');
+  },
+};
+
+// Height is `components.chip.height` — a formula derived from the same
+// breakpoint-varying label font-size used to render the text (see theme.ts),
+// not a hardcoded literal. Asserting the formula holds at whatever
+// breakpoint the test runs proves the wiring stays correct at every other
+// breakpoint too, without needing to actually resize the viewport (same
+// viewport-independent pattern as DateField's TriggerIconTracksControlSize).
+export const TagChipHeightTracksLabelFontSize: Story = {
+  render: () => (
+    <Chip onRemove={() => {}} removeLabel="Poista Hervanta">
+      Hervanta
+    </Chip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = canvas.getByText('Hervanta').closest('span');
+    await expect(root).not.toBeNull();
+    const style = getComputedStyle(root!);
+    const fontSize = parseFloat(style.fontSize);
+    const height = parseFloat(style.height);
+    // 2 × 4px vertical padding + 150% line-height of the label font size.
+    await expect(height).toBeCloseTo(2 * 4 + fontSize * 1.5, 0);
   },
 };

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,65 @@
+import type { ReactElement, ReactNode } from 'react';
+import cx from 'clsx';
+import { Chip as MantineChip } from '@mantine/core';
+import { StepCheckIcon } from '../../icons/StepCheckIcon';
+import { CloseIcon } from '../../icons/CloseIcon';
+import { IconButton } from '../IconButton/IconButton';
+import { filterRoot, filterLabel, filterInput, tagRoot, tagDismissIcon } from './Chip.css';
+
+export interface ChipCommonProps {
+  children: ReactNode;
+  icon?: ReactElement;
+  disabled?: boolean;
+  className?: string;
+}
+
+export interface ChipFilterProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  selectedIcon?: ReactElement;
+  onRemove?: never;
+  removeLabel?: never;
+}
+
+export interface ChipTagProps {
+  onRemove: () => void;
+  removeLabel: string;
+  checked?: never;
+  onChange?: never;
+  selectedIcon?: never;
+}
+
+export type ChipProps = ChipCommonProps & (ChipFilterProps | ChipTagProps);
+
+export function Chip(props: ChipProps) {
+  const { children, disabled, className } = props;
+
+  if ('onRemove' in props && props.onRemove) {
+    const { onRemove, removeLabel, icon } = props as ChipCommonProps & ChipTagProps;
+    return (
+      <span className={cx(tagRoot, className)} data-disabled={disabled || undefined}>
+        {icon}
+        {children}
+        <IconButton size="xs" onClick={onRemove} disabled={disabled} aria-label={removeLabel}>
+          <CloseIcon className={tagDismissIcon} />
+        </IconButton>
+      </span>
+    );
+  }
+
+  const { checked, onChange, selectedIcon, icon } = props as ChipCommonProps & ChipFilterProps;
+
+  return (
+    <MantineChip
+      checked={checked}
+      onChange={onChange}
+      disabled={disabled}
+      className={cx(filterRoot, className)}
+      classNames={{ label: filterLabel, input: filterInput }}
+      icon={selectedIcon ?? <StepCheckIcon />}
+    >
+      {!checked && icon}
+      {children}
+    </MantineChip>
+  );
+}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react';
 import cx from 'clsx';
 import { Chip as MantineChip } from '@mantine/core';
 import { CheckmarkIcon } from '../../icons/CheckmarkIcon';
@@ -16,8 +16,16 @@ import {
   chipIcon,
 } from './Chip.css';
 
-export interface ChipCommonProps {
+export interface ChipCommonProps extends Omit<
+  ComponentPropsWithoutRef<'input'>,
+  'checked' | 'onChange' | 'disabled' | 'children' | 'className' | 'type' | 'size'
+> {
   children: ReactNode;
+  /**
+   * Leading icon. On a filter chip this only renders while `checked` is
+   * `false` — it is replaced by the checkmark/`selectedIcon` once selected,
+   * so passing both `checked` and `icon` together silently drops `icon`.
+   */
   icon?: ReactElement;
   disabled?: boolean;
   className?: string;
@@ -42,17 +50,15 @@ export interface ChipTagProps {
 export type ChipProps = ChipCommonProps & (ChipFilterProps | ChipTagProps);
 
 export function Chip(props: ChipProps) {
-  const { children, disabled, className } = props;
-
   // `onRemove?: never` still permits a filter-chip caller to explicitly pass
   // `onRemove: undefined`, and `in` returns true for a present-but-undefined
   // key — the `&& props.onRemove` truthy check is what actually discriminates
   // the union at runtime (see Table.tsx's TableRowSelection for the same
   // never-based pattern).
   if ('onRemove' in props && props.onRemove) {
-    const { onRemove, removeLabel, icon } = props;
+    const { onRemove, removeLabel, icon, children, disabled, className, ...rest } = props;
     return (
-      <span className={cx(tagRoot, className)} data-disabled={disabled || undefined}>
+      <span className={cx(tagRoot, className)} data-disabled={disabled || undefined} {...rest}>
         {icon && <span className={chipIcon}>{icon}</span>}
         {children}
         <IconButton size="sm" onClick={onRemove} disabled={disabled} aria-label={removeLabel}>
@@ -62,34 +68,33 @@ export function Chip(props: ChipProps) {
     );
   }
 
-  const { checked, onChange, selectedIcon, icon } = props;
+  const { checked, onChange, selectedIcon, icon, children, disabled, className, ...rest } = props;
   const hasLeadingIcon = !checked && !!icon;
 
-  const chip = (
-    <MantineChip
-      checked={checked}
-      onChange={onChange}
-      disabled={disabled}
-      className={hasLeadingIcon ? filterRoot : cx(filterRoot, className)}
-      classNames={{
-        label: cx(filterLabel, hasLeadingIcon && filterLabelWithLeadingIcon),
-        input: filterInput,
-        iconWrapper: chipIcon,
-      }}
-      icon={selectedIcon ?? <CheckmarkIcon />}
-    >
-      {children}
-    </MantineChip>
-  );
-
-  if (!hasLeadingIcon) {
-    return chip;
-  }
-
+  // Always rendered as a wrapper `<span>` around `MantineChip` — even when
+  // there's no leading icon to overlay — so the root element type never
+  // changes between checked/unchecked. Conditionally swapping between this
+  // wrapper and the bare `MantineChip` (a `<div>`) made React unmount and
+  // remount the whole subtree, including the `<input>`, on every toggle,
+  // dropping keyboard focus.
   return (
     <span className={cx(filterWrapper, className)} data-disabled={disabled || undefined}>
-      {chip}
-      <span className={cx(chipIcon, filterIconOverlay)}>{icon}</span>
+      <MantineChip
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        className={filterRoot}
+        classNames={{
+          label: cx(filterLabel, hasLeadingIcon && filterLabelWithLeadingIcon),
+          input: filterInput,
+          iconWrapper: chipIcon,
+        }}
+        icon={selectedIcon ?? <CheckmarkIcon />}
+        {...rest}
+      >
+        {children}
+      </MantineChip>
+      {hasLeadingIcon && <span className={cx(chipIcon, filterIconOverlay)}>{icon}</span>}
     </span>
   );
 }

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -44,20 +44,25 @@ export type ChipProps = ChipCommonProps & (ChipFilterProps | ChipTagProps);
 export function Chip(props: ChipProps) {
   const { children, disabled, className } = props;
 
+  // `onRemove?: never` still permits a filter-chip caller to explicitly pass
+  // `onRemove: undefined`, and `in` returns true for a present-but-undefined
+  // key — the `&& props.onRemove` truthy check is what actually discriminates
+  // the union at runtime (see Table.tsx's TableRowSelection for the same
+  // never-based pattern).
   if ('onRemove' in props && props.onRemove) {
-    const { onRemove, removeLabel, icon } = props as ChipCommonProps & ChipTagProps;
+    const { onRemove, removeLabel, icon } = props;
     return (
       <span className={cx(tagRoot, className)} data-disabled={disabled || undefined}>
         {icon && <span className={chipIcon}>{icon}</span>}
         {children}
-        <IconButton size="xs" onClick={onRemove} disabled={disabled} aria-label={removeLabel}>
+        <IconButton size="sm" onClick={onRemove} disabled={disabled} aria-label={removeLabel}>
           <CloseIcon className={tagDismissIcon} />
         </IconButton>
       </span>
     );
   }
 
-  const { checked, onChange, selectedIcon, icon } = props as ChipCommonProps & ChipFilterProps;
+  const { checked, onChange, selectedIcon, icon } = props;
   const hasLeadingIcon = !checked && !!icon;
 
   const chip = (
@@ -65,7 +70,7 @@ export function Chip(props: ChipProps) {
       checked={checked}
       onChange={onChange}
       disabled={disabled}
-      className={cx(filterRoot, className)}
+      className={hasLeadingIcon ? filterRoot : cx(filterRoot, className)}
       classNames={{
         label: cx(filterLabel, hasLeadingIcon && filterLabelWithLeadingIcon),
         input: filterInput,
@@ -82,7 +87,7 @@ export function Chip(props: ChipProps) {
   }
 
   return (
-    <span className={filterWrapper} data-disabled={disabled || undefined}>
+    <span className={cx(filterWrapper, className)} data-disabled={disabled || undefined}>
       {chip}
       <span className={cx(chipIcon, filterIconOverlay)}>{icon}</span>
     </span>

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,10 +1,20 @@
 import type { ReactElement, ReactNode } from 'react';
 import cx from 'clsx';
 import { Chip as MantineChip } from '@mantine/core';
-import { StepCheckIcon } from '../../icons/StepCheckIcon';
+import { CheckmarkIcon } from '../../icons/CheckmarkIcon';
 import { CloseIcon } from '../../icons/CloseIcon';
 import { IconButton } from '../IconButton/IconButton';
-import { filterRoot, filterLabel, filterInput, tagRoot, tagDismissIcon } from './Chip.css';
+import {
+  filterWrapper,
+  filterRoot,
+  filterLabel,
+  filterLabelWithLeadingIcon,
+  filterInput,
+  filterIconOverlay,
+  tagRoot,
+  tagDismissIcon,
+  chipIcon,
+} from './Chip.css';
 
 export interface ChipCommonProps {
   children: ReactNode;
@@ -38,7 +48,7 @@ export function Chip(props: ChipProps) {
     const { onRemove, removeLabel, icon } = props as ChipCommonProps & ChipTagProps;
     return (
       <span className={cx(tagRoot, className)} data-disabled={disabled || undefined}>
-        {icon}
+        {icon && <span className={chipIcon}>{icon}</span>}
         {children}
         <IconButton size="xs" onClick={onRemove} disabled={disabled} aria-label={removeLabel}>
           <CloseIcon className={tagDismissIcon} />
@@ -48,18 +58,33 @@ export function Chip(props: ChipProps) {
   }
 
   const { checked, onChange, selectedIcon, icon } = props as ChipCommonProps & ChipFilterProps;
+  const hasLeadingIcon = !checked && !!icon;
 
-  return (
+  const chip = (
     <MantineChip
       checked={checked}
       onChange={onChange}
       disabled={disabled}
       className={cx(filterRoot, className)}
-      classNames={{ label: filterLabel, input: filterInput }}
-      icon={selectedIcon ?? <StepCheckIcon />}
+      classNames={{
+        label: cx(filterLabel, hasLeadingIcon && filterLabelWithLeadingIcon),
+        input: filterInput,
+        iconWrapper: chipIcon,
+      }}
+      icon={selectedIcon ?? <CheckmarkIcon />}
     >
-      {!checked && icon}
       {children}
     </MantineChip>
+  );
+
+  if (!hasLeadingIcon) {
+    return chip;
+  }
+
+  return (
+    <span className={filterWrapper} data-disabled={disabled || undefined}>
+      {chip}
+      <span className={cx(chipIcon, filterIconOverlay)}>{icon}</span>
+    </span>
   );
 }

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export { Chip, type ChipProps } from './Chip';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -2,6 +2,7 @@ export { Accordion, AccordionItem } from './Accordion/Accordion';
 export { Breadcrumbs } from './Breadcrumbs/Breadcrumbs';
 export { Button } from './Button/Button';
 export { Checkbox } from './Checkbox/Checkbox';
+export { Chip, type ChipProps } from './Chip/Chip';
 export { IconButton } from './IconButton/IconButton';
 export {
   LabeledIconButton,

--- a/src/icons/CheckmarkIcon.tsx
+++ b/src/icons/CheckmarkIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export const CheckmarkIcon = ({ width = 24, ...props }: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={width}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M21.7471 5.66406L9.04297 19.957L2.29297 13.207L3.70703 11.793L8.95703 17.043L20.2529 4.33594L21.7471 5.66406Z" />
+    </svg>
+  );
+};

--- a/src/icons/Icons.stories.tsx
+++ b/src/icons/Icons.stories.tsx
@@ -17,6 +17,7 @@ import { CartRemoveIcon } from './CartRemoveIcon';
 import { CheckboxCheckedIcon } from './CheckboxCheckedIcon';
 import { CheckboxIndeterminateIcon } from './CheckboxIndeterminateIcon';
 import { CheckboxUncheckedIcon } from './CheckboxUncheckedIcon';
+import { CheckmarkIcon } from './CheckmarkIcon';
 import { ChevronDownIcon } from './ChevronDownIcon';
 import { ChevronLeftIcon } from './ChevronLeftIcon';
 import { ChevronRightIcon } from './ChevronRightIcon';
@@ -113,6 +114,7 @@ const icons: {
   { name: 'CheckboxChecked', Component: CheckboxCheckedIcon },
   { name: 'CheckboxIndeterminate', Component: CheckboxIndeterminateIcon },
   { name: 'CheckboxUnchecked', Component: CheckboxUncheckedIcon },
+  { name: 'Checkmark', Component: CheckmarkIcon },
   { name: 'ChevronDown', Component: ChevronDownIcon },
   { name: 'ChevronLeft', Component: ChevronLeftIcon },
   { name: 'ChevronRight', Component: ChevronRightIcon },

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -15,6 +15,7 @@ export * from './CartRemoveIcon';
 export * from './CheckboxCheckedIcon';
 export * from './CheckboxIndeterminateIcon';
 export * from './CheckboxUncheckedIcon';
+export * from './CheckmarkIcon';
 export * from './ChevronDownIcon';
 export * from './ChevronLeftIcon';
 export * from './ChevronRightIcon';

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -41,6 +41,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -51,7 +52,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
         "horizontal": "calc(1rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",
@@ -369,6 +370,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.875rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.875rem * var(--mantine-scale))",
@@ -379,7 +381,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "spacing": "calc(0.25rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.625rem * var(--mantine-scale))",
@@ -697,6 +699,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.75rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.75rem * var(--mantine-scale))",
@@ -707,7 +710,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "spacing": "calc(0.25rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.5rem * var(--mantine-scale))",
@@ -1439,6 +1442,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       "chip": {
         "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
         "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.875rem * var(--mantine-scale)) * 1.5)",
+        "iconSize": "calc(1.125rem * var(--mantine-scale))",
         "label": {
           "fontFamily": "Open Sans Variable, sans-serif",
           "fontSize": "calc(0.875rem * var(--mantine-scale))",
@@ -1449,7 +1453,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
           "horizontal": "calc(0.75rem * var(--mantine-scale))",
           "vertical": "calc(0.25rem * var(--mantine-scale))",
         },
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "spacing": "calc(0.25rem * var(--mantine-scale))",
         "tagFill": "#f2f2f4",
       },
       "controlHeight": "calc(2.625rem * var(--mantine-scale))",
@@ -1768,6 +1772,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -1778,7 +1783,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
         "horizontal": "calc(1rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",
@@ -2096,6 +2101,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.75rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.75rem * var(--mantine-scale))",
@@ -2106,7 +2112,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "spacing": "calc(0.25rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.5rem * var(--mantine-scale))",
@@ -2424,6 +2430,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
       "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
+      "iconSize": "calc(1.125rem * var(--mantine-scale))",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -2434,7 +2441,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
         "horizontal": "calc(1rem * var(--mantine-scale))",
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "spacing": "calc(0.5rem * var(--mantine-scale))",
       "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -40,6 +40,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -51,6 +52,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",
     "datePicker": {
@@ -366,6 +368,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.875rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.875rem * var(--mantine-scale))",
@@ -377,6 +380,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.625rem * var(--mantine-scale))",
     "datePicker": {
@@ -692,6 +696,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.75rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.75rem * var(--mantine-scale))",
@@ -703,6 +708,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.5rem * var(--mantine-scale))",
     "datePicker": {
@@ -1432,6 +1438,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       },
       "chip": {
         "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+        "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.875rem * var(--mantine-scale)) * 1.5)",
         "label": {
           "fontFamily": "Open Sans Variable, sans-serif",
           "fontSize": "calc(0.875rem * var(--mantine-scale))",
@@ -1443,6 +1450,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
           "vertical": "calc(0.25rem * var(--mantine-scale))",
         },
         "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "tagFill": "#f2f2f4",
       },
       "controlHeight": "calc(2.625rem * var(--mantine-scale))",
       "datePicker": {
@@ -1759,6 +1767,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -1770,6 +1779,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",
     "datePicker": {
@@ -2085,6 +2095,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(0.75rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(0.75rem * var(--mantine-scale))",
@@ -2096,6 +2107,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(2.5rem * var(--mantine-scale))",
     "datePicker": {
@@ -2411,6 +2423,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
+      "height": "calc(calc(0.25rem * var(--mantine-scale)) * 2 + calc(1rem * var(--mantine-scale)) * 1.5)",
       "label": {
         "fontFamily": "Open Sans Variable, sans-serif",
         "fontSize": "calc(1rem * var(--mantine-scale))",
@@ -2422,6 +2435,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
         "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
+      "tagFill": "#f2f2f4",
     },
     "controlHeight": "calc(3.25rem * var(--mantine-scale))",
     "datePicker": {

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -48,7 +48,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",
-        "vertical": "calc(0.75rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
@@ -374,7 +374,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
-        "vertical": "calc(0.5rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -700,7 +700,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
-        "vertical": "calc(0.5rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -1440,7 +1440,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         },
         "padding": {
           "horizontal": "calc(0.75rem * var(--mantine-scale))",
-          "vertical": "calc(0.5rem * var(--mantine-scale))",
+          "vertical": "calc(0.25rem * var(--mantine-scale))",
         },
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
@@ -1767,7 +1767,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",
-        "vertical": "calc(0.75rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
@@ -2093,7 +2093,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
-        "vertical": "calc(0.5rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -2419,7 +2419,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",
-        "vertical": "calc(0.75rem * var(--mantine-scale))",
+        "vertical": "calc(0.25rem * var(--mantine-scale))",
       },
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -40,9 +40,11 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1.25rem * var(--mantine-scale))",
-        "size": "calc(1.125rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(1rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",
@@ -364,9 +366,11 @@ exports[`Token Values Match Snapshot > md 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1.125rem * var(--mantine-scale))",
-        "size": "calc(1rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(0.875rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
@@ -688,9 +692,11 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1rem * var(--mantine-scale))",
-        "size": "calc(0.875rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(0.75rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
@@ -1426,9 +1432,11 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       },
       "chip": {
         "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-        "font": {
-          "lineHeight": "calc(1.125rem * var(--mantine-scale))",
-          "size": "calc(1rem * var(--mantine-scale))",
+        "label": {
+          "fontFamily": "Open Sans Variable, sans-serif",
+          "fontSize": "calc(0.875rem * var(--mantine-scale))",
+          "fontWeight": "600",
+          "lineHeight": "150%",
         },
         "padding": {
           "horizontal": "calc(0.75rem * var(--mantine-scale))",
@@ -1751,9 +1759,11 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1.25rem * var(--mantine-scale))",
-        "size": "calc(1.125rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(1rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",
@@ -2075,9 +2085,11 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1rem * var(--mantine-scale))",
-        "size": "calc(0.875rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(0.75rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(0.75rem * var(--mantine-scale))",
@@ -2399,9 +2411,11 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     },
     "chip": {
       "cornerRadius": "calc(1.25rem * var(--mantine-scale))",
-      "font": {
-        "lineHeight": "calc(1.25rem * var(--mantine-scale))",
-        "size": "calc(1.125rem * var(--mantine-scale))",
+      "label": {
+        "fontFamily": "Open Sans Variable, sans-serif",
+        "fontSize": "calc(1rem * var(--mantine-scale))",
+        "fontWeight": "600",
+        "lineHeight": "150%",
       },
       "padding": {
         "horizontal": "calc(1rem * var(--mantine-scale))",

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -203,7 +203,15 @@ export function getTheme(bp: BreakpointKey) {
     chip: {
       spacing: bpTokens.spacing.xs,
       cornerRadius: rem('20px'),
-      font: { lineHeight: bpTokens.components.input.lineHeight, size: bpTokens.typography.size.p2 },
+      // Figma's "Chip/Label" composite token: Caption's own size/family/line-height,
+      // but Subheader-style Semi-Bold weight rather than Caption's own Regular —
+      // matches `typography.caption` above except for that one deliberate override.
+      label: {
+        fontFamily: fontFamilyBody,
+        fontSize: bpTokens.typography.size.caption,
+        fontWeight: '600',
+        lineHeight: '150%',
+      },
       padding: { horizontal: bpTokens.spacing.sm, vertical: bpTokens.spacing.xs },
     },
     datePicker: {

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -212,7 +212,14 @@ export function getTheme(bp: BreakpointKey) {
         fontWeight: '600',
         lineHeight: '150%',
       },
-      padding: { horizontal: bpTokens.spacing.sm, vertical: bpTokens.spacing.xs },
+      // Vertical padding is a fixed constant (not per-breakpoint, unlike
+      // `horizontal` below) — Figma's Spacing/0,5 = 4px at every breakpoint.
+      // Combined with `label`'s breakpoint-varying Caption size/line-height,
+      // this gives the spec's 32px total height at the lg/xl/xxl tier
+      // (4 + 150%*16px + 4 = 32) and a correspondingly smaller height on
+      // narrower breakpoints as Caption itself shrinks — same "reference
+      // height at the largest breakpoint" pattern used elsewhere in TREDS.
+      padding: { horizontal: bpTokens.spacing.sm, vertical: primitives.spacing['0,5'] },
     },
     datePicker: {
       todayMarker: colors.neutral['800'],

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -201,7 +201,14 @@ export function getTheme(bp: BreakpointKey) {
       textContentSpacing: primitives.spacing['1'],
     },
     chip: {
-      spacing: bpTokens.spacing.xs,
+      // Figma's "spacing/2-extra-small" — confirmed against the dedicated
+      // "Breakpoints" reference frame (5870:41586) in the redesign file,
+      // which binds this exact gap (icon↔label, label↔dismiss-button) to
+      // that variable at every breakpoint (8px at xxl/xl/lg, 4px at
+      // md/sm/xs) — not `xs` ("spacing/extra-small", 12px/8px), which an
+      // earlier, apparently-stale example instance elsewhere in the file
+      // used and this token was previously (incorrectly) matched to.
+      spacing: bpTokens.spacing.xxs,
       cornerRadius: rem('20px'),
       // Figma's "Chip/Label" composite token: Caption's own size/family/line-height,
       // but Subheader-style Semi-Bold weight rather than Caption's own Regular —
@@ -232,6 +239,11 @@ export function getTheme(bp: BreakpointKey) {
       // resting fill) — see the TextLink review lesson on not reusing a
       // semantically-mismatched token just because its value happens to match.
       tagFill: colors.neutral['100'],
+      // Fixed constant like `padding.vertical` above, not part of the
+      // responsive scale — Figma's Chip "Icon" slot is a literal 18×18px
+      // square at every breakpoint (verified against the 768/480/320
+      // breakpoint mockups in the redesign file, all identical).
+      iconSize: rem('18px'),
     },
     datePicker: {
       todayMarker: colors.neutral['800'],

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -58,6 +58,11 @@ const text = {
 
 const highlight = { fontWeight: '700', backgroundColor: 'transparent' } as const;
 
+// Single source of truth for Chip label's line-height, so `chip.label.lineHeight`
+// and `chip.height`'s calc formula (which derives the same 150% relationship
+// from the label's font size) can't silently desync.
+const chipLineHeightPercent = 150;
+
 const strokeWeight = rem('2px');
 
 const focusRing = {
@@ -217,7 +222,7 @@ export function getTheme(bp: BreakpointKey) {
         fontFamily: fontFamilyBody,
         fontSize: bpTokens.typography.size.caption,
         fontWeight: '600',
-        lineHeight: '150%',
+        lineHeight: `${chipLineHeightPercent}%`,
       },
       // Vertical padding is a fixed constant (not per-breakpoint, unlike
       // `horizontal` below) — Figma's Spacing/0,5 = 4px at every breakpoint.
@@ -227,12 +232,13 @@ export function getTheme(bp: BreakpointKey) {
       // narrower breakpoints as Caption itself shrinks — same "reference
       // height at the largest breakpoint" pattern used elsewhere in TREDS.
       padding: { horizontal: bpTokens.spacing.sm, vertical: primitives.spacing['0,5'] },
-      // Total pill height = 2×vertical padding + 150% line-height of the
-      // label's font size. Mantine's Chip has no vertical-padding concept
-      // of its own (it sets height directly via --chip-size), so this is
-      // computed once here and fed to both the Mantine-wrapped filter role
-      // and the bespoke removable-tag role, keeping their heights identical.
-      height: `calc(${primitives.spacing['0,5']} * 2 + ${bpTokens.typography.size.caption} * 1.5)`,
+      // Total pill height = 2×vertical padding + line-height of the label's
+      // font size (`chipLineHeightPercent`, matching `label.lineHeight`
+      // above). Mantine's Chip has no vertical-padding concept of its own
+      // (it sets height directly via --chip-size), so this is computed once
+      // here and fed to both the Mantine-wrapped filter role and the bespoke
+      // removable-tag role, keeping their heights identical.
+      height: `calc(${primitives.spacing['0,5']} * 2 + ${bpTokens.typography.size.caption} * ${chipLineHeightPercent / 100})`,
       // Figma's "Neutral/100" tag fill — distinct from `background.disabled`
       // even though the raw value is the same, since that token means
       // something unrelated (a disabled-state background, not a tag chip's

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -220,6 +220,18 @@ export function getTheme(bp: BreakpointKey) {
       // narrower breakpoints as Caption itself shrinks — same "reference
       // height at the largest breakpoint" pattern used elsewhere in TREDS.
       padding: { horizontal: bpTokens.spacing.sm, vertical: primitives.spacing['0,5'] },
+      // Total pill height = 2×vertical padding + 150% line-height of the
+      // label's font size. Mantine's Chip has no vertical-padding concept
+      // of its own (it sets height directly via --chip-size), so this is
+      // computed once here and fed to both the Mantine-wrapped filter role
+      // and the bespoke removable-tag role, keeping their heights identical.
+      height: `calc(${primitives.spacing['0,5']} * 2 + ${bpTokens.typography.size.caption} * 1.5)`,
+      // Figma's "Neutral/100" tag fill — distinct from `background.disabled`
+      // even though the raw value is the same, since that token means
+      // something unrelated (a disabled-state background, not a tag chip's
+      // resting fill) — see the TextLink review lesson on not reusing a
+      // semantically-mismatched token just because its value happens to match.
+      tagFill: colors.neutral['100'],
     },
     datePicker: {
       todayMarker: colors.neutral['800'],


### PR DESCRIPTION
## Summary
- Adds the `Chip` component: a discriminated-union API supporting a filter/selection role (`checked`+`onChange`, wraps Mantine's `Chip`) and a removable-tag role (`onRemove`+`removeLabel`, bespoke).
- Adds `CheckmarkIcon` to the icon library as the default selected-state icon.
- Full pass fixing icon sizing/spacing/padding and colors against Figma's Chip component set (see commit `7452a56` for the detailed list — unchecked border/text were bound to the wrong token entirely, checked-state padding silently fell back to a Mantine default, the leading icon didn't track state-driven text color, etc).

## Review fixes (`7c34810`)
A multi-agent review pass (general code quality, test coverage, comment accuracy, type design) surfaced and fixed:
- The selected-state checkmark/`selectedIcon` rendered under the 18px icon token (Mantine's `iconWrapper` `max-width` calc was still deriving from its own unset 12px default) — added the missing `--chip-icon-size` CSS var
- The tag dismiss icon rendered at 16px instead of the documented 18px slot — resized to match
- Consumer `className` landed on the wrong element (inner chip vs. outer wrapper) when a leading icon was shown — now always lands on the outermost box
- Removed unnecessary `as` type casts in `Chip`'s discriminated-union narrowing (verified via `tsc --strict` that narrowing already works without them) and documented the runtime discriminant
- Corrected a few stale/inaccurate CSS comments (a dead symbol reference, an overstated CSS-specificity claim, a spacing-variable misattribution) and tied the label's line-height token to its height formula so they can't silently desync
- Added missing test coverage: unchecked+disabled filter chip colors, tag-role leading icon, filter chip toggle-off and keyboard toggling, tag chip disabled text color

## Test plan
- [x] `npm run eslint` / `tsc --noEmit` / full test suite (221/221) all pass
- [x] Visually verified all documented stories (`Default`, `Selected`, `With Leading Icon`, `Removable Tag`, `Disabled`) against the Figma reference, including hover/active/disabled states
- [x] `FilterChipColors`, `FilterChipCheckedDisabledColors`, `FilterChipUncheckedDisabledColors`, `FilterChipLeadingIconMatchesTextColor`, `FilterChipLeadingIconDisabledColor` cover the color-audit fixes with real assertions, not just visual inspection
- [x] Re-verified the icon-sizing fixes in a live Storybook instance via browser screenshots (checkmark now matches the leading-icon size; dismiss icon visibly larger/on-spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
