### PR TITLE
feat(#74, #57): add Paper and Card components

### DIFF
--- a/src/components/Accordion/Accordion.css.ts
+++ b/src/components/Accordion/Accordion.css.ts
@@ -5,7 +5,7 @@ const {
   theme: {
     strokeWeight,
     divider,
-    dropShadow,
+    dropShadowTile,
     components: { accordion: accordionVars, typography, item: itemVars, iconButton },
     focusRing,
   },
@@ -78,7 +78,7 @@ export const chevron = style({
 export const item = style({
   display: 'flex',
   flexDirection: 'column',
-  boxShadow: `0px 1px 4px 0px ${dropShadow}`,
+  boxShadow: dropShadowTile,
 });
 
 export const content = style({

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -8,6 +8,7 @@ const {
   theme: {
     components: { card },
     contrast,
+    focus,
   },
 } = vars;
 
@@ -87,3 +88,14 @@ const invertibleSelectors = [...Object.values(typography), ...Object.values(link
 // class), but is kept defensively in case either ever gains a second class
 // (e.g. a `className` override) that would otherwise tie or exceed it.
 globalStyle(invertibleSelectors, { color: `${contrast} !important` });
+
+// The neutral `focusRing` outline (`focus.visible`, #1e1e22) both TextLink and
+// Typography spread for `:focus-visible` fails WCAG's 3:1 non-text-contrast
+// minimum against Card's colored backgrounds (#116) — override just the color
+// (width/offset already match) to the same inverted tone used above, scoped to
+// `:focus-visible` on the same allowlist so it only fires on colored Cards.
+const invertibleFocusSelectors = [...Object.values(typography), ...Object.values(link)]
+  .map((className) => `${content}${inverted} .${className}:focus-visible`)
+  .join(', ');
+
+globalStyle(invertibleFocusSelectors, { outlineColor: `${focus.visibleInverted} !important` });

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -15,14 +15,23 @@ export const root = style({ display: 'flex', flexDirection: 'column' });
 
 export const rootMediaLeft = style({ flexDirection: 'row' });
 
-// Applied unconditionally so the wrapper doesn't zero out in the default
-// column layout, collapsing real media content.
-export const media = style({ minWidth: 0, minHeight: 0 });
+// `minWidth`/`minHeight: 0` let the wrapper shrink below its content's intrinsic
+// size instead of overflowing (needed in the `left` row layout, where `media` is
+// a fixed `flex: 0 0 50%` column — see below). `overflow: hidden` is a second,
+// independent guard: even a correctly-shrunk wrapper doesn't clip an oversized
+// descendant on its own.
+export const media = style({ minWidth: 0, minHeight: 0, overflow: 'hidden' });
 
 // Media content (an `<img>`, or any other element a consumer passes) has no
-// intrinsic constraint of its own — without this, a source image larger than
-// the card overflows both the top (full-width) and left (split-column) layouts.
-globalStyle(`${media} > *`, { display: 'block', maxWidth: '100%', height: 'auto' });
+// intrinsic constraint of its own — without this, a source image larger than the
+// card overflows both the top (full-width) and left (split-column) layouts. A
+// descendant selector (not `> *`) so the constraint reaches the actual media
+// element even when a consumer wraps it (e.g. `<picture><img/></picture>`).
+globalStyle(`${media} img, ${media} video, ${media} svg`, {
+  display: 'block',
+  maxWidth: '100%',
+  height: 'auto',
+});
 
 // Card's size scale (`sm`/`md`/`lg`) is the same padding scale Paper already
 // exposes — reuse it directly rather than re-declaring an identical variant map.

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -1,9 +1,12 @@
-import { style, styleVariants, globalStyle } from '@vanilla-extract/css';
+import { style, globalStyle } from '@vanilla-extract/css';
 import { vars } from '../../theme';
+import { typography } from '../Typography/Typography.css';
+import { link } from '../TextLink/TextLink.css';
+import { paddingVariants } from '../Paper/Paper.css';
 
 const {
   theme: {
-    components: { card, paper },
+    components: { card },
     contrast,
   },
 } = vars;
@@ -12,25 +15,39 @@ export const root = style({ display: 'flex', flexDirection: 'column' });
 
 export const rootMediaLeft = style({ flexDirection: 'row' });
 
-// `flex: 1 0 0` only makes sense on the row axis (an even split with `content`,
-// via `rootMediaLeft`) — applied unconditionally it also zeroes the wrapper's
-// height in the default column layout, collapsing real media content.
+// Applied unconditionally so the wrapper doesn't zero out in the default
+// column layout, collapsing real media content.
 export const media = style({ minWidth: 0, minHeight: 0 });
 
-globalStyle(`${rootMediaLeft} > ${media}`, { flex: '1 0 0' });
+// Media content (an `<img>`, or any other element a consumer passes) has no
+// intrinsic constraint of its own — without this, a source image larger than
+// the card overflows both the top (full-width) and left (split-column) layouts.
+globalStyle(`${media} > *`, { display: 'block', maxWidth: '100%', height: 'auto' });
+
+// Card's size scale (`sm`/`md`/`lg`) is the same padding scale Paper already
+// exposes — reuse it directly rather than re-declaring an identical variant map.
+export const contentPaddingVariants = paddingVariants;
 
 export const content = style({
   display: 'flex',
   flexDirection: 'column',
+  // Default (no media, or `top` placement): grow to fill the column's
+  // leftover space. Overridden to `0 0 50%` in the `left` row layout below.
   flex: '1 0 0',
+  minWidth: 0,
   gap: card.spacing,
 });
 
-export const contentPaddingVariants = styleVariants({
-  large: { padding: paper.padding.large },
-  medium: { padding: paper.padding.medium },
-  small: { padding: paper.padding.small },
-});
+// Explicit `50%` rather than an equal `flex-grow` split: with `content`
+// carrying padding and `media` carrying none, growing both from an equal
+// `flex-basis` doesn't actually land them at equal final widths — a
+// `flex-basis: 0`/`0%` target is still a border-box size, so the growth
+// algorithm effectively gives the padded item a head start before growth is
+// distributed. `flex: 0 0 50%` sidesteps that: each side's final width is the
+// fixed value itself, not a computed target, so the split is exact regardless
+// of either side's padding.
+globalStyle(`${rootMediaLeft} > ${media}`, { flex: '0 0 50%' });
+globalStyle(`${rootMediaLeft} > ${content}`, { flex: '0 0 50%' });
 
 export const textBlock = style({
   display: 'flex',
@@ -38,21 +55,26 @@ export const textBlock = style({
   gap: card.textContentSpacing,
 });
 
-// Marker class, toggled on `textBlock` when `background !== 'default'` — no rule of
+// Marker class, toggled on `content` when `background !== 'default'` — no rule of
 // its own, just a hook for the `globalStyle` selector below.
 export const inverted = style({});
 
-// Typography's `h2`/`h3`/`p2` variants (and any Typography a consumer nests inside
-// `children`) set `color` directly on their own class, so a parent-level color
-// doesn't inherit through. `*` inside `textBlock` reaches eyebrow/title *and*
-// arbitrary body content alike, without touching `actions` (a sibling, outside
-// `textBlock` — its own Button styling must never be forced white). Buttons are
-// also excluded here even though `children` can contain them (Card.tsx's own
-// `children` doc says so) — a Button's own color/border pairing must stay intact,
-// only its text-only siblings (Typography, TextLink) should invert. `!important` is
-// needed even with the compound selector, since `.textBlock.inverted *` carries no
-// more specificity than Typography's own single class (`*` contributes none) — same
-// technique DateField already uses for the same class of problem.
-globalStyle(`${textBlock}${inverted} *:not(button):not(button *)`, {
-  color: `${contrast} !important`,
-});
+// Typography's variants and TextLink's link states each set `color` directly on
+// their own class, so a parent-level color doesn't inherit through — each has to
+// be targeted explicitly. This is deliberately an allowlist (Typography + TextLink
+// only), not `*`: a blanket selector would also force-invert any other component a
+// consumer nests in `children`/`actions` (e.g. a `Chip`, which has its own light
+// surface — forcing its label white would make it unreadable against its own
+// background, not the Card's). Covers both `textBlock` (eyebrow/title/body) and
+// `actions`, since a plain-text `actions` slot (e.g. a "read more" TextLink) should
+// invert the same way; a `Button` in either slot is simply never in this list, so
+// its own color/border pairing stays intact without needing an explicit exclusion.
+const invertibleSelectors = [...Object.values(typography), ...Object.values(link)]
+  .map((className) => `${content}${inverted} .${className}`)
+  .join(', ');
+
+// `!important` isn't required to beat Typography/TextLink's own class on
+// specificity (a two-class ancestor selector already outranks their single
+// class), but is kept defensively in case either ever gains a second class
+// (e.g. a `className` override) that would otherwise tie or exceed it.
+globalStyle(invertibleSelectors, { color: `${contrast} !important` });

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -21,17 +21,36 @@ export const rootMediaLeft = style({ flexDirection: 'row' });
 // a fixed `flex: 0 0 50%` column — see below). `overflow: hidden` is a second,
 // independent guard: even a correctly-shrunk wrapper doesn't clip an oversized
 // descendant on its own.
-export const media = style({ minWidth: 0, minHeight: 0, overflow: 'hidden' });
+//
+// `top` placement additionally fixes the wrapper to a 3:2 box (photos'
+// conventional crop ratio) — without it, the wrapper's height is undefined
+// (nothing else in the column layout gives it one) and would collapse to 0 now
+// that the media element itself is sized off the wrapper, not its own intrinsic
+// size (see the `img`/`video`/`svg` rule below). `left` placement doesn't need
+// this: its wrapper already gets a height for free by stretching to match
+// `content`'s row height (default flex align-items: stretch).
+export const media = style({
+  minWidth: 0,
+  minHeight: 0,
+  overflow: 'hidden',
+  aspectRatio: '3 / 2',
+});
+
+globalStyle(`${rootMediaLeft} > ${media}`, { aspectRatio: 'auto' });
 
 // Media content (an `<img>`, or any other element a consumer passes) has no
-// intrinsic constraint of its own — without this, a source image larger than the
-// card overflows both the top (full-width) and left (split-column) layouts. A
-// descendant selector (not `> *`) so the constraint reaches the actual media
-// element even when a consumer wraps it (e.g. `<picture><img/></picture>`).
+// intrinsic constraint of its own — without `width`/`height: 100%`, an image
+// smaller than the wrapper (e.g. a thumbnail narrower than the card) rendered
+// at its own intrinsic size instead of filling the frame, leaving visible gaps
+// beside/below it. `object-fit: cover` crops rather than stretches, so a source
+// image's own aspect ratio never distorts to fit the wrapper's. A descendant
+// selector (not `> *`) so the constraint reaches the actual media element even
+// when a consumer wraps it (e.g. `<picture><img/></picture>`).
 globalStyle(`${media} img, ${media} video, ${media} svg`, {
   display: 'block',
-  maxWidth: '100%',
-  height: 'auto',
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
 });
 
 // Card's size scale (`sm`/`md`/`lg`) is the same padding scale Paper already

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style, styleVariants, globalStyle } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 
 const {
@@ -33,8 +33,16 @@ export const textBlock = style({
   gap: card.textContentSpacing,
 });
 
-// Typography's `h2`/`h3`/`p2` variants set `color` directly on their own class, so a
-// parent-level color doesn't inherit through — this needs to win at equal specificity
-// against Typography's own class, same technique DateField already uses for the same
-// class of problem (see DateField.css.ts's `contrast`-token `!important` overrides).
-export const contrastText = style({ color: `${contrast} !important` });
+// Marker class, toggled on `textBlock` when `background !== 'default'` — no rule of
+// its own, just a hook for the `globalStyle` selector below.
+export const inverted = style({});
+
+// Typography's `h2`/`h3`/`p2` variants (and any Typography a consumer nests inside
+// `children`) set `color` directly on their own class, so a parent-level color
+// doesn't inherit through. `*` inside `textBlock` reaches eyebrow/title *and*
+// arbitrary body content alike, without touching `actions` (a sibling, outside
+// `textBlock` — its own Button styling must never be forced white). `!important` is
+// needed even with the compound selector, since `.textBlock.inverted *` carries no
+// more specificity than Typography's own single class (`*` contributes none) — same
+// technique DateField already uses for the same class of problem.
+globalStyle(`${textBlock}${inverted} *`, { color: `${contrast} !important` });

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -43,8 +43,10 @@ export const media = style({
 // beside/below it. `object-fit: cover` crops rather than stretches, so a source
 // image's own aspect ratio never distorts to fit the wrapper's. A descendant
 // selector (not `> *`) so the constraint reaches the actual media element even
-// when a consumer wraps it (e.g. `<picture><img/></picture>`).
-globalStyle(`${media} img, ${media} video, ${media} svg`, {
+// when a consumer wraps it (e.g. `<picture><img/></picture>`). `iframe`/`canvas`
+// are listed alongside `img`/`video`/`svg` for the same reason — an embedded
+// video (YouTube/Vimeo) or canvas has its own intrinsic/default size too.
+globalStyle(`${media} img, ${media} video, ${media} svg, ${media} iframe, ${media} canvas`, {
   display: 'block',
   width: '100%',
   height: '100%',

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -33,10 +33,8 @@ export const media = style({
   minWidth: 0,
   minHeight: 0,
   overflow: 'hidden',
-  aspectRatio: '3 / 2',
+  aspectRatio: card.mediaAspectRatio,
 });
-
-globalStyle(`${rootMediaLeft} > ${media}`, { aspectRatio: 'auto' });
 
 // Media content (an `<img>`, or any other element a consumer passes) has no
 // intrinsic constraint of its own — without `width`/`height: 100%`, an image
@@ -75,8 +73,11 @@ export const content = style({
 // distributed. `flex: 0 0 50%` sidesteps that: each side's final width is the
 // fixed value itself, not a computed target, so the split is exact regardless
 // of either side's padding.
-globalStyle(`${rootMediaLeft} > ${media}`, { flex: '0 0 50%' });
-globalStyle(`${rootMediaLeft} > ${content}`, { flex: '0 0 50%' });
+globalStyle(`${rootMediaLeft} > ${media}`, {
+  aspectRatio: 'auto',
+  flex: `0 0 ${card.mediaSplit}`,
+});
+globalStyle(`${rootMediaLeft} > ${content}`, { flex: `0 0 ${card.mediaSplit}` });
 
 export const textBlock = style({
   display: 'flex',
@@ -104,15 +105,19 @@ const invertibleSelectors = [...Object.values(typography), ...Object.values(link
 
 // `!important` isn't required to beat Typography/TextLink's own class on
 // specificity (a two-class ancestor selector already outranks their single
-// class), but is kept defensively in case either ever gains a second class
-// (e.g. a `className` override) that would otherwise tie or exceed it.
+// class), but is kept defensively against a same-specificity rule declared
+// later in source order (e.g. a consumer `className` override), which would
+// otherwise win the cascade regardless of specificity.
 globalStyle(invertibleSelectors, { color: `${contrast} !important` });
 
-// The neutral `focusRing` outline (`focus.visible`, #1e1e22) both TextLink and
-// Typography spread for `:focus-visible` fails WCAG's 3:1 non-text-contrast
-// minimum against Card's colored backgrounds (#116) — override just the color
-// (width/offset already match) to the same inverted tone used above, scoped to
-// `:focus-visible` on the same allowlist so it only fires on colored Cards.
+// TextLink is the only one of the two that spreads `focusRing` for
+// `:focus-visible` — Typography elements aren't natively focusable and never
+// match this selector, but it's built from the same allowlist as the color
+// override above for consistency. TextLink's neutral outline (`focus.visible`,
+// #1e1e22) fails WCAG's 3:1 non-text-contrast minimum against Card's colored
+// backgrounds (#116) — override just the color (width/offset already match)
+// to the same inverted tone used above, scoped to `:focus-visible` so it only
+// fires on colored Cards.
 const invertibleFocusSelectors = [...Object.values(typography), ...Object.values(link)]
   .map((className) => `${content}${inverted} .${className}:focus-visible`)
   .join(', ');

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -12,7 +12,12 @@ export const root = style({ display: 'flex', flexDirection: 'column' });
 
 export const rootMediaLeft = style({ flexDirection: 'row' });
 
-export const media = style({ flex: '1 0 0', minWidth: 0, minHeight: 0 });
+// `flex: 1 0 0` only makes sense on the row axis (an even split with `content`,
+// via `rootMediaLeft`) — applied unconditionally it also zeroes the wrapper's
+// height in the default column layout, collapsing real media content.
+export const media = style({ minWidth: 0, minHeight: 0 });
+
+globalStyle(`${rootMediaLeft} > ${media}`, { flex: '1 0 0' });
 
 export const content = style({
   display: 'flex',
@@ -41,8 +46,13 @@ export const inverted = style({});
 // `children`) set `color` directly on their own class, so a parent-level color
 // doesn't inherit through. `*` inside `textBlock` reaches eyebrow/title *and*
 // arbitrary body content alike, without touching `actions` (a sibling, outside
-// `textBlock` — its own Button styling must never be forced white). `!important` is
+// `textBlock` — its own Button styling must never be forced white). Buttons are
+// also excluded here even though `children` can contain them (Card.tsx's own
+// `children` doc says so) — a Button's own color/border pairing must stay intact,
+// only its text-only siblings (Typography, TextLink) should invert. `!important` is
 // needed even with the compound selector, since `.textBlock.inverted *` carries no
 // more specificity than Typography's own single class (`*` contributes none) — same
 // technique DateField already uses for the same class of problem.
-globalStyle(`${textBlock}${inverted} *`, { color: `${contrast} !important` });
+globalStyle(`${textBlock}${inverted} *:not(button):not(button *)`, {
+  color: `${contrast} !important`,
+});

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -87,8 +87,9 @@ export const textBlock = style({
   gap: card.textContentSpacing,
 });
 
-// Marker class, toggled on `content` when `background !== 'default'` — no rule of
-// its own, just a hook for the `globalStyle` selector below.
+// Marker class, toggled on `content` when Card derives `inverted` (see
+// `Card.tsx`) — no rule of its own, just a hook for the `globalStyle`
+// selectors below.
 export const inverted = style({});
 
 // Typography's variants and TextLink's link states each set `color` directly on
@@ -117,7 +118,7 @@ globalStyle(invertibleSelectors, { color: `${contrast} !important` });
 // match this selector, but it's built from the same allowlist as the color
 // override above for consistency. TextLink's neutral outline (`focus.visible`,
 // #1e1e22) fails WCAG's 3:1 non-text-contrast minimum against Card's colored
-// backgrounds (#116) — override just the color (width/offset already match)
+// backgrounds — override just the color (width/offset already match)
 // to the same inverted tone used above, scoped to `:focus-visible` so it only
 // fires on colored Cards.
 const invertibleFocusSelectors = [...Object.values(typography), ...Object.values(link)]

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -1,0 +1,40 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: {
+    components: { card, paper },
+    contrast,
+  },
+} = vars;
+
+export const root = style({ display: 'flex', flexDirection: 'column' });
+
+export const rootMediaLeft = style({ flexDirection: 'row' });
+
+export const media = style({ flex: '1 0 0', minWidth: 0, minHeight: 0 });
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: '1 0 0',
+  gap: card.spacing,
+});
+
+export const contentPaddingVariants = styleVariants({
+  large: { padding: paper.padding.large },
+  medium: { padding: paper.padding.medium },
+  small: { padding: paper.padding.small },
+});
+
+export const textBlock = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: card.textContentSpacing,
+});
+
+// Typography's `h2`/`h3`/`p2` variants set `color` directly on their own class, so a
+// parent-level color doesn't inherit through — this needs to win at equal specificity
+// against Typography's own class, same technique DateField already uses for the same
+// class of problem (see DateField.css.ts's `contrast`-token `!important` overrides).
+export const contrastText = style({ color: `${contrast} !important` });

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -21,6 +21,13 @@ type Story = StoryObj<typeof meta>;
 
 const docExample = ['dev', 'autodocs'];
 
+// A 1x1 GIF has no real intrinsic size, so it can't catch the media wrapper
+// collapsing to 0 height in the default (column) layout — this SVG has real
+// width/height and stands in for a real photo in that regression check.
+const sizedMediaImage = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="260" height="195"><rect width="260" height="195" fill="#ccc"/></svg>'
+)}`;
+
 export const Default: Story = {
   tags: docExample,
   play: async ({ canvasElement }) => {
@@ -49,7 +56,6 @@ export const MediumSize: Story = {
 };
 
 export const SmallSize: Story = {
-  tags: docExample,
   args: { size: 'small' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -58,7 +64,7 @@ export const SmallSize: Story = {
   },
 };
 
-export const MediumPaddingSmallerThanLarge: Story = {
+export const RootHasNoPadding: Story = {
   render: () => (
     <>
       <Card title="Suuri" size="large" data-testid="large" />
@@ -78,6 +84,25 @@ export const MediumPaddingSmallerThanLarge: Story = {
   },
 };
 
+export const PaddingScalesWithSize: Story = {
+  render: () => (
+    <>
+      <Card title="Suuri" size="large" />
+      <Card title="Keskikokoinen" size="medium" />
+      <Card title="Pieni" size="small" />
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [large, medium, small] = canvas
+      .getAllByTestId('card-content')
+      .map((el) => parseFloat(getComputedStyle(el).padding));
+
+    await expect(small).toBeLessThan(medium);
+    await expect(medium).toBeLessThan(large);
+  },
+};
+
 export const WithEyebrow: Story = {
   tags: docExample,
   args: { eyebrow: 'Lisätietoa' },
@@ -90,13 +115,17 @@ export const WithEyebrow: Story = {
 
 export const WithMediaTop: Story = {
   tags: docExample,
-  args: { media: <img alt="" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" /> },
+  args: { media: <img alt="" src={sizedMediaImage} /> },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const media = canvas.getByRole('img');
     const mediaWrapper = media.parentElement as HTMLElement;
 
     await expect(getComputedStyle(mediaWrapper).padding).toBe('0px');
+    // Regression: the wrapper must size to the image, not collapse to 0 height
+    // in the default column layout (only the `left` row layout should split
+    // the wrapper 50/50 with `content` via `flex: 1 0 0`).
+    await expect(mediaWrapper.getBoundingClientRect().height).toBeGreaterThanOrEqual(190);
   },
 };
 
@@ -125,10 +154,12 @@ export const WithActions: Story = {
   },
 };
 
+const handleActionsClick = fn();
+
 export const ActionsRemainClickable: Story = {
   args: {
     actions: (
-      <Button variant="secondary" onClick={fn()}>
+      <Button variant="secondary" onClick={handleActionsClick}>
         Toiminto
       </Button>
     ),
@@ -138,6 +169,7 @@ export const ActionsRemainClickable: Story = {
     const button = canvas.getByRole('button', { name: 'Toiminto' });
 
     await userEvent.click(button);
+    await expect(handleActionsClick).toHaveBeenCalledOnce();
     await expect(button).toHaveFocus();
   },
 };
@@ -161,7 +193,6 @@ export const WithInlineTextLink: Story = {
 };
 
 export const WithExternalTextLink: Story = {
-  tags: docExample,
   args: {
     children: (
       <>
@@ -189,6 +220,21 @@ export const TurquoiseBackgroundTextLinkUsesContrastText: Story = {
     const canvas = within(canvasElement);
 
     await expect(getComputedStyle(canvas.getByRole('link')).color).toBe('rgb(255, 255, 255)');
+  },
+};
+
+export const TurquoiseBackgroundButtonInChildrenKeepsOwnColors: Story = {
+  args: {
+    background: 'turquoise',
+    children: <Button variant="secondary">Toiminto</Button>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Unlike Typography/TextLink, a Button nested in `children` must keep its
+    // own color pairing rather than being force-inverted along with the rest
+    // of the text block — this is the same guarantee `actions` already has.
+    await expect(getComputedStyle(canvas.getByRole('button')).color).not.toBe('rgb(255, 255, 255)');
   },
 };
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -321,6 +321,25 @@ export const TurquoiseBackgroundTextLinkUsesContrastText: Story = {
   },
 };
 
+export const TurquoiseBackgroundTextLinkFocusUsesInvertedOutline: Story = {
+  args: {
+    background: 'turquoise',
+    children: <TextLink href="#">Lue lisää</TextLink>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    await userEvent.tab();
+    await expect(link).toHaveFocus();
+    // The neutral focusRing outline (`focus.visible`, #1e1e22) fails WCAG's
+    // 3:1 non-text contrast minimum against Card's colored backgrounds — must
+    // use the inverted outline color (`focus.visibleInverted`, white) here
+    // instead, the same allowlist-driven inversion `color` already gets (#116).
+    await expect(getComputedStyle(link).outlineColor).toBe('rgb(255, 255, 255)');
+  },
+};
+
 export const TurquoiseBackgroundButtonInChildrenKeepsOwnColors: Story = {
   args: {
     background: 'turquoise',

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within, userEvent } from '@storybook/testing-library';
+import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { Card } from './Card';
 import { Button } from '../Button';
@@ -400,6 +400,45 @@ export const TurquoiseBackgroundUsesContrastText: Story = {
     // this must also flip to contrast color, not just the eyebrow/title Card owns.
     await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
       'rgb(255, 255, 255)'
+    );
+  },
+};
+
+// ── Dev-warning tests (verifies the console.error guards in Card.tsx) ────────
+
+// Captures console.error calls for the dev-warning tests below.
+let capturedConsoleErrors: string[] = [];
+
+const captureConsoleErrors = () => {
+  capturedConsoleErrors = [];
+  const original = console.error;
+  console.error = (...messageArgs: unknown[]) => {
+    capturedConsoleErrors.push(String(messageArgs[0]));
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+export const WarnsOnInvalidSize: Story = {
+  // `as any` simulates a non-TS consumer passing a value outside the
+  // documented union — must warn rather than silently dropping both the
+  // padding and the heading's typography variant entirely.
+  args: { size: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `size` value/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsOnInvalidTitleOrder: Story = {
+  args: { titleOrder: 6 as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `titleOrder` value/.test(m))).toBe(true)
     );
   },
 };

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -3,11 +3,16 @@ import { within, userEvent } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { Card } from './Card';
 import { Button } from '../Button';
+import { Typography } from '../Typography';
 
 const meta = {
   component: Card,
   tags: ['!dev', '!autodocs'],
-  args: { title: 'Otsikko', 'data-testid': 'card' },
+  args: {
+    title: 'Otsikko',
+    'data-testid': 'card',
+    children: <Typography variant="p1">Kuvaava teksti</Typography>,
+  },
 } satisfies Meta<typeof Card>;
 
 export default meta;
@@ -146,5 +151,10 @@ export const TurquoiseBackgroundUsesContrastText: Story = {
       'rgb(255, 255, 255)'
     );
     await expect(getComputedStyle(canvas.getByText('Lisätietoa')).color).toBe('rgb(255, 255, 255)');
+    // `children` is arbitrary consumer content, not something Card renders itself —
+    // this must also flip to contrast color, not just the eyebrow/title Card owns.
+    await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
+      'rgb(255, 255, 255)'
+    );
   },
 };

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -150,9 +150,19 @@ export const WithEyebrow: Story = {
 
 export const WithMediaTop: Story = {
   tags: docExample,
+  // Card fills its parent's width by design (no width cap of its own) — a
+  // realistic single-column width here keeps the 3:2 media block from
+  // stretching to Storybook's full canvas width, matching how Card is
+  // actually placed (a grid cell/column), not a bug in the ratio itself.
+  render: (args) => (
+    <div style={{ width: 600 }}>
+      <Card {...args} />
+    </div>
+  ),
   args: { media: <img alt="" src={sizedMediaImage} /> },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const card = canvas.getByTestId('card');
     const media = canvas.getByRole('img');
     const mediaWrapper = media.parentElement as HTMLElement;
 
@@ -161,6 +171,20 @@ export const WithMediaTop: Story = {
     // in the default column layout (only the `left` row layout splits the
     // wrapper 50/50 with `content`, via `flex: 0 0 50%` on each side).
     await expect(mediaWrapper.getBoundingClientRect().height).toBeGreaterThanOrEqual(190);
+
+    // Regression: the image itself must fill the wrapper's full width, not
+    // sit at its own intrinsic size (the 260px placeholder image is narrower
+    // than the card) — the wrapper div already stretches full-width via flex,
+    // so this has to be checked on the `<img>`, not its wrapper.
+    const cardWidth = card.getBoundingClientRect().width;
+    const mediaImgWidth = media.getBoundingClientRect().width;
+    await expect(Math.abs(mediaImgWidth - cardWidth)).toBeLessThan(2);
+
+    // The `top` frame is a fixed 3:2 box — the image crops to fill it rather
+    // than dictating the box's own height.
+    const mediaHeight = mediaWrapper.getBoundingClientRect().height;
+    await expect(Math.abs(cardWidth / mediaHeight - 1.5)).toBeLessThan(0.05);
+    await expect(getComputedStyle(media).objectFit).toBe('cover');
   },
 };
 
@@ -188,8 +212,15 @@ export const MediaDoesNotOverflowCard: Story = {
 
 export const WithMediaLeft: Story = {
   tags: docExample,
+  // Same rationale as `WithMediaTop` — a realistic row width instead of
+  // Storybook's full canvas width.
+  render: (args) => (
+    <div style={{ width: 1200 }}>
+      <Card {...args} />
+    </div>
+  ),
   args: {
-    media: <img alt="" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" />,
+    media: <img alt="" src={sizedMediaImage} />,
     mediaPlacement: 'left',
   },
   play: async ({ canvasElement }) => {
@@ -220,6 +251,16 @@ export const WithMediaLeftSplitsWidthEvenly: Story = {
     const mediaWidth = mediaWrapper.getBoundingClientRect().width;
     const contentWidth = content.getBoundingClientRect().width;
     await expect(Math.abs(mediaWidth - contentWidth)).toBeLessThan(2);
+
+    // `left` placement has no fixed aspect ratio (unlike `top`) — the media
+    // column instead stretches to match `content`'s height (default flex-row
+    // stretch), and the cropped image must fill that box exactly on both axes.
+    const mediaHeight = mediaWrapper.getBoundingClientRect().height;
+    const contentHeight = content.getBoundingClientRect().height;
+    await expect(Math.abs(mediaHeight - contentHeight)).toBeLessThan(2);
+    await expect(Math.abs(media.getBoundingClientRect().width - mediaWidth)).toBeLessThan(2);
+    await expect(Math.abs(media.getBoundingClientRect().height - mediaHeight)).toBeLessThan(2);
+    await expect(getComputedStyle(media).objectFit).toBe('cover');
   },
 };
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -158,8 +158,8 @@ export const WithMediaTop: Story = {
 
     await expect(getComputedStyle(mediaWrapper).padding).toBe('0px');
     // Regression: the wrapper must size to the image, not collapse to 0 height
-    // in the default column layout (only the `left` row layout should split
-    // the wrapper 50/50 with `content` via `flex: 1 0 0`).
+    // in the default column layout (only the `left` row layout splits the
+    // wrapper 50/50 with `content`, via `flex: 0 0 50%` on each side).
     await expect(mediaWrapper.getBoundingClientRect().height).toBeGreaterThanOrEqual(190);
   },
 };
@@ -215,11 +215,22 @@ export const WithMediaLeftSplitsWidthEvenly: Story = {
     const mediaWrapper = media.parentElement as HTMLElement;
     const content = canvas.getByTestId('card-content');
 
-    // Regression: `flex: 1 0 0` on the media wrapper should split the row
+    // Regression: `flex: 0 0 50%` on the media wrapper should split the row
     // ~50/50 with `content`, not let the (constrained) image size the column.
     const mediaWidth = mediaWrapper.getBoundingClientRect().width;
     const contentWidth = content.getBoundingClientRect().width;
     await expect(Math.abs(mediaWidth - contentWidth)).toBeLessThan(2);
+  },
+};
+
+export const MediaPlacementLeftIgnoredWithoutMedia: Story = {
+  args: { mediaPlacement: 'left' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Documented as "ignored when `media` is omitted" — must stay in the
+    // default column layout, not switch to the row layout with no media to show.
+    await expect(getComputedStyle(canvas.getByTestId('card')).flexDirection).toBe('column');
   },
 };
 
@@ -270,6 +281,12 @@ export const WithInlineTextLink: Story = {
     const link = canvas.getByRole('link', { name: 'Lue lisää' });
 
     await expect(link).toHaveAttribute('href', '#');
+
+    // Card has no onClick of its own — a TextLink in `children` must stay
+    // independently focusable, the same guarantee `WithActions` already
+    // covers for a nested Button.
+    await userEvent.tab();
+    await expect(link).toHaveFocus();
   },
 };
 
@@ -337,6 +354,21 @@ export const TurquoiseBackgroundChipInChildrenKeepsOwnColors: Story = {
     await expect(getComputedStyle(canvas.getByText('Suodatin')).color).not.toBe(
       'rgb(255, 255, 255)'
     );
+  },
+};
+
+export const TurquoiseBackgroundButtonInActionsKeepsOwnColors: Story = {
+  args: {
+    background: 'turquoise',
+    actions: <Button variant="secondary">Toiminto</Button>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Same guarantee as `TurquoiseBackgroundButtonInChildrenKeepsOwnColors`,
+    // but for the `actions` slot — the inversion allowlist excludes Button
+    // regardless of which slot it's nested in.
+    await expect(getComputedStyle(canvas.getByRole('button')).color).not.toBe('rgb(255, 255, 255)');
   },
 };
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -376,7 +376,7 @@ export const TurquoiseBackgroundTextLinkFocusUsesInvertedOutline: Story = {
     // The neutral focusRing outline (`focus.visible`, #1e1e22) fails WCAG's
     // 3:1 non-text contrast minimum against Card's colored backgrounds — must
     // use the inverted outline color (`focus.visibleInverted`, white) here
-    // instead, the same allowlist-driven inversion `color` already gets (#116).
+    // instead, the same allowlist-driven inversion `color` already gets.
     await expect(getComputedStyle(link).outlineColor).toBe('rgb(255, 255, 255)');
   },
 };
@@ -395,8 +395,8 @@ export const TurquoiseBackgroundButtonInChildrenKeepsOwnColors: Story = {
     // Asserted against the concrete `states.default` value (not just
     // `.not.toBe(white)`) so this can't silently pass for any wrong color —
     // see the constraint documented on `CardProps['background']`: this pairing
-    // is known to fail contrast on colored backgrounds until #115 ships an
-    // inverted Button variant.
+    // is known to fail contrast on colored backgrounds until Button ships an
+    // inverted variant.
     await expect(getComputedStyle(canvas.getByRole('button')).color).toBe('rgb(41, 84, 154)');
   },
 };
@@ -433,7 +433,7 @@ export const TurquoiseBackgroundButtonInActionsKeepsOwnColors: Story = {
     // Same guarantee as `TurquoiseBackgroundButtonInChildrenKeepsOwnColors`,
     // but for the `actions` slot — the inversion allowlist excludes Button
     // regardless of which slot it's nested in. Same concrete-value assertion
-    // for the same reason (see that story's comment, and #115).
+    // for the same reason (see that story's comment).
     await expect(getComputedStyle(canvas.getByRole('button')).color).toBe('rgb(41, 84, 154)');
   },
 };
@@ -466,6 +466,23 @@ export const TurquoiseBackgroundUsesContrastText: Story = {
     // this must also flip to contrast color, not just the eyebrow/title Card owns.
     await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
       'rgb(255, 255, 255)'
+    );
+  },
+};
+
+export const InvalidBackgroundDegradesToNonInvertedText: Story = {
+  // Paper's own guard warns on this (console.error, not asserted here — see
+  // Paper.stories.tsx's `WarnsOnInvalidBackground`) but still renders with no
+  // background color applied, leaving a white surface. Regression: Card's
+  // `inverted` derivation must key off membership in `backgroundVariants`, not
+  // a blanket `!== 'default'` check, or title/body text would force-invert to
+  // white against that white surface and become unreadable.
+  args: { background: 'invalid' as never },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByRole('heading', { name: 'Otsikko' })).color).toBe(
+      'rgb(30, 30, 34)'
     );
   },
 };

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -4,6 +4,7 @@ import { expect, fn } from 'storybook/test';
 import { Card } from './Card';
 import { Button } from '../Button';
 import { Typography } from '../Typography';
+import { TextLink } from '../TextLink';
 
 const meta = {
   component: Card,
@@ -138,6 +139,56 @@ export const ActionsRemainClickable: Story = {
 
     await userEvent.click(button);
     await expect(button).toHaveFocus();
+  },
+};
+
+export const WithInlineTextLink: Story = {
+  tags: docExample,
+  args: {
+    children: (
+      <>
+        <Typography variant="p1">Kuvaava teksti</Typography>
+        <TextLink href="#">Lue lisää</TextLink>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Lue lisää' });
+
+    await expect(link).toHaveAttribute('href', '#');
+  },
+};
+
+export const WithExternalTextLink: Story = {
+  tags: docExample,
+  args: {
+    children: (
+      <>
+        <Typography variant="p1">Kuvaava teksti</Typography>
+        <TextLink href="https://tampere.fi" openExternal>
+          Tampereen verkkosivut
+        </TextLink>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    await expect(link).toHaveAttribute('target', '_blank');
+  },
+};
+
+export const TurquoiseBackgroundTextLinkUsesContrastText: Story = {
+  args: {
+    background: 'turquoise',
+    children: <TextLink href="#">Lue lisää</TextLink>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByRole('link')).color).toBe('rgb(255, 255, 255)');
   },
 };
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -508,3 +508,30 @@ export const WarnsOnInvalidTitleOrder: Story = {
     );
   },
 };
+
+export const WarnsOnInvalidMediaPlacement: Story = {
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `mediaPlacement` value/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const FixedSurfacePropsCannotBeOverridden: Story = {
+  // Simulates a non-TS consumer passing one of Card's fixed Paper props through
+  // (`CardProps` doesn't declare them, so a typed caller can't) — Card's own
+  // `radius`/`withShadow`/`padding` must still win, since Card's whole surface
+  // contract (edge-to-edge media, no visible border) depends on them.
+  args: { radius: 'pill', withShadow: false, padding: 'lg' } as never,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByTestId('card');
+    const style = getComputedStyle(card);
+
+    await expect(style.borderRadius).toBe('0px');
+    await expect(style.boxShadow).not.toBe('none');
+    await expect(style.padding).toBe('0px');
+  },
+};

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -5,6 +5,7 @@ import { Card } from './Card';
 import { Button } from '../Button';
 import { Typography } from '../Typography';
 import { TextLink } from '../TextLink';
+import { Chip } from '../Chip';
 
 const meta = {
   component: Card,
@@ -47,7 +48,7 @@ export const Default: Story = {
 
 export const MediumSize: Story = {
   tags: docExample,
-  args: { size: 'medium' },
+  args: { size: 'md' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -56,7 +57,7 @@ export const MediumSize: Story = {
 };
 
 export const SmallSize: Story = {
-  args: { size: 'small' },
+  args: { size: 'sm' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -67,8 +68,8 @@ export const SmallSize: Story = {
 export const RootHasNoPadding: Story = {
   render: () => (
     <>
-      <Card title="Suuri" size="large" data-testid="large" />
-      <Card title="Pieni" size="small" data-testid="small" />
+      <Card title="Suuri" size="lg" data-testid="large" />
+      <Card title="Pieni" size="sm" data-testid="small" />
     </>
   ),
   play: async ({ canvasElement }) => {
@@ -87,19 +88,53 @@ export const RootHasNoPadding: Story = {
 export const PaddingScalesWithSize: Story = {
   render: () => (
     <>
-      <Card title="Suuri" size="large" />
-      <Card title="Keskikokoinen" size="medium" />
-      <Card title="Pieni" size="small" />
+      <Card title="Suuri" size="lg" data-testid="lg" />
+      <Card title="Keskikokoinen" size="md" data-testid="md" />
+      <Card title="Pieni" size="sm" data-testid="sm" />
     </>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const [large, medium, small] = canvas
-      .getAllByTestId('card-content')
-      .map((el) => parseFloat(getComputedStyle(el).padding));
+    const large = parseFloat(getComputedStyle(canvas.getByTestId('lg-content')).padding);
+    const medium = parseFloat(getComputedStyle(canvas.getByTestId('md-content')).padding);
+    const small = parseFloat(getComputedStyle(canvas.getByTestId('sm-content')).padding);
 
     await expect(small).toBeLessThan(medium);
     await expect(medium).toBeLessThan(large);
+  },
+};
+
+export const WithCustomClassName: Story = {
+  args: { className: 'consumer-custom-class' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('card').className).toContain('consumer-custom-class');
+  },
+};
+
+export const WithTitleOrderOverride: Story = {
+  args: { size: 'lg', titleOrder: 4 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // `size="lg"` defaults to H2 — an explicit `titleOrder` must win, so a Card
+    // nested under an existing heading level isn't forced to emit a second H2.
+    await expect(canvas.getByRole('heading', { name: 'Otsikko' }).tagName).toBe('H4');
+  },
+};
+
+export const RootHasNoInteractiveAffordance: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByTestId('card');
+
+    // Card is a static container — it must never itself become clickable or
+    // focusable, so nested interactive elements (in `actions`/`children`)
+    // stay the only way to interact with it.
+    await expect(card).not.toHaveAttribute('tabindex');
+    await expect(card.getAttribute('role')).not.toBe('button');
+    await expect(card.onclick).toBeNull();
   },
 };
 
@@ -129,6 +164,28 @@ export const WithMediaTop: Story = {
   },
 };
 
+const oversizedMediaImage = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="900" height="300"><rect width="900" height="300" fill="#ccc"/></svg>'
+)}`;
+
+export const MediaDoesNotOverflowCard: Story = {
+  render: (args) => (
+    <div style={{ width: 320 }}>
+      <Card {...args} />
+    </div>
+  ),
+  args: { media: <img alt="" src={oversizedMediaImage} /> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByTestId('card');
+    const media = canvas.getByRole('img');
+
+    await expect(media.getBoundingClientRect().width).toBeLessThanOrEqual(
+      card.getBoundingClientRect().width
+    );
+  },
+};
+
 export const WithMediaLeft: Story = {
   tags: docExample,
   args: {
@@ -139,6 +196,30 @@ export const WithMediaLeft: Story = {
     const canvas = within(canvasElement);
 
     await expect(getComputedStyle(canvas.getByTestId('card')).flexDirection).toBe('row');
+  },
+};
+
+export const WithMediaLeftSplitsWidthEvenly: Story = {
+  render: (args) => (
+    <div style={{ width: 640 }}>
+      <Card {...args} />
+    </div>
+  ),
+  args: {
+    media: <img alt="" src={oversizedMediaImage} />,
+    mediaPlacement: 'left',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const media = canvas.getByRole('img');
+    const mediaWrapper = media.parentElement as HTMLElement;
+    const content = canvas.getByTestId('card-content');
+
+    // Regression: `flex: 1 0 0` on the media wrapper should split the row
+    // ~50/50 with `content`, not let the (constrained) image size the column.
+    const mediaWidth = mediaWrapper.getBoundingClientRect().width;
+    const contentWidth = content.getBoundingClientRect().width;
+    await expect(Math.abs(mediaWidth - contentWidth)).toBeLessThan(2);
   },
 };
 
@@ -235,6 +316,41 @@ export const TurquoiseBackgroundButtonInChildrenKeepsOwnColors: Story = {
     // own color pairing rather than being force-inverted along with the rest
     // of the text block — this is the same guarantee `actions` already has.
     await expect(getComputedStyle(canvas.getByRole('button')).color).not.toBe('rgb(255, 255, 255)');
+  },
+};
+
+export const TurquoiseBackgroundChipInChildrenKeepsOwnColors: Story = {
+  args: {
+    background: 'turquoise',
+    children: (
+      <Chip checked={false} onChange={() => {}}>
+        Suodatin
+      </Chip>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Like Button, Chip has its own light surface — force-inverting its text
+    // to white would make it unreadable against its own background, not the
+    // Card's. Only Card's own text content (Typography/TextLink) should invert.
+    await expect(getComputedStyle(canvas.getByText('Suodatin')).color).not.toBe(
+      'rgb(255, 255, 255)'
+    );
+  },
+};
+
+export const TurquoiseBackgroundActionsTextLinkInverts: Story = {
+  args: {
+    background: 'turquoise',
+    actions: <TextLink href="#">Lue lisää</TextLink>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Unlike Button, a TextLink in `actions` has no independent surface of its
+    // own — it should invert the same way one nested in `children` already does.
+    await expect(getComputedStyle(canvas.getByRole('link')).color).toBe('rgb(255, 255, 255)');
   },
 };
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, userEvent } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { Card } from './Card';
+import { Button } from '../Button';
 
 const meta = {
   component: Card,
@@ -108,7 +109,7 @@ export const WithMediaLeft: Story = {
 
 export const WithActions: Story = {
   tags: docExample,
-  args: { actions: <button type="button">Lue lisää</button> },
+  args: { actions: <Button variant="secondary">Lue lisää</Button> },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: 'Lue lisää' });
@@ -121,9 +122,9 @@ export const WithActions: Story = {
 export const ActionsRemainClickable: Story = {
   args: {
     actions: (
-      <button type="button" onClick={fn()}>
+      <Button variant="secondary" onClick={fn()}>
         Toiminto
-      </button>
+      </Button>
     ),
   },
   play: async ({ canvasElement }) => {

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect, fn } from 'storybook/test';
+import { Card } from './Card';
+
+const meta = {
+  component: Card,
+  tags: ['!dev', '!autodocs'],
+  args: { title: 'Otsikko', 'data-testid': 'card' },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const docExample = ['dev', 'autodocs'];
+
+export const Default: Story = {
+  tags: docExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByRole('heading', { name: 'Otsikko' });
+
+    await expect(title.tagName).toBe('H2');
+    await expect(getComputedStyle(title).color).toBe('rgb(30, 30, 34)');
+
+    const card = canvas.getByTestId('card');
+    const cardStyle = getComputedStyle(card);
+    await expect(cardStyle.boxShadow).not.toBe('none');
+    await expect(cardStyle.borderStyle).toBe('none');
+    await expect(cardStyle.padding).toBe('0px');
+  },
+};
+
+export const MediumSize: Story = {
+  tags: docExample,
+  args: { size: 'medium' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Otsikko' }).tagName).toBe('H3');
+  },
+};
+
+export const SmallSize: Story = {
+  tags: docExample,
+  args: { size: 'small' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Otsikko' }).tagName).toBe('H3');
+  },
+};
+
+export const MediumPaddingSmallerThanLarge: Story = {
+  render: () => (
+    <>
+      <Card title="Suuri" size="large" data-testid="large" />
+      <Card title="Pieni" size="small" data-testid="small" />
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const large = parseFloat(getComputedStyle(canvas.getByTestId('large')).padding);
+    const small = parseFloat(getComputedStyle(canvas.getByTestId('small')).padding);
+
+    // Card itself never carries padding (Paper's root stays `padding="none"` so
+    // media can bleed to the edge) — the size-driven padding lives on the inner
+    // content wrapper instead, so both should read 0px on the root.
+    await expect(large).toBe(0);
+    await expect(small).toBe(0);
+  },
+};
+
+export const WithEyebrow: Story = {
+  tags: docExample,
+  args: { eyebrow: 'Lisätietoa' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Lisätietoa')).not.toBeNull();
+  },
+};
+
+export const WithMediaTop: Story = {
+  tags: docExample,
+  args: { media: <img alt="" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" /> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const media = canvas.getByRole('img');
+    const mediaWrapper = media.parentElement as HTMLElement;
+
+    await expect(getComputedStyle(mediaWrapper).padding).toBe('0px');
+  },
+};
+
+export const WithMediaLeft: Story = {
+  tags: docExample,
+  args: {
+    media: <img alt="" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" />,
+    mediaPlacement: 'left',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('card')).flexDirection).toBe('row');
+  },
+};
+
+export const WithActions: Story = {
+  tags: docExample,
+  args: { actions: <button type="button">Lue lisää</button> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Lue lisää' });
+
+    await userEvent.tab();
+    await expect(button).toHaveFocus();
+  },
+};
+
+export const ActionsRemainClickable: Story = {
+  args: {
+    actions: (
+      <button type="button" onClick={fn()}>
+        Toiminto
+      </button>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Toiminto' });
+
+    await userEvent.click(button);
+    await expect(button).toHaveFocus();
+  },
+};
+
+export const TurquoiseBackgroundUsesContrastText: Story = {
+  tags: docExample,
+  args: { background: 'turquoise', eyebrow: 'Lisätietoa' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByRole('heading', { name: 'Otsikko' })).color).toBe(
+      'rgb(255, 255, 255)'
+    );
+    await expect(getComputedStyle(canvas.getByText('Lisätietoa')).color).toBe('rgb(255, 255, 255)');
+  },
+};

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -332,7 +332,12 @@ export const TurquoiseBackgroundButtonInChildrenKeepsOwnColors: Story = {
     // Unlike Typography/TextLink, a Button nested in `children` must keep its
     // own color pairing rather than being force-inverted along with the rest
     // of the text block — this is the same guarantee `actions` already has.
-    await expect(getComputedStyle(canvas.getByRole('button')).color).not.toBe('rgb(255, 255, 255)');
+    // Asserted against the concrete `states.default` value (not just
+    // `.not.toBe(white)`) so this can't silently pass for any wrong color —
+    // see the constraint documented on `CardProps['background']`: this pairing
+    // is known to fail contrast on colored backgrounds until #115 ships an
+    // inverted Button variant.
+    await expect(getComputedStyle(canvas.getByRole('button')).color).toBe('rgb(41, 84, 154)');
   },
 };
 
@@ -367,8 +372,9 @@ export const TurquoiseBackgroundButtonInActionsKeepsOwnColors: Story = {
 
     // Same guarantee as `TurquoiseBackgroundButtonInChildrenKeepsOwnColors`,
     // but for the `actions` slot — the inversion allowlist excludes Button
-    // regardless of which slot it's nested in.
-    await expect(getComputedStyle(canvas.getByRole('button')).color).not.toBe('rgb(255, 255, 255)');
+    // regardless of which slot it's nested in. Same concrete-value assertion
+    // for the same reason (see that story's comment, and #115).
+    await expect(getComputedStyle(canvas.getByRole('button')).color).toBe('rgb(41, 84, 154)');
   },
 };
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -15,6 +15,15 @@ import {
 export interface CardProps extends React.AriaAttributes {
   /** `'lg'` → H2 heading + Paper's `lg` padding. `'md'`/`'sm'` → H3 heading + matching padding. */
   size?: 'lg' | 'md' | 'sm';
+  /**
+   * A non-`'default'` background inverts Card's own text (Typography/TextLink)
+   * to a readable contrast color, but nested components with their own light
+   * surface — e.g. `Button`, `Chip` — deliberately keep their own colors (see
+   * `Card.css.ts`'s `invertibleSelectors`) rather than being force-inverted.
+   * That pairing isn't contrast-checked against colored backgrounds yet, so a
+   * `Button` in `children`/`actions` can be unreadable there — keep non-default
+   * backgrounds to text-only content until #115 adds an inverted Button variant.
+   */
   background?: PaperProps['background'];
   media?: ReactNode;
   /** Ignored when `media` is omitted. Default `'top'`. */

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, type ReactNode } from 'react';
 import cx from 'clsx';
-import { Paper, type PaperProps } from '../Paper';
+import { Paper, type PaperProps, type SurfacePrimitiveProps } from '../Paper';
 import { backgroundVariants } from '../Paper/Paper.css';
 import { Typography } from '../Typography';
 import {
@@ -13,7 +13,7 @@ import {
   inverted as invertedMarker,
 } from './Card.css';
 
-export interface CardProps extends React.AriaAttributes {
+export interface CardProps extends SurfacePrimitiveProps {
   /** `'lg'` → H2 heading + Paper's `lg` padding. `'md'`/`'sm'` → H3 heading + matching padding. */
   size?: 'lg' | 'md' | 'sm';
   /**
@@ -49,11 +49,6 @@ export interface CardProps extends React.AriaAttributes {
   /** Body content between the title and `actions` — text, Buttons, other components. */
   children?: ReactNode;
   className?: string;
-  id?: string;
-  role?: string;
-  /** Polymorphic root element, e.g. `component="article"`. */
-  component?: React.ElementType;
-  'data-testid'?: string;
 }
 
 const headingVariant = { lg: 'h2', md: 'h3', sm: 'h3' } as const;
@@ -97,7 +92,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     // heading style and the heading element), `mediaPlacement` silently falls back
     // to the `top` layout, and `titleOrder` silently stops overriding the heading
     // level. `background` isn't checked here — Paper already guards it, and Card
-    // just forwards the value (though Card's own `inverted` derivation below
+    // just forwards the value (though Card's own `inverted` derivation above
     // degrades safely for an invalid value regardless).
     useEffect(() => {
       if (process.env.NODE_ENV === 'production') return;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -13,37 +13,52 @@ import {
 } from './Card.css';
 
 export interface CardProps {
-  /** `'large'` → H2 heading + Paper's `large` padding. `'medium'`/`'small'` → H3 heading + matching padding. */
-  size?: 'large' | 'medium' | 'small';
+  /** `'lg'` → H2 heading + Paper's `lg` padding. `'md'`/`'sm'` → H3 heading + matching padding. */
+  size?: 'lg' | 'md' | 'sm';
   background?: PaperProps['background'];
   media?: ReactNode;
   /** Ignored when `media` is omitted. Default `'top'`. */
   mediaPlacement?: 'top' | 'left';
   title: string;
+  /**
+   * Overrides `size`'s default heading level (`lg`→2, `md`/`sm`→3) — e.g. for a
+   * Card nested under an existing heading, so it doesn't emit a second H2.
+   */
+  titleOrder?: 2 | 3 | 4 | 5;
   /** Optional small text above the title. */
   eyebrow?: string;
   /** Optional slot rendered after the body content. */
   actions?: ReactNode;
   /** Body content between the title and `actions` — text, Buttons, other components. */
   children?: ReactNode;
+  className?: string;
   'data-testid'?: string;
 }
 
-const headingVariant = { large: 'h2', medium: 'h3', small: 'h3' } as const;
+const headingVariant = { lg: 'h2', md: 'h3', sm: 'h3' } as const;
+const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
 
 /** A static content tile. Not itself a link — nested interactive elements (in `actions`/`children`) stay independently focusable. */
 export function Card({
-  size = 'large',
+  size = 'lg',
   background = 'default',
   media,
   mediaPlacement = 'top',
   title,
+  titleOrder,
   eyebrow,
   actions,
   children,
+  className,
   ...props
 }: CardProps) {
+  // Assumes every non-default background is dark enough to need contrast text.
+  // Holds for today's three (turquoise/blue/pink) — revisit if `red`/`yellow`/
+  // `green` are ever added to `PaperProps['background']` (see Paper.tsx), since
+  // a light one would need this to key off a per-background contrast token
+  // instead of a blanket `!== 'default'` check.
   const inverted = background !== 'default';
+  const contentTestId = props['data-testid'] && `${props['data-testid']}-content`;
 
   return (
     <Paper
@@ -51,14 +66,22 @@ export function Card({
       radius="sharp"
       withShadow
       padding="none"
-      className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft)}
+      className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft, className)}
       {...props}
     >
       {media && <div className={mediaClass}>{media}</div>}
-      <div className={cx(content, contentPaddingVariants[size])} data-testid="card-content">
-        <div className={cx(textBlock, inverted && invertedMarker)}>
+      <div
+        className={cx(content, contentPaddingVariants[size], inverted && invertedMarker)}
+        data-testid={contentTestId}
+      >
+        <div className={textBlock}>
           {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
-          <Typography variant={headingVariant[size]}>{title}</Typography>
+          <Typography
+            variant={headingVariant[size]}
+            component={titleOrder ? titleComponent[titleOrder] : undefined}
+          >
+            {title}
+          </Typography>
           {children}
         </div>
         {actions}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -27,6 +27,12 @@ export interface CardProps extends React.AriaAttributes {
    * inverted variant.
    */
   background?: PaperProps['background'];
+  /**
+   * Rendered in a fixed 3:2 frame (`top` placement) or a 50/50 column (`left`
+   * placement), cropped with `object-fit: cover` so its own aspect ratio never
+   * distorts to fit — an `<img>`, `<video>`, `<svg>`, `<iframe>`/`<canvas>`
+   * embed, or a wrapped element (e.g. `<picture><img/></picture>`).
+   */
   media?: ReactNode;
   /** Ignored when `media` is omitted. Default `'top'`. */
   mediaPlacement?: 'top' | 'left';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,7 +9,7 @@ import {
   content,
   contentPaddingVariants,
   textBlock,
-  contrastText,
+  inverted as invertedMarker,
 } from './Card.css';
 
 export interface CardProps {
@@ -56,18 +56,9 @@ export function Card({
     >
       {media && <div className={mediaClass}>{media}</div>}
       <div className={cx(content, contentPaddingVariants[size])}>
-        <div className={textBlock}>
-          {eyebrow && (
-            <Typography variant="p2" className={inverted ? contrastText : undefined}>
-              {eyebrow}
-            </Typography>
-          )}
-          <Typography
-            variant={headingVariant[size]}
-            className={inverted ? contrastText : undefined}
-          >
-            {title}
-          </Typography>
+        <div className={cx(textBlock, inverted && invertedMarker)}>
+          {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+          <Typography variant={headingVariant[size]}>{title}</Typography>
           {children}
         </div>
         {actions}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -55,7 +55,7 @@ export function Card({
       {...props}
     >
       {media && <div className={mediaClass}>{media}</div>}
-      <div className={cx(content, contentPaddingVariants[size])}>
+      <div className={cx(content, contentPaddingVariants[size])} data-testid="card-content">
         <div className={cx(textBlock, inverted && invertedMarker)}>
           {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
           <Typography variant={headingVariant[size]}>{title}</Typography>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 import cx from 'clsx';
 import { Paper, type PaperProps } from '../Paper';
 import { Typography } from '../Typography';
@@ -12,7 +12,7 @@ import {
   inverted as invertedMarker,
 } from './Card.css';
 
-export interface CardProps {
+export interface CardProps extends React.AriaAttributes {
   /** `'lg'` → H2 heading + Paper's `lg` padding. `'md'`/`'sm'` → H3 heading + matching padding. */
   size?: 'lg' | 'md' | 'sm';
   background?: PaperProps['background'];
@@ -32,6 +32,10 @@ export interface CardProps {
   /** Body content between the title and `actions` — text, Buttons, other components. */
   children?: ReactNode;
   className?: string;
+  id?: string;
+  role?: string;
+  /** Polymorphic root element, e.g. `component="article"`. */
+  component?: React.ElementType;
   'data-testid'?: string;
 }
 
@@ -39,53 +43,61 @@ const headingVariant = { lg: 'h2', md: 'h3', sm: 'h3' } as const;
 const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
 
 /** A static content tile. Not itself a link — nested interactive elements (in `actions`/`children`) stay independently focusable. */
-export function Card({
-  size = 'lg',
-  background = 'default',
-  media,
-  mediaPlacement = 'top',
-  title,
-  titleOrder,
-  eyebrow,
-  actions,
-  children,
-  className,
-  ...props
-}: CardProps) {
-  // Assumes every non-default background is dark enough to need contrast text.
-  // Holds for today's three (turquoise/blue/pink) — revisit if `red`/`yellow`/
-  // `green` are ever added to `PaperProps['background']` (see Paper.tsx), since
-  // a light one would need this to key off a per-background contrast token
-  // instead of a blanket `!== 'default'` check.
-  const inverted = background !== 'default';
-  const contentTestId = props['data-testid'] && `${props['data-testid']}-content`;
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  (
+    {
+      size = 'lg',
+      background = 'default',
+      media,
+      mediaPlacement = 'top',
+      title,
+      titleOrder,
+      eyebrow,
+      actions,
+      children,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    // Assumes every non-default background is dark enough to need contrast text.
+    // Holds for today's three (turquoise/blue/pink) — revisit if `red`/`yellow`/
+    // `green` are ever added to `PaperProps['background']` (see Paper.tsx), since
+    // a light one would need this to key off a per-background contrast token
+    // instead of a blanket `!== 'default'` check.
+    const inverted = background !== 'default';
+    const contentTestId = props['data-testid'] && `${props['data-testid']}-content`;
 
-  return (
-    <Paper
-      background={background}
-      radius="sharp"
-      withShadow
-      padding="none"
-      className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft, className)}
-      {...props}
-    >
-      {media && <div className={mediaClass}>{media}</div>}
-      <div
-        className={cx(content, contentPaddingVariants[size], inverted && invertedMarker)}
-        data-testid={contentTestId}
+    return (
+      <Paper
+        ref={ref}
+        background={background}
+        radius="sharp"
+        withShadow
+        padding="none"
+        {...props}
+        className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft, className)}
       >
-        <div className={textBlock}>
-          {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
-          <Typography
-            variant={headingVariant[size]}
-            component={titleOrder ? titleComponent[titleOrder] : undefined}
-          >
-            {title}
-          </Typography>
-          {children}
+        {media && <div className={mediaClass}>{media}</div>}
+        <div
+          className={cx(content, contentPaddingVariants[size], inverted && invertedMarker)}
+          data-testid={contentTestId}
+        >
+          <div className={textBlock}>
+            {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+            <Typography
+              variant={headingVariant[size]}
+              component={titleOrder ? titleComponent[titleOrder] : undefined}
+            >
+              {title}
+            </Typography>
+            {children}
+          </div>
+          {actions}
         </div>
-        {actions}
-      </div>
-    </Paper>
-  );
-}
+      </Paper>
+    );
+  }
+);
+
+Card.displayName = 'Card';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ReactNode } from 'react';
+import { forwardRef, useEffect, type ReactNode } from 'react';
 import cx from 'clsx';
 import { Paper, type PaperProps } from '../Paper';
 import { Typography } from '../Typography';
@@ -67,6 +67,22 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     // instead of a blanket `!== 'default'` check.
     const inverted = background !== 'default';
     const contentTestId = props['data-testid'] && `${props['data-testid']}-content`;
+
+    // Dev-only guard: an out-of-union `size`/`titleOrder` silently resolves to
+    // `undefined` in the lookups below — `size` drops padding *and* falls back to
+    // Typography's default variant entirely (no heading style at all), and
+    // `titleOrder` silently stops overriding the heading level. `background` isn't
+    // checked here — Paper already guards it, and Card just forwards the value.
+    useEffect(() => {
+      if (process.env.NODE_ENV === 'production') return;
+
+      if (!(size in headingVariant)) {
+        console.error(`Card: invalid \`size\` value "${size}".`);
+      }
+      if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
+        console.error(`Card: invalid \`titleOrder\` value "${titleOrder}".`);
+      }
+    }, [size, titleOrder]);
 
     return (
       <Paper

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react';
+import cx from 'clsx';
+import { Paper, type PaperProps } from '../Paper';
+import { Typography } from '../Typography';
+import {
+  root,
+  rootMediaLeft,
+  media as mediaClass,
+  content,
+  contentPaddingVariants,
+  textBlock,
+  contrastText,
+} from './Card.css';
+
+export interface CardProps {
+  /** `'large'` → H2 heading + Paper's `large` padding. `'medium'`/`'small'` → H3 heading + matching padding. */
+  size?: 'large' | 'medium' | 'small';
+  background?: PaperProps['background'];
+  media?: ReactNode;
+  /** Ignored when `media` is omitted. Default `'top'`. */
+  mediaPlacement?: 'top' | 'left';
+  title: string;
+  /** Optional small text above the title. */
+  eyebrow?: string;
+  /** Optional slot rendered after the body content. */
+  actions?: ReactNode;
+  /** Body content between the title and `actions` — text, Buttons, other components. */
+  children?: ReactNode;
+  'data-testid'?: string;
+}
+
+const headingVariant = { large: 'h2', medium: 'h3', small: 'h3' } as const;
+
+/** A static content tile. Not itself a link — nested interactive elements (in `actions`/`children`) stay independently focusable. */
+export function Card({
+  size = 'large',
+  background = 'default',
+  media,
+  mediaPlacement = 'top',
+  title,
+  eyebrow,
+  actions,
+  children,
+  ...props
+}: CardProps) {
+  const inverted = background !== 'default';
+
+  return (
+    <Paper
+      background={background}
+      radius="sharp"
+      withShadow
+      padding="none"
+      className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft)}
+      {...props}
+    >
+      {media && <div className={mediaClass}>{media}</div>}
+      <div className={cx(content, contentPaddingVariants[size])}>
+        <div className={textBlock}>
+          {eyebrow && (
+            <Typography variant="p2" className={inverted ? contrastText : undefined}>
+              {eyebrow}
+            </Typography>
+          )}
+          <Typography
+            variant={headingVariant[size]}
+            className={inverted ? contrastText : undefined}
+          >
+            {title}
+          </Typography>
+          {children}
+        </div>
+        {actions}
+      </div>
+    </Paper>
+  );
+}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, type ReactNode } from 'react';
 import cx from 'clsx';
 import { Paper, type PaperProps } from '../Paper';
+import { backgroundVariants } from '../Paper/Paper.css';
 import { Typography } from '../Typography';
 import {
   root,
@@ -22,7 +23,8 @@ export interface CardProps extends React.AriaAttributes {
    * `Card.css.ts`'s `invertibleSelectors`) rather than being force-inverted.
    * That pairing isn't contrast-checked against colored backgrounds yet, so a
    * `Button` in `children`/`actions` can be unreadable there — keep non-default
-   * backgrounds to text-only content until #115 adds an inverted Button variant.
+   * backgrounds to text-only content until Button gets a contrast-checked
+   * inverted variant.
    */
   background?: PaperProps['background'];
   media?: ReactNode;
@@ -74,33 +76,48 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     // `green` are ever added to `PaperProps['background']` (see Paper.tsx), since
     // a light one would need this to key off a per-background contrast token
     // instead of a blanket `!== 'default'` check.
-    const inverted = background !== 'default';
+    //
+    // Guarded by membership in `backgroundVariants` (not just `!== 'default'`) so
+    // an out-of-union value — which Paper's own guard warns on but still renders
+    // with no background color applied — degrades to non-inverted (dark-on-white)
+    // text instead of force-inverting to unreadable light-on-white text.
+    const inverted = background in backgroundVariants && background !== 'default';
     const contentTestId = props['data-testid'] && `${props['data-testid']}-content`;
 
-    // Dev-only guard: an out-of-union `size`/`titleOrder` silently resolves to
-    // `undefined` in the lookups below — `size` drops padding *and* falls back to
-    // Typography's default variant entirely (no heading style at all), and
-    // `titleOrder` silently stops overriding the heading level. `background` isn't
-    // checked here — Paper already guards it, and Card just forwards the value.
+    // Dev-only guard: an out-of-union `size`/`mediaPlacement`/`titleOrder` silently
+    // resolves to `undefined` in the lookups below — `size` drops padding and
+    // passes `variant={undefined}` to Typography, which has no fallback of its own
+    // (Typography's underlying `Box` falls back to a plain `div`, losing both the
+    // heading style and the heading element), `mediaPlacement` silently falls back
+    // to the `top` layout, and `titleOrder` silently stops overriding the heading
+    // level. `background` isn't checked here — Paper already guards it, and Card
+    // just forwards the value (though Card's own `inverted` derivation below
+    // degrades safely for an invalid value regardless).
     useEffect(() => {
       if (process.env.NODE_ENV === 'production') return;
 
       if (!(size in headingVariant)) {
         console.error(`Card: invalid \`size\` value "${size}".`);
       }
+      if (mediaPlacement !== 'top' && mediaPlacement !== 'left') {
+        console.error(`Card: invalid \`mediaPlacement\` value "${String(mediaPlacement)}".`);
+      }
       if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
         console.error(`Card: invalid \`titleOrder\` value "${titleOrder}".`);
       }
-    }, [size, titleOrder]);
+    }, [size, mediaPlacement, titleOrder]);
 
     return (
       <Paper
         ref={ref}
+        {...props}
+        // Spread after `props` so Card's fixed surface contract always wins,
+        // even if a non-TS caller manages to pass one of these Paper props
+        // through (`CardProps` doesn't declare them, so a typed caller can't).
         background={background}
         radius="sharp"
         withShadow
         padding="none"
-        {...props}
         className={cx(root, media && mediaPlacement === 'left' && rootMediaLeft, className)}
       >
         {media && <div className={mediaClass}>{media}</div>}

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card, type CardProps } from './Card';

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -28,6 +28,7 @@ export const backgroundVariants = styleVariants({
 });
 
 export const paddingVariants = styleVariants({
+  none: { padding: 0 },
   small: { padding: paper.padding.small },
   medium: { padding: paper.padding.medium },
   large: { padding: paper.padding.large },

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -1,0 +1,39 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: {
+    components: { paper },
+    background,
+    cornerRadius,
+    strokeWeight,
+    divider,
+    dropShadow,
+  },
+} = vars;
+
+export const root = style({
+  backgroundColor: background.default,
+  borderRadius: cornerRadius.sharp,
+  border: 'none',
+  boxShadow: 'none',
+});
+
+export const backgroundVariants = styleVariants({
+  default: { backgroundColor: background.default },
+  inverted: { backgroundColor: paper.background.inverted },
+});
+
+export const paddingVariants = styleVariants({
+  small: { padding: paper.padding.small },
+  medium: { padding: paper.padding.medium },
+  large: { padding: paper.padding.large },
+});
+
+export const pill = style({ borderRadius: cornerRadius.rounded });
+
+export const withBorder = style({ border: `${strokeWeight} solid ${divider}` });
+
+// Matches the shape Accordion/DateField already use for this same token — confirmed
+// against Figma's Card dropshadow spec (offset 0/1, blur 4, spread 0).
+export const withShadow = style({ boxShadow: `0px 1px 4px 0px ${dropShadow}` });

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -9,6 +9,7 @@ const {
     strokeWeight,
     divider,
     dropShadow,
+    states,
   },
 } = vars;
 
@@ -32,7 +33,12 @@ export const paddingVariants = styleVariants({
 
 export const pill = style({ borderRadius: cornerRadius.rounded });
 
-export const withBorder = style({ border: `${strokeWeight} solid ${divider}` });
+export const withBorder = style({ borderWidth: strokeWeight, borderStyle: 'solid' });
+
+export const borderColorVariants = styleVariants({
+  divider: { borderColor: divider },
+  brand: { borderColor: states.default },
+});
 
 // Matches the shape Accordion/DateField already use for this same token — confirmed
 // against Figma's Card dropshadow spec (offset 0/1, blur 4, spread 0).

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -22,7 +22,9 @@ export const root = style({
 
 export const backgroundVariants = styleVariants({
   default: { backgroundColor: background.default },
-  inverted: { backgroundColor: paper.background.inverted },
+  turquoise: { backgroundColor: paper.background.turquoise },
+  blue: { backgroundColor: paper.background.blue },
+  pink: { backgroundColor: paper.background.pink },
 });
 
 export const paddingVariants = styleVariants({

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -8,7 +8,7 @@ const {
     cornerRadius,
     strokeWeight,
     divider,
-    dropShadow,
+    dropShadowTile,
     states,
   },
 } = vars;
@@ -45,8 +45,7 @@ export const borderColorVariants = styleVariants({
   brand: { borderColor: states.default },
 });
 
-// Matches the shape Accordion already uses for this same token — confirmed
-// against Figma's Card dropshadow spec (offset 0/1, blur 4, spread 0). DateField's
-// shadow uses a different, larger shape (its own floating popover surface, not a
-// tile) — not a match to compare against.
-export const withShadow = style({ boxShadow: `0px 1px 4px 0px ${dropShadow}` });
+// `dropShadowTile` is shared with Accordion, which uses this same shape.
+// DateField's shadow uses a different, larger shape (its own floating popover
+// surface, not a tile) — not a match to compare against.
+export const withShadow = style({ boxShadow: dropShadowTile });

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -26,11 +26,14 @@ export const backgroundVariants = styleVariants({
   pink: { backgroundColor: paper.background.pink },
 });
 
+// Prop values (`sm`/`md`/`lg`) match the rest of the library's size scale
+// convention (IconButton, NavigationLink); the underlying token keys
+// (`paper.padding.small/medium/large` in theme.ts) stay as Figma's own names.
 export const paddingVariants = styleVariants({
   none: { padding: 0 },
-  small: { padding: paper.padding.small },
-  medium: { padding: paper.padding.medium },
-  large: { padding: paper.padding.large },
+  sm: { padding: paper.padding.small },
+  md: { padding: paper.padding.medium },
+  lg: { padding: paper.padding.large },
 });
 
 export const pill = style({ borderRadius: cornerRadius.rounded });

--- a/src/components/Paper/Paper.css.ts
+++ b/src/components/Paper/Paper.css.ts
@@ -14,7 +14,6 @@ const {
 } = vars;
 
 export const root = style({
-  backgroundColor: background.default,
   borderRadius: cornerRadius.sharp,
   border: 'none',
   boxShadow: 'none',
@@ -43,6 +42,8 @@ export const borderColorVariants = styleVariants({
   brand: { borderColor: states.default },
 });
 
-// Matches the shape Accordion/DateField already use for this same token — confirmed
-// against Figma's Card dropshadow spec (offset 0/1, blur 4, spread 0).
+// Matches the shape Accordion already uses for this same token — confirmed
+// against Figma's Card dropshadow spec (offset 0/1, blur 4, spread 0). DateField's
+// shadow uses a different, larger shape (its own floating popover surface, not a
+// tile) — not a match to compare against.
 export const withShadow = style({ boxShadow: `0px 1px 4px 0px ${dropShadow}` });

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -122,15 +122,6 @@ export const NoPadding: Story = {
   },
 };
 
-export const PaddingScalesSmallToLarge: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const small = getComputedStyle(canvas.getByTestId('paper'));
-    await expect(parseFloat(small.padding)).toBeGreaterThan(0);
-  },
-};
-
 export const PaddingMediumExceedsSmall: Story = {
   render: () => (
     <>

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -6,7 +6,7 @@ import { Paper } from './Paper';
 const meta = {
   component: Paper,
   tags: ['!dev', '!autodocs'],
-  args: { children: 'Paperi' },
+  args: { 'data-testid': 'paper' },
 } satisfies Meta<typeof Paper>;
 
 export default meta;
@@ -18,13 +18,23 @@ export const Default: Story = {
   tags: docExample,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
+    const paper = canvas.getByTestId('paper');
     const style = getComputedStyle(paper);
 
     await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
     await expect(style.borderRadius).toBe('0px');
     await expect(style.borderStyle).toBe('none');
-    await expect(style.boxShadow).toBe('none');
+    await expect(style.boxShadow).not.toBe('none');
+  },
+};
+
+export const NoShadow: Story = {
+  tags: docExample,
+  args: { withShadow: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('paper')).boxShadow).toBe('none');
   },
 };
 
@@ -33,9 +43,10 @@ export const InvertedBackground: Story = {
   args: { background: 'inverted' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
 
-    await expect(getComputedStyle(paper).backgroundColor).toBe('rgb(0, 116, 164)');
+    await expect(getComputedStyle(canvas.getByTestId('paper')).backgroundColor).toBe(
+      'rgb(0, 116, 164)'
+    );
   },
 };
 
@@ -44,9 +55,8 @@ export const PillRadius: Story = {
   args: { radius: 'pill' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
 
-    await expect(getComputedStyle(paper).borderRadius).toBe('9999px');
+    await expect(getComputedStyle(canvas.getByTestId('paper')).borderRadius).toBe('9999px');
   },
 };
 
@@ -55,23 +65,11 @@ export const WithBorder: Story = {
   args: { withBorder: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
-    const style = getComputedStyle(paper);
+    const style = getComputedStyle(canvas.getByTestId('paper'));
 
     await expect(style.borderStyle).toBe('solid');
     await expect(style.borderWidth).toBe('2px');
     await expect(style.borderColor).toBe('rgb(222, 222, 226)');
-  },
-};
-
-export const WithShadow: Story = {
-  tags: docExample,
-  args: { withShadow: true },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
-
-    await expect(getComputedStyle(paper).boxShadow).not.toBe('none');
   },
 };
 
@@ -82,7 +80,7 @@ export const PaddingScalesSmallToLarge: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const small = getComputedStyle(canvas.getByText('Paperi'));
+    const small = getComputedStyle(canvas.getByTestId('paper'));
     await expect(parseFloat(small.padding)).toBeGreaterThan(0);
   },
 };
@@ -90,15 +88,9 @@ export const PaddingScalesSmallToLarge: Story = {
 export const PaddingMediumExceedsSmall: Story = {
   render: () => (
     <>
-      <Paper padding="small" data-testid="small">
-        Pieni
-      </Paper>
-      <Paper padding="medium" data-testid="medium">
-        Keski
-      </Paper>
-      <Paper padding="large" data-testid="large">
-        Suuri
-      </Paper>
+      <Paper padding="small" data-testid="small" />
+      <Paper padding="medium" data-testid="medium" />
+      <Paper padding="large" data-testid="large" />
     </>
   ),
   play: async ({ canvasElement }) => {
@@ -113,11 +105,10 @@ export const PaddingMediumExceedsSmall: Story = {
 };
 
 export const PolymorphicComponent: Story = {
-  render: () => <Paper component="section">Paperi</Paper>,
+  render: () => <Paper component="section" data-testid="paper" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const paper = canvas.getByText('Paperi');
 
-    await expect(paper.tagName).toBe('SECTION');
+    await expect(canvas.getByTestId('paper').tagName).toBe('SECTION');
   },
 };

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -38,14 +38,38 @@ export const NoShadow: Story = {
   },
 };
 
-export const InvertedBackground: Story = {
+export const TurquoiseBackground: Story = {
   tags: docExample,
-  args: { background: 'inverted' },
+  args: { background: 'turquoise' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await expect(getComputedStyle(canvas.getByTestId('paper')).backgroundColor).toBe(
       'rgb(0, 116, 164)'
+    );
+  },
+};
+
+export const BlueBackground: Story = {
+  tags: docExample,
+  args: { background: 'blue' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('paper')).backgroundColor).toBe(
+      'rgb(34, 67, 123)'
+    );
+  },
+};
+
+export const PinkBackground: Story = {
+  tags: docExample,
+  args: { background: 'pink' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('paper')).backgroundColor).toBe(
+      'rgb(173, 57, 99)'
     );
   },
 };

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -223,3 +223,44 @@ export const WarnsOnInvalidBorderColor: Story = {
     );
   },
 };
+
+export const WarnsOnInvalidRadius: Story = {
+  args: { radius: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `radius` value/.test(m))).toBe(true)
+    );
+  },
+};
+
+// ── Mantine style-prop bypass tests ───────────────────────────────────────────
+// `PaperProps` omits Mantine's raw style props (`bg`/`p`/`shadow`/`bd`/etc.) at
+// the type level, so a typed caller can't reach them — these simulate a caller
+// that bypasses the type system anyway (`as any`, untyped JS).
+
+export const IgnoresMantineStyleProps: Story = {
+  render: () => <Paper data-testid="paper" {...({ bg: 'red', p: 40, shadow: 'none' } as any)} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const style = getComputedStyle(canvas.getByTestId('paper'));
+
+    // Regression: none of the bypassed props should reach the rendered element
+    // — Paper's own defaults (white background, `md` padding, a shadow) win.
+    await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
+    await expect(style.padding).not.toBe('40px');
+    await expect(style.boxShadow).not.toBe('none');
+  },
+};
+
+export const WarnsOnMantineStyleProps: Story = {
+  args: { bg: 'red', shadow: 'none' } as never,
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /prop\(s\) bg, shadow are ignored/.test(m))).toBe(
+        true
+      )
+    );
+  },
+};

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -74,6 +74,18 @@ export const WithBorder: Story = {
   },
 };
 
+export const WithBorderBrandColor: Story = {
+  tags: docExample,
+  args: { withBorder: true, withShadow: false, borderColor: 'brand' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('paper')).borderColor).toBe(
+      'rgb(41, 84, 154)'
+    );
+  },
+};
+
 // Hidden test-only stories below — pure regression checks, no unique visual
 // state beyond what the docs-visible stories above already show.
 

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -62,7 +62,7 @@ export const PillRadius: Story = {
 
 export const WithBorder: Story = {
   tags: docExample,
-  args: { withBorder: true },
+  args: { withBorder: true, withShadow: false },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const style = getComputedStyle(canvas.getByTestId('paper'));
@@ -70,6 +70,7 @@ export const WithBorder: Story = {
     await expect(style.borderStyle).toBe('solid');
     await expect(style.borderWidth).toBe('2px');
     await expect(style.borderColor).toBe('rgb(222, 222, 226)');
+    await expect(style.boxShadow).toBe('none');
   },
 };
 

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
+import { Paper } from './Paper';
+
+const meta = {
+  component: Paper,
+  tags: ['!dev', '!autodocs'],
+  args: { children: 'Paperi' },
+} satisfies Meta<typeof Paper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const docExample = ['dev', 'autodocs'];
+
+export const Default: Story = {
+  tags: docExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+    const style = getComputedStyle(paper);
+
+    await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
+    await expect(style.borderRadius).toBe('0px');
+    await expect(style.borderStyle).toBe('none');
+    await expect(style.boxShadow).toBe('none');
+  },
+};
+
+export const InvertedBackground: Story = {
+  tags: docExample,
+  args: { background: 'inverted' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+
+    await expect(getComputedStyle(paper).backgroundColor).toBe('rgb(0, 116, 164)');
+  },
+};
+
+export const PillRadius: Story = {
+  tags: docExample,
+  args: { radius: 'pill' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+
+    await expect(getComputedStyle(paper).borderRadius).toBe('9999px');
+  },
+};
+
+export const WithBorder: Story = {
+  tags: docExample,
+  args: { withBorder: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+    const style = getComputedStyle(paper);
+
+    await expect(style.borderStyle).toBe('solid');
+    await expect(style.borderWidth).toBe('2px');
+    await expect(style.borderColor).toBe('rgb(222, 222, 226)');
+  },
+};
+
+export const WithShadow: Story = {
+  tags: docExample,
+  args: { withShadow: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+
+    await expect(getComputedStyle(paper).boxShadow).not.toBe('none');
+  },
+};
+
+// Hidden test-only stories below — pure regression checks, no unique visual
+// state beyond what the docs-visible stories above already show.
+
+export const PaddingScalesSmallToLarge: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const small = getComputedStyle(canvas.getByText('Paperi'));
+    await expect(parseFloat(small.padding)).toBeGreaterThan(0);
+  },
+};
+
+export const PaddingMediumExceedsSmall: Story = {
+  render: () => (
+    <>
+      <Paper padding="small" data-testid="small">
+        Pieni
+      </Paper>
+      <Paper padding="medium" data-testid="medium">
+        Keski
+      </Paper>
+      <Paper padding="large" data-testid="large">
+        Suuri
+      </Paper>
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const small = parseFloat(getComputedStyle(canvas.getByTestId('small')).padding);
+    const medium = parseFloat(getComputedStyle(canvas.getByTestId('medium')).padding);
+    const large = parseFloat(getComputedStyle(canvas.getByTestId('large')).padding);
+
+    await expect(small).toBeLessThan(medium);
+    await expect(medium).toBeLessThan(large);
+  },
+};
+
+export const PolymorphicComponent: Story = {
+  render: () => <Paper component="section">Paperi</Paper>,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const paper = canvas.getByText('Paperi');
+
+    await expect(paper.tagName).toBe('SECTION');
+  },
+};

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -113,6 +113,15 @@ export const WithBorderBrandColor: Story = {
 // Hidden test-only stories below — pure regression checks, no unique visual
 // state beyond what the docs-visible stories above already show.
 
+export const NoPadding: Story = {
+  args: { padding: 'none' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('paper')).padding).toBe('0px');
+  },
+};
+
 export const PaddingScalesSmallToLarge: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within } from '@storybook/testing-library';
+import { within, waitFor } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Paper } from './Paper';
 
@@ -170,5 +170,56 @@ export const PolymorphicComponent: Story = {
     const canvas = within(canvasElement);
 
     await expect(canvas.getByTestId('paper').tagName).toBe('SECTION');
+  },
+};
+
+// ── Dev-warning tests (verifies the console.error guards in Paper.tsx) ───────
+
+// Captures console.error calls for the dev-warning tests below.
+let capturedConsoleErrors: string[] = [];
+
+const captureConsoleErrors = () => {
+  capturedConsoleErrors = [];
+  const original = console.error;
+  console.error = (...messageArgs: unknown[]) => {
+    capturedConsoleErrors.push(String(messageArgs[0]));
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+export const WarnsOnInvalidBackground: Story = {
+  // `as any` simulates a non-TS consumer (or an `as any` escape hatch) passing
+  // a value outside the documented union — must warn rather than silently
+  // rendering with no background class at all.
+  args: { background: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `background` value/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsOnInvalidPadding: Story = {
+  args: { padding: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `padding` value/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsOnInvalidBorderColor: Story = {
+  // Only checked when `withBorder` is set — an invalid `borderColor` with no
+  // border on screen has nothing to warn about.
+  args: { withBorder: true, borderColor: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `borderColor` value/.test(m))).toBe(true)
+    );
   },
 };

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -110,6 +110,29 @@ export const WithBorderBrandColor: Story = {
   },
 };
 
+export const WithBorderAndShadow: Story = {
+  // Both default to on independently — verifies they don't clobber each other
+  // when combined, unlike the docs-visible stories above which each isolate
+  // one by explicitly turning the other off.
+  args: { withBorder: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const style = getComputedStyle(canvas.getByTestId('paper'));
+
+    await expect(style.borderStyle).toBe('solid');
+    await expect(style.boxShadow).not.toBe('none');
+  },
+};
+
+export const CustomClassNameIsPreserved: Story = {
+  args: { className: 'consumer-custom-class' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('paper').className).toContain('consumer-custom-class');
+  },
+};
+
 // Hidden test-only stories below — pure regression checks, no unique visual
 // state beyond what the docs-visible stories above already show.
 
@@ -125,9 +148,9 @@ export const NoPadding: Story = {
 export const PaddingMediumExceedsSmall: Story = {
   render: () => (
     <>
-      <Paper padding="small" data-testid="small" />
-      <Paper padding="medium" data-testid="medium" />
-      <Paper padding="large" data-testid="large" />
+      <Paper padding="sm" data-testid="small" />
+      <Paper padding="md" data-testid="medium" />
+      <Paper padding="lg" data-testid="large" />
     </>
   ),
   play: async ({ canvasElement }) => {

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -14,7 +14,14 @@ import {
 export type PaperProps = PropsWithChildren<
   Omit<MantinePaperProps, 'shadow' | 'radius' | 'withBorder' | 'bg' | 'p'>
 > & {
-  background?: 'default' | 'inverted';
+  /**
+   * `'default'` is white. The other three are Figma's own "color override" examples
+   * (confirmed by pixel-sampling a real rendered instance of each, since Figma's
+   * reference codegen only reports the base component's default binding, not
+   * per-instance fill overrides). `'red' | 'yellow' | 'green'` aren't included yet —
+   * no confirmed Figma example backs a specific shade for those.
+   */
+  background?: 'default' | 'turquoise' | 'blue' | 'pink';
   /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
   radius?: 'sharp' | 'pill';
   withBorder?: boolean;

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -34,29 +34,35 @@ export type PaperProps = PropsWithChildren<
     | 'ps'
     | 'pe'
   >
-> & {
-  /**
-   * `'default'` is white. The other three are Figma's own "color override" examples
-   * (confirmed by pixel-sampling a real rendered instance of each, since Figma's
-   * reference codegen only reports the base component's default binding, not
-   * per-instance fill overrides). `'red' | 'yellow' | 'green'` aren't included yet —
-   * no confirmed Figma example backs a specific shade for those.
-   */
-  background?: 'default' | 'turquoise' | 'blue' | 'pink';
-  /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
-  radius?: 'sharp' | 'pill';
-  /** Default `false`. */
-  withBorder?: boolean;
-  /** Only applied when `withBorder` is set. Default `'divider'` (neutral). */
-  borderColor?: 'divider' | 'brand';
-  /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
-  withShadow?: boolean;
-  /** Default `'md'`. */
-  padding?: 'none' | 'sm' | 'md' | 'lg';
-  /** Polymorphic root element, e.g. `component="section"`. */
-  component?: React.ElementType;
-  'data-testid'?: string;
-};
+> &
+  // Mantine's `PaperProps` only extends `BoxProps`/style props — native attributes
+  // like `id`/`role`/`aria-*` come from the polymorphic factory's element typing,
+  // which a manually-typed wrapper doesn't inherit, so they're added back explicitly.
+  React.AriaAttributes & {
+    id?: string;
+    role?: string;
+    /**
+     * `'default'` is white. The other three are Figma's own "color override" examples
+     * (confirmed by pixel-sampling a real rendered instance of each, since Figma's
+     * reference codegen only reports the base component's default binding, not
+     * per-instance fill overrides). `'red' | 'yellow' | 'green'` aren't included yet —
+     * no confirmed Figma example backs a specific shade for those.
+     */
+    background?: 'default' | 'turquoise' | 'blue' | 'pink';
+    /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
+    radius?: 'sharp' | 'pill';
+    /** Default `false`. */
+    withBorder?: boolean;
+    /** Only applied when `withBorder` is set. Default `'divider'` (neutral). */
+    borderColor?: 'divider' | 'brand';
+    /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
+    withShadow?: boolean;
+    /** Default `'md'`. */
+    padding?: 'none' | 'sm' | 'md' | 'lg';
+    /** Polymorphic root element, e.g. `component="section"`. */
+    component?: React.ElementType;
+    'data-testid'?: string;
+  };
 
 /** A bare surface container — background, corner radius, optional border, optional shadow, and padding. No behaviour of its own. */
 export const Paper = forwardRef<HTMLDivElement, PaperProps>(

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -122,7 +122,17 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       if (hasBorder && !(borderColor in borderColorVariants)) {
         console.error(`Paper: invalid \`borderColor\` value "${borderColor}".`);
       }
-    }, [background, padding, radius, hasBorder, borderColor]);
+
+      // A type-bypassing caller (`as any`, untyped JS) can still reach Mantine's
+      // raw style props, which `restProps` below silently drops — warn so that
+      // silent drop has some signal, matching the guards above.
+      const leakedStyleProps = MANTINE_STYLE_PROP_KEYS.filter((key) => key in props);
+      if (leakedStyleProps.length > 0) {
+        console.error(
+          `Paper: prop(s) ${leakedStyleProps.join(', ')} are ignored — use \`background\`/\`padding\`/\`radius\`/\`withBorder\`/\`withShadow\` instead.`
+        );
+      }
+    }, [background, padding, radius, hasBorder, borderColor, props]);
 
     const restProps: Record<string, unknown> = { ...props };
     for (const key of MANTINE_STYLE_PROP_KEYS) delete restProps[key];

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type PropsWithChildren } from 'react';
+import { forwardRef, useEffect, type PropsWithChildren } from 'react';
 import cx from 'clsx';
 import { Paper as MantinePaper, type PaperProps as MantinePaperProps } from '@mantine/core';
 import {
@@ -79,6 +79,23 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
     },
     ref
   ) => {
+    // Dev-only guard: an out-of-union value silently resolves to `undefined` in
+    // the `styleVariants` lookups below and drops that piece of styling with no
+    // other signal — same risk class TextLink/DateField already guard elsewhere.
+    useEffect(() => {
+      if (process.env.NODE_ENV === 'production') return;
+
+      if (!(background in backgroundVariants)) {
+        console.error(`Paper: invalid \`background\` value "${background}".`);
+      }
+      if (!(padding in paddingVariants)) {
+        console.error(`Paper: invalid \`padding\` value "${padding}".`);
+      }
+      if (hasBorder && !(borderColor in borderColorVariants)) {
+        console.error(`Paper: invalid \`borderColor\` value "${borderColor}".`);
+      }
+    }, [background, padding, hasBorder, borderColor]);
+
     return (
       // Mantine's `Paper` is polymorphic via a large per-element prop union that a
       // manually-typed `forwardRef` wrapper can't satisfy generically — our own

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -12,7 +12,28 @@ import {
 } from './Paper.css';
 
 export type PaperProps = PropsWithChildren<
-  Omit<MantinePaperProps, 'shadow' | 'radius' | 'withBorder' | 'bg' | 'p'>
+  Omit<
+    MantinePaperProps,
+    // The curated props below (`radius`/`withBorder`/`padding`) each replace a
+    // Mantine style prop of the same effect — omit both the renamed key and
+    // every same-effect alias (`bd`/`bdrs` for border, `p*` for padding), or a
+    // consumer could bypass the curated API entirely via the Mantine original.
+    | 'shadow'
+    | 'radius'
+    | 'bdrs'
+    | 'withBorder'
+    | 'bd'
+    | 'bg'
+    | 'p'
+    | 'px'
+    | 'py'
+    | 'pt'
+    | 'pb'
+    | 'pl'
+    | 'pr'
+    | 'ps'
+    | 'pe'
+  >
 > & {
   /**
    * `'default'` is white. The other three are Figma's own "color override" examples
@@ -24,12 +45,14 @@ export type PaperProps = PropsWithChildren<
   background?: 'default' | 'turquoise' | 'blue' | 'pink';
   /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
   radius?: 'sharp' | 'pill';
+  /** Default `false`. */
   withBorder?: boolean;
   /** Only applied when `withBorder` is set. Default `'divider'` (neutral). */
   borderColor?: 'divider' | 'brand';
   /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
   withShadow?: boolean;
-  padding?: 'none' | 'small' | 'medium' | 'large';
+  /** Default `'md'`. */
+  padding?: 'none' | 'sm' | 'md' | 'lg';
   /** Polymorphic root element, e.g. `component="section"`. */
   component?: React.ElementType;
   'data-testid'?: string;
@@ -44,7 +67,7 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       withBorder: hasBorder = false,
       borderColor = 'divider',
       withShadow: hasShadow = true,
-      padding = 'medium',
+      padding = 'md',
       children,
       ...props
     },

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -33,6 +33,19 @@ const MANTINE_STYLE_PROP_KEYS = [
   'bdrs',
 ] as const;
 
+// Mantine's `PaperProps` only extends `BoxProps`/style props — native attributes
+// like `id`/`role`/`aria-*` come from the polymorphic factory's element typing,
+// which a manually-typed wrapper doesn't inherit, so they're added back explicitly.
+// Shared with `CardProps` (which builds directly on Paper) so the two don't
+// redeclare — and risk drifting on — the same attribute block independently.
+export type SurfacePrimitiveProps = React.AriaAttributes & {
+  id?: string;
+  role?: React.AriaRole;
+  /** Polymorphic root element, e.g. `component="section"` or `"article"`. */
+  component?: React.ElementType;
+  'data-testid'?: string;
+};
+
 export type PaperProps = PropsWithChildren<
   Omit<
     MantinePaperProps,
@@ -57,12 +70,7 @@ export type PaperProps = PropsWithChildren<
     | 'pe'
   >
 > &
-  // Mantine's `PaperProps` only extends `BoxProps`/style props — native attributes
-  // like `id`/`role`/`aria-*` come from the polymorphic factory's element typing,
-  // which a manually-typed wrapper doesn't inherit, so they're added back explicitly.
-  React.AriaAttributes & {
-    id?: string;
-    role?: string;
+  SurfacePrimitiveProps & {
     /**
      * `'default'` is white. The other three are Figma's own "color override" examples
      * (confirmed by pixel-sampling a real rendered instance of each, since Figma's
@@ -71,7 +79,7 @@ export type PaperProps = PropsWithChildren<
      * no confirmed Figma example backs a specific shade for those.
      */
     background?: 'default' | 'turquoise' | 'blue' | 'pink';
-    /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
+    /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses. */
     radius?: 'sharp' | 'pill';
     /** Default `false`. */
     withBorder?: boolean;
@@ -81,9 +89,6 @@ export type PaperProps = PropsWithChildren<
     withShadow?: boolean;
     /** Default `'md'`. */
     padding?: 'none' | 'sm' | 'md' | 'lg';
-    /** Polymorphic root element, e.g. `component="section"`. */
-    component?: React.ElementType;
-    'data-testid'?: string;
   };
 
 /** A bare surface container — background, corner radius, optional border, optional shadow, and padding. No behaviour of its own. */

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -17,10 +17,12 @@ export type PaperProps = PropsWithChildren<
   /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
   radius?: 'sharp' | 'pill';
   withBorder?: boolean;
+  /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
   withShadow?: boolean;
   padding?: 'small' | 'medium' | 'large';
   /** Polymorphic root element, e.g. `component="section"`. */
   component?: React.ElementType;
+  'data-testid'?: string;
 };
 
 /** A bare surface container — background, corner radius, optional border, optional shadow, and padding. No behaviour of its own. */
@@ -30,7 +32,7 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       background = 'default',
       radius = 'sharp',
       withBorder: hasBorder = false,
-      withShadow: hasShadow = false,
+      withShadow: hasShadow = true,
       padding = 'medium',
       children,
       ...props

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -1,0 +1,64 @@
+import { forwardRef, type PropsWithChildren } from 'react';
+import cx from 'clsx';
+import { Paper as MantinePaper, type PaperProps as MantinePaperProps } from '@mantine/core';
+import {
+  root,
+  backgroundVariants,
+  paddingVariants,
+  pill,
+  withBorder,
+  withShadow,
+} from './Paper.css';
+
+export type PaperProps = PropsWithChildren<
+  Omit<MantinePaperProps, 'shadow' | 'radius' | 'withBorder' | 'bg' | 'p'>
+> & {
+  background?: 'default' | 'inverted';
+  /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
+  radius?: 'sharp' | 'pill';
+  withBorder?: boolean;
+  withShadow?: boolean;
+  padding?: 'small' | 'medium' | 'large';
+  /** Polymorphic root element, e.g. `component="section"`. */
+  component?: React.ElementType;
+};
+
+/** A bare surface container — background, corner radius, optional border, optional shadow, and padding. No behaviour of its own. */
+export const Paper = forwardRef<HTMLDivElement, PaperProps>(
+  (
+    {
+      background = 'default',
+      radius = 'sharp',
+      withBorder: hasBorder = false,
+      withShadow: hasShadow = false,
+      padding = 'medium',
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      // Mantine's `Paper` is polymorphic via a large per-element prop union that a
+      // manually-typed `forwardRef` wrapper can't satisfy generically — our own
+      // `component?: React.ElementType` is intentionally looser. Cast at this one
+      // boundary rather than losing type safety on the rest of `PaperProps`.
+      <MantinePaper
+        ref={ref}
+        {...(props as MantinePaperProps)}
+        className={cx(
+          root,
+          backgroundVariants[background],
+          paddingVariants[padding],
+          radius === 'pill' && pill,
+          hasBorder && withBorder,
+          hasShadow && withShadow,
+          props.className
+        )}
+      >
+        {children}
+      </MantinePaper>
+    );
+  }
+);
+
+Paper.displayName = 'Paper';

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -11,6 +11,28 @@ import {
   withShadow,
 } from './Paper.css';
 
+// Mantine style-prop aliases the `Omit` below excludes from `PaperProps` at the
+// type level — stripped again here at runtime so a caller who bypasses the type
+// (plain JS, `as any`, an untyped spread) can't use them to reach the same
+// styling the curated `background`/`radius`/`padding`/`withBorder`/`withShadow`
+// props exist to gate. `radius`/`withBorder` don't need listing: they're already
+// captured by their own destructured names below, so they never reach `...props`.
+const MANTINE_STYLE_PROP_KEYS = [
+  'bg',
+  'p',
+  'px',
+  'py',
+  'pt',
+  'pb',
+  'pl',
+  'pr',
+  'ps',
+  'pe',
+  'shadow',
+  'bd',
+  'bdrs',
+] as const;
+
 export type PaperProps = PropsWithChildren<
   Omit<
     MantinePaperProps,
@@ -79,9 +101,12 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
     },
     ref
   ) => {
-    // Dev-only guard: an out-of-union value silently resolves to `undefined` in
-    // the `styleVariants` lookups below and drops that piece of styling with no
-    // other signal — same risk class TextLink/DateField already guard elsewhere.
+    // Dev-only guard: an out-of-union `background`/`padding`/`borderColor` value
+    // silently resolves to `undefined` in the `styleVariants` lookups below and
+    // drops that piece of styling with no other signal — same risk class
+    // TextLink/DateField already guard elsewhere. `radius` isn't a lookup (it's
+    // compared directly against `'pill'`), but an out-of-union value there
+    // silently falls back to the sharp-corner default just as silently.
     useEffect(() => {
       if (process.env.NODE_ENV === 'production') return;
 
@@ -91,10 +116,16 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       if (!(padding in paddingVariants)) {
         console.error(`Paper: invalid \`padding\` value "${padding}".`);
       }
+      if (radius !== 'sharp' && radius !== 'pill') {
+        console.error(`Paper: invalid \`radius\` value "${String(radius)}".`);
+      }
       if (hasBorder && !(borderColor in borderColorVariants)) {
         console.error(`Paper: invalid \`borderColor\` value "${borderColor}".`);
       }
-    }, [background, padding, hasBorder, borderColor]);
+    }, [background, padding, radius, hasBorder, borderColor]);
+
+    const restProps: Record<string, unknown> = { ...props };
+    for (const key of MANTINE_STYLE_PROP_KEYS) delete restProps[key];
 
     return (
       // Mantine's `Paper` is polymorphic via a large per-element prop union that a
@@ -103,7 +134,7 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       // boundary rather than losing type safety on the rest of `PaperProps`.
       <MantinePaper
         ref={ref}
-        {...(props as MantinePaperProps)}
+        {...(restProps as MantinePaperProps)}
         className={cx(
           root,
           backgroundVariants[background],

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -29,7 +29,7 @@ export type PaperProps = PropsWithChildren<
   borderColor?: 'divider' | 'brand';
   /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
   withShadow?: boolean;
-  padding?: 'small' | 'medium' | 'large';
+  padding?: 'none' | 'small' | 'medium' | 'large';
   /** Polymorphic root element, e.g. `component="section"`. */
   component?: React.ElementType;
   'data-testid'?: string;

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -7,6 +7,7 @@ import {
   paddingVariants,
   pill,
   withBorder,
+  borderColorVariants,
   withShadow,
 } from './Paper.css';
 
@@ -17,6 +18,8 @@ export type PaperProps = PropsWithChildren<
   /** Corner shape. `'pill'` matches the same `cornerRadius` tier Button's `radius` prop uses (#73). */
   radius?: 'sharp' | 'pill';
   withBorder?: boolean;
+  /** Only applied when `withBorder` is set. Default `'divider'` (neutral). */
+  borderColor?: 'divider' | 'brand';
   /** Default `true` — matches Figma's Card surface, which has a drop shadow (not a border). */
   withShadow?: boolean;
   padding?: 'small' | 'medium' | 'large';
@@ -32,6 +35,7 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
       background = 'default',
       radius = 'sharp',
       withBorder: hasBorder = false,
+      borderColor = 'divider',
       withShadow: hasShadow = true,
       padding = 'medium',
       children,
@@ -53,6 +57,7 @@ export const Paper = forwardRef<HTMLDivElement, PaperProps>(
           paddingVariants[padding],
           radius === 'pill' && pill,
           hasBorder && withBorder,
+          hasBorder && borderColorVariants[borderColor],
           hasShadow && withShadow,
           props.className
         )}

--- a/src/components/Paper/index.ts
+++ b/src/components/Paper/index.ts
@@ -1,0 +1,1 @@
+export { Paper, type PaperProps } from './Paper';

--- a/src/components/Paper/index.ts
+++ b/src/components/Paper/index.ts
@@ -1,1 +1,1 @@
-export { Paper, type PaperProps } from './Paper';
+export { Paper, type PaperProps, type SurfacePrimitiveProps } from './Paper';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,7 @@
 export { Accordion, AccordionItem } from './Accordion/Accordion';
 export { Breadcrumbs } from './Breadcrumbs/Breadcrumbs';
 export { Button } from './Button/Button';
+export { Card, type CardProps } from './Card/Card';
 export { Checkbox } from './Checkbox/Checkbox';
 export { Chip, type ChipProps } from './Chip/Chip';
 export { IconButton } from './IconButton/IconButton';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,6 +12,7 @@ export { LoadingSpinner } from './LoadingSpinner/LoadingSpinner';
 export { Modal } from './Modal/Modal';
 export { NavigationLink } from './NavigationLink/NavigationLink';
 export { Pagination } from './Pagination/Pagination';
+export { Paper, type PaperProps } from './Paper/Paper';
 export { RadioButton } from './RadioButton/RadioButton';
 export { SearchField } from './SearchField/SearchField';
 export { Select } from './Select/Select';

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -35,6 +35,8 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -290,6 +292,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",
@@ -379,6 +382,8 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -634,6 +639,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",
@@ -723,6 +729,8 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -978,6 +986,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",
@@ -1481,6 +1490,8 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "card": {
+        "mediaAspectRatio": "3 / 2",
+        "mediaSplit": "50%",
         "spacing": "calc(1rem * var(--mantine-scale))",
         "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
       },
@@ -1736,6 +1747,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
     },
     "divider": "#dedee2",
     "dropShadow": "rgba(0, 0, 0, 0.5000)",
+    "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
     "error": "#ae1e20",
     "focus": {
       "visible": "#1e1e22",
@@ -1826,6 +1838,8 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -2081,6 +2095,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",
@@ -2170,6 +2185,8 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -2425,6 +2442,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",
@@ -2514,6 +2532,8 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "mediaAspectRatio": "3 / 2",
+      "mediaSplit": "50%",
       "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
@@ -2769,6 +2789,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
   },
   "divider": "#dedee2",
   "dropShadow": "rgba(0, 0, 0, 0.5000)",
+  "dropShadowTile": "0px 1px 4px 0px rgba(0, 0, 0, 0.5000)",
   "error": "#ae1e20",
   "focus": {
     "visible": "#1e1e22",

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -35,6 +35,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -378,6 +379,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -721,6 +723,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -1478,6 +1481,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "card": {
+        "spacing": "calc(1rem * var(--mantine-scale))",
         "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "chip": {
@@ -1822,6 +1826,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -2165,6 +2170,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -2508,6 +2514,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
+      "spacing": "calc(1.5rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -35,8 +35,6 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(1rem * var(--mantine-scale))",
-      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -201,6 +199,16 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(4rem * var(--mantine-scale))",
+        "medium": "calc(3rem * var(--mantine-scale))",
+        "small": "calc(1.5rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -368,8 +376,6 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(0.75rem * var(--mantine-scale))",
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -534,6 +540,16 @@ exports[`Token Values Match Snapshot > md 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(3rem * var(--mantine-scale))",
+        "medium": "calc(2.5rem * var(--mantine-scale))",
+        "small": "calc(1rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -701,8 +717,6 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(0.75rem * var(--mantine-scale))",
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -867,6 +881,16 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(2.5rem * var(--mantine-scale))",
+        "medium": "calc(2rem * var(--mantine-scale))",
+        "small": "calc(1rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -1448,8 +1472,6 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "spacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "card": {
-        "padding": "calc(0.75rem * var(--mantine-scale))",
-        "spacing": "calc(0.75rem * var(--mantine-scale))",
         "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
       },
       "chip": {
@@ -1614,6 +1636,16 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       "pagination": {
         "itemHeight": "calc(2.5rem * var(--mantine-scale))",
         "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+      },
+      "paper": {
+        "background": {
+          "inverted": "#0074a4",
+        },
+        "padding": {
+          "large": "calc(3rem * var(--mantine-scale))",
+          "medium": "calc(2.5rem * var(--mantine-scale))",
+          "small": "calc(1rem * var(--mantine-scale))",
+        },
       },
       "searchField": {
         "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -1782,8 +1814,6 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(1rem * var(--mantine-scale))",
-      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -1948,6 +1978,16 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(4rem * var(--mantine-scale))",
+        "medium": "calc(3rem * var(--mantine-scale))",
+        "small": "calc(1.5rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -2115,8 +2155,6 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "spacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(0.75rem * var(--mantine-scale))",
-      "spacing": "calc(0.75rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -2281,6 +2319,16 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(2.5rem * var(--mantine-scale))",
+        "medium": "calc(2rem * var(--mantine-scale))",
+        "small": "calc(1rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",
@@ -2448,8 +2496,6 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "spacing": "calc(0.75rem * var(--mantine-scale))",
     },
     "card": {
-      "padding": "calc(1rem * var(--mantine-scale))",
-      "spacing": "calc(1rem * var(--mantine-scale))",
       "textContentSpacing": "calc(0.5rem * var(--mantine-scale))",
     },
     "chip": {
@@ -2614,6 +2660,16 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     "pagination": {
       "itemHeight": "calc(2.5rem * var(--mantine-scale))",
       "itemWidth": "calc(2.5rem * var(--mantine-scale))",
+    },
+    "paper": {
+      "background": {
+        "inverted": "#0074a4",
+      },
+      "padding": {
+        "large": "calc(4rem * var(--mantine-scale))",
+        "medium": "calc(3rem * var(--mantine-scale))",
+        "small": "calc(1.5rem * var(--mantine-scale))",
+      },
     },
     "searchField": {
       "dropDownMaxHeight": "calc(15.625rem * var(--mantine-scale))",

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -202,7 +202,9 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(4rem * var(--mantine-scale))",
@@ -543,7 +545,9 @@ exports[`Token Values Match Snapshot > md 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(3rem * var(--mantine-scale))",
@@ -884,7 +888,9 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(2.5rem * var(--mantine-scale))",
@@ -1639,7 +1645,9 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       },
       "paper": {
         "background": {
-          "inverted": "#0074a4",
+          "blue": "#22437b",
+          "pink": "#ad3963",
+          "turquoise": "#0074a4",
         },
         "padding": {
           "large": "calc(3rem * var(--mantine-scale))",
@@ -1981,7 +1989,9 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(4rem * var(--mantine-scale))",
@@ -2322,7 +2332,9 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(2.5rem * var(--mantine-scale))",
@@ -2663,7 +2675,9 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     },
     "paper": {
       "background": {
-        "inverted": "#0074a4",
+        "blue": "#22437b",
+        "pink": "#ad3963",
+        "turquoise": "#0074a4",
       },
       "padding": {
         "large": "calc(4rem * var(--mantine-scale))",

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -73,6 +73,11 @@ const chipLineHeightPercent = 150;
 
 const strokeWeight = rem('2px');
 
+const dropShadow = 'rgba(0, 0, 0, 0.5000)';
+// Figma's Card/Accordion dropshadow spec (offset 0/1, blur 4, spread 0) — shared
+// so the two components' shadows can't drift apart by editing one.
+const dropShadowTile = `0px 1px 4px 0px ${dropShadow}`;
+
 const focusRing = {
   outline: `${strokeWeight} solid ${focus.visible}`,
   outlineOffset: `calc(${strokeWeight} / 2)`,
@@ -221,6 +226,10 @@ export function getTheme(bp: BreakpointKey) {
       // Figma's "Card static content" top-level gap (spacing/medium) — between the
       // text-content block (eyebrow/title/body) and the actions slot.
       spacing: bpTokens.spacing.md,
+      // Photos' conventional crop ratio, used for `top`-placement media.
+      mediaAspectRatio: '3 / 2',
+      // `left`-placement media/content column split.
+      mediaSplit: '50%',
     },
     paper: {
       // Figma's "Card static content" padding scale (spacing/medium,
@@ -431,7 +440,8 @@ export function getTheme(bp: BreakpointKey) {
     divider: colors.neutral['200'],
     cornerRadius,
     strokeWeight,
-    dropShadow: 'rgba(0, 0, 0, 0.5000)',
+    dropShadow,
+    dropShadowTile,
     states,
     inputStates,
     selectionStates,

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -229,13 +229,17 @@ export function getTheme(bp: BreakpointKey) {
         medium: bpTokens.spacing.xl,
         large: bpTokens.spacing.xxl,
       },
+      // Figma's Card "color override" examples — confirmed by pixel-sampling a
+      // real rendered instance of each (Figma's own reference codegen only
+      // reports the base component's default binding, not per-instance fill
+      // overrides, so this couldn't be read from `get_design_context` alone).
+      // Only these three are wired up because only these three have a real
+      // Figma example backing the exact shade — `red`/`yellow`/`green` aren't
+      // included since guessing an untested shade risks a contrast mismatch.
       background: {
-        // Figma's Card "Inverted" surface — `turquoise/300`, confirmed via
-        // `get_variable_defs` on a real inverted Card instance. Deliberately
-        // not `brand.blue.main` (a different color, #29549a) — `turquoise`
-        // isn't wired into `brand.ts` as its own brand-mode tier since this
-        // is currently a single one-off stop, not a general brand accent.
-        inverted: colors.turquoise['300'],
+        turquoise: colors.turquoise['300'],
+        blue: colors.blue['500'],
+        pink: colors.pink['200'],
       },
     },
     chip: {

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -218,6 +218,9 @@ export function getTheme(bp: BreakpointKey) {
     },
     card: {
       textContentSpacing: primitives.spacing['1'],
+      // Figma's "Card static content" top-level gap (spacing/medium) — between the
+      // text-content block (eyebrow/title/body) and the actions slot.
+      spacing: bpTokens.spacing.md,
     },
     paper: {
       // Figma's "Card static content" padding scale (spacing/medium,

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -225,8 +225,9 @@ export function getTheme(bp: BreakpointKey) {
     paper: {
       // Figma's "Card static content" padding scale (spacing/medium,
       // spacing/extra-large, spacing/2-extra-large) — confirmed responsive
-      // (e.g. `small` is 24px at xxl/xl/lg but drops to 16px at the 480
-      // breakpoint, same as every other `bpTokens.spacing` consumer).
+      // (e.g. `small` is 24px at xxl/xl/lg but drops to 16px from the `md`
+      // (768px) breakpoint down through `xs`, same as every other
+      // `bpTokens.spacing` consumer).
       padding: {
         small: bpTokens.spacing.md,
         medium: bpTokens.spacing.xl,

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -217,9 +217,26 @@ export function getTheme(bp: BreakpointKey) {
       padding: { horizontal: bpTokens.spacing.md, vertical: bpTokens.spacing.sm },
     },
     card: {
-      padding: bpTokens.spacing.sm,
-      spacing: bpTokens.spacing.sm,
       textContentSpacing: primitives.spacing['1'],
+    },
+    paper: {
+      // Figma's "Card static content" padding scale (spacing/medium,
+      // spacing/extra-large, spacing/2-extra-large) — confirmed responsive
+      // (e.g. `small` is 24px at xxl/xl/lg but drops to 16px at the 480
+      // breakpoint, same as every other `bpTokens.spacing` consumer).
+      padding: {
+        small: bpTokens.spacing.md,
+        medium: bpTokens.spacing.xl,
+        large: bpTokens.spacing.xxl,
+      },
+      background: {
+        // Figma's Card "Inverted" surface — `turquoise/300`, confirmed via
+        // `get_variable_defs` on a real inverted Card instance. Deliberately
+        // not `brand.blue.main` (a different color, #29549a) — `turquoise`
+        // isn't wired into `brand.ts` as its own brand-mode tier since this
+        // is currently a single one-off stop, not a general brand accent.
+        inverted: colors.turquoise['300'],
+      },
     },
     chip: {
       // Figma's "spacing/2-extra-small" — confirmed against the dedicated


### PR DESCRIPTION
## Summary
- Adds **Paper** (#74) — a bare surface primitive (background, corner radius, optional border, optional shadow, padding), built on Mantine's `Paper` but styled entirely through TREDS tokens rather than Mantine's own theme-scale props.
- Adds **Card** (#57) — the static content tile, built directly on Paper (not Mantine's `Card`/`Card.Section`, which would conflict with using Paper as the real surface).
- `background` supports `'default' | 'turquoise' | 'blue' | 'pink'` — confirmed against real Figma "color override" examples (pixel-sampled from a rendered screenshot, since Figma's own reference codegen only reports each instance's base binding, not per-instance fill overrides).
- Card's `size: 'large' | 'medium' | 'small'` couples header size + padding together (H2+Large / H3+Medium / H3+Small), matching the only three combos Figma's "Card static content" component shows.
- Card composes `Typography`, `Button`, and `TextLink` in its slots (`title`, `eyebrow`, `media`, `actions`, `children`); it's a static container — no `onClick`, so nested interactive elements stay independently focusable (Linkbox #75 is the separate "whole card is a link" ticket).
- Card's `media` fills its frame edge-to-edge via `object-fit: cover` instead of rendering at the media's own intrinsic size (which could leave visible gaps for anything smaller than the card) — `top` placement crops into a fixed 3:2 box, `left` placement stretches to match the row's height.

## Known issues (filed, not blocking)
- #115 — nested `Button` is unreadable on non-default (colored) Card backgrounds (contrast ~1.25–1.4:1, fails WCAG AA). Real fix is blocked on #117 (an inverted Button variant needs Figma design work first); the interim mitigation documents the constraint and tightens the regression test.

## Test plan
- [x] TDD throughout — every behavior change/addition was red before green
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all clean
- [x] Full suite: 279/279 (`npm test`)
- [x] `npm run build` succeeds
- [x] Verified visually in Storybook (Playwright): Paper's background/border/shadow/radius/padding variants, Card's media placement (top crops into a 3:2 box, left stretches to the row's height, both via `object-fit: cover`), size scale, contrast-text/focus-ring inversion on colored backgrounds, and dev-mode prop-value warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
