### PR TITLE
feat(#75): add Linkbox component

### DIFF
--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -1,0 +1,113 @@
+import { style, globalStyle } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+import { typography } from '../Typography/Typography.css';
+import { textBlock as cardTextBlock } from '../Card/Card.css';
+
+const {
+  theme: {
+    text,
+    contrast,
+    hover,
+    focusRing,
+    focusRingInverted,
+    components: { card },
+  },
+} = vars;
+
+// Reuse Card's eyebrow/title/body gap (Figma's "Spacing/2-extra-small", 8px) —
+// Linkbox's own eyebrow/title/description stack matches that exactly.
+export const textBlock = cardTextBlock;
+
+// Root needs `position: relative` so the nested-interactive overlay `<a>`
+// (`overlayLink` below) can size itself via `inset: 0` against this box
+// rather than the page.
+export const root = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: card.spacing,
+});
+
+// Figma's "Kuvaava teksti" (P1) is styled with text/secondary, not
+// Typography's own p1 default (text/primary) — only the description needs
+// this override; the eyebrow (P2) and title (H3) already default to
+// text/secondary and text/header respectively.
+export const description = style({ color: text.secondary });
+
+// Icon row sits below the text block, matching Figma's arrow position.
+export const iconRow = style({ display: 'flex', alignItems: 'center', color: text.header });
+
+export const icon = style({ width: '1.5rem', height: '1.5rem' });
+
+// Marker class toggled when `inverted` — no rule of its own (the background
+// color itself comes from Paper's `background="turquoise"`), just a hook for
+// the invertible text/icon selectors below. Same technique as Card.css.ts's
+// `inverted` marker.
+export const inverted = style({});
+
+// Same allowlist-driven inversion technique as Card.css.ts's
+// `invertibleSelectors` — flips Linkbox's own text/icon to the contrast
+// color when `inverted`, without a blanket selector that would also force
+// invert something a consumer nests in `actions`.
+const invertibleTextSelectors = Object.values(typography)
+  .map((className) => `${root}${inverted} .${className}`)
+  .join(', ');
+
+globalStyle(invertibleTextSelectors, { color: `${contrast} !important` });
+globalStyle(`${root}${inverted} .${iconRow}`, { color: contrast });
+
+// ── Simple mode: the root itself is the `<a>` ────────────────────────────
+export const link = style({
+  textDecoration: 'none',
+  selectors: {
+    '&:hover': { backgroundColor: hover.overlay },
+    '&:focus-visible': { ...focusRing, backgroundColor: hover.overlay },
+  },
+});
+
+globalStyle(`${root}${inverted}.${link}:hover`, { backgroundColor: hover.overlayContrast });
+globalStyle(`${root}${inverted}.${link}:focus-visible`, {
+  ...focusRingInverted,
+  backgroundColor: hover.overlayContrast,
+});
+
+// ── Nested-interactive mode: a covering overlay `<a>`, plus a positioned
+// content wrapper so the real content/actions paint above it ────────────
+export const overlayLink = style({
+  position: 'absolute',
+  inset: 0,
+  zIndex: 0,
+  textDecoration: 'none',
+  selectors: {
+    '&:hover': { backgroundColor: hover.overlay },
+    '&:focus-visible': { ...focusRing, backgroundColor: hover.overlay },
+  },
+});
+
+globalStyle(`${root}${inverted} .${overlayLink}:hover`, { backgroundColor: hover.overlayContrast });
+globalStyle(`${root}${inverted} .${overlayLink}:focus-visible`, {
+  ...focusRingInverted,
+  backgroundColor: hover.overlayContrast,
+});
+
+// `zIndex: 1` puts `content`/`actions` above `overlayLink` so a real pointer
+// click over e.g. a nested Button hits the button, not the covering link —
+// not caught by `ActionsRemainClickable`'s `userEvent.click` (which targets
+// the button node directly rather than hit-testing screen coordinates, the
+// same synthetic-event gap TextLink.css.ts documents for `:hover`); verified
+// manually via Storybook instead.
+//
+// Also carries its own flex-column + `card.spacing` gap: wrapping `content`
+// (textBlock + iconRow) in this div for the z-index above otherwise strands
+// them in plain block flow, losing the gap `root`'s own flex layout gives
+// its *direct* children — regression caught visually in Storybook (nested
+// mode's arrow sat flush against the description instead of Figma's 24px
+// gap). Reused for the `actions` wrapper too, where a single child is
+// unaffected and multiple children get the same sensible stacking.
+export const positionedContent = style({
+  position: 'relative',
+  zIndex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: card.spacing,
+});

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -57,13 +57,16 @@ export const inverted = style({});
 
 // Same allowlist-driven inversion technique as Card.css.ts's
 // `invertibleSelectors` — flips Linkbox's own text/icon to the contrast
-// color when `inverted`.
+// color when `inverted`. `inverted` alone (not compounded with `root`) is
+// enough to scope this to Linkbox instances — it's a Linkbox-local marker,
+// and `root` lives on a different (inner) element now (see `leftMarker`
+// below), so the two are no longer ever on the same element.
 const invertibleTextSelectors = Object.values(typography)
-  .map((className) => `${root}${inverted} .${className}`)
+  .map((className) => `${inverted} .${className}`)
   .join(', ');
 
 globalStyle(invertibleTextSelectors, { color: `${contrast} !important` });
-globalStyle(`${root}${inverted} .${iconRow}`, { color: contrast });
+globalStyle(`${inverted} .${iconRow}`, { color: contrast });
 
 // The whole box is a real `<a>` — Paper's `component="a"`. The overlay tint
 // is applied via `backgroundImage` (a same-color-stop linear-gradient), not
@@ -91,43 +94,56 @@ export const link = style({
 // cells (confirmed against the "Card link content" Figma frame), so the
 // outline itself doesn't need an inverted override the way e.g. Card's
 // nested TextLink focus ring does against its own (different) backgrounds.
-globalStyle(`${root}${inverted}.${link}:hover`, {
+globalStyle(`${inverted}.${link}:hover`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
-globalStyle(`${root}${inverted}.${link}:focus-visible`, {
+globalStyle(`${inverted}.${link}:focus-visible`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
 
 // `left` media placement is a 50/50 row split above the `md` breakpoint —
-// below that, the whole card has narrowed enough that a row split gets
-// cramped, so it collapses to the same stacked layout `top` uses by default
-// (no override needed for the stacked state itself — that's just `root`'s
-// unconditional base `flexDirection: column`).
+// below that, Linkbox's own rendered width has narrowed enough that a row
+// split gets cramped, so it collapses to the same stacked layout `top` uses
+// by default (no override needed for the stacked state itself — that's just
+// `root`'s unconditional base `flexDirection: column`).
 //
-// This is the first component in the repo to use a real `@media` query in
-// its own stylesheet — every other breakpoint-dependent value comes from
+// This is the first component in the repo to use a real `@container` query
+// in its own stylesheet — every other breakpoint-dependent value comes from
 // `vars.theme` swapping at `:root` (theme.css.ts), which works for a value
 // swap but not a structural row↔column switch. Deliberately scoped to this
 // component's own `leftMarker` (never applied to Card's `rootMediaLeft`), so
-// Card's own `left` placement — which stays row at every breakpoint — is
+// Card's own `left` placement — which stays row at every viewport width — is
 // untouched.
 //
-// Viewport-based, not a container query (none exist yet in this repo): a
-// `left`-placed Linkbox squeezed into a narrow grid column on a wide
-// viewport still renders row layout. Known limitation, not a regression —
-// Card's own `left` placement never collapses at all, at any width.
-export const leftMarker = style({});
+// A container query, not a viewport `@media` query: `leftMarker` establishes
+// itself as the query container (`containerType: 'inline-size'`), so the
+// collapse is keyed off Linkbox's own rendered width, not the browser
+// viewport. A `left`-placed Linkbox squeezed into a narrow grid column
+// collapses correctly even on a wide screen — the gap a `@media` version of
+// this rule would have left open (Card's own `left` placement still has that
+// gap, since it never collapses at all, at any width or container size).
+//
+// `leftMarker` is on the outer element (Paper/the `<a>` itself); `root` is
+// the *inner* flex wrapper one level down (see Linkbox.tsx) — deliberately
+// two different elements, because a `@container` query cannot restyle
+// layout-mode properties (like `flexDirection`) on the very element that
+// establishes the container. Querying `leftMarker` from its own rule for its
+// own `flexDirection` silently no-ops in Chromium even though the containment
+// spec doesn't forbid it outright; splitting container and containee avoids
+// the issue entirely, since `root` is a genuine descendant, not the container
+// querying itself.
+export const leftMarker = style({ containerType: 'inline-size' });
 
-const wideEnoughForRowSplit = `screen and (min-width: ${breakpoint.md.appWidth})`;
+const wideEnoughForRowSplit = `(min-width: ${breakpoint.md.appWidth})`;
 
-globalStyle(leftMarker, {
-  '@media': { [wideEnoughForRowSplit]: { flexDirection: 'row' } },
+globalStyle(`${leftMarker} > ${root}`, {
+  '@container': { [wideEnoughForRowSplit]: { flexDirection: 'row' } },
 });
-globalStyle(`${leftMarker} > ${media}`, {
-  '@media': {
+globalStyle(`${leftMarker} ${media}`, {
+  '@container': {
     [wideEnoughForRowSplit]: { aspectRatio: 'auto', flex: `0 0 ${card.mediaSplit}` },
   },
 });
-globalStyle(`${leftMarker} > ${content}`, {
-  '@media': { [wideEnoughForRowSplit]: { flex: `0 0 ${card.mediaSplit}` } },
+globalStyle(`${leftMarker} ${content}`, {
+  '@container': { [wideEnoughForRowSplit]: { flex: `0 0 ${card.mediaSplit}` } },
 });

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -1,7 +1,14 @@
 import { style, globalStyle } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 import { typography } from '../Typography/Typography.css';
-import { textBlock as cardTextBlock } from '../Card/Card.css';
+import {
+  textBlock as cardTextBlock,
+  root as cardRoot,
+  media as cardMedia,
+  content as cardContent,
+  contentPaddingVariants,
+} from '../Card/Card.css';
+import { breakpoint } from '../../theme/tokens/breakpoint';
 
 const {
   theme: {
@@ -17,7 +24,19 @@ const {
 // Linkbox's own eyebrow/title/description stack matches that exactly.
 export const textBlock = cardTextBlock;
 
-export const root = style({ display: 'flex', flexDirection: 'column', gap: card.spacing });
+// Reused wholesale from Card — Linkbox's own root/media/content/padding
+// structure is identical to Card's: `root` is a plain column flex container,
+// `media` is a fixed 3:2 box (or `auto` + a flex-basis split under Card's own
+// `rootMediaLeft`, which Linkbox never imports/applies) that bleeds to the
+// edge, and `content` is the padded text-content block that fills whatever
+// space `media` doesn't take. Only the `left`-placement responsive collapse
+// below is Linkbox-specific — Card's own `left` placement stays row at every
+// breakpoint; that behaviour is untouched since Linkbox never applies Card's
+// `rootMediaLeft` class.
+export const root = cardRoot;
+export const media = cardMedia;
+export const content = cardContent;
+export const contentPadding = contentPaddingVariants.md;
 
 // Figma's "Kuvaava teksti" (P1) is styled with text/secondary, not
 // Typography's own p1 default (text/primary) — only the description needs
@@ -77,4 +96,38 @@ globalStyle(`${root}${inverted}.${link}:hover`, {
 });
 globalStyle(`${root}${inverted}.${link}:focus-visible`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
+});
+
+// `left` media placement is a 50/50 row split above the `md` breakpoint —
+// below that, the whole card has narrowed enough that a row split gets
+// cramped, so it collapses to the same stacked layout `top` uses by default
+// (no override needed for the stacked state itself — that's just `root`'s
+// unconditional base `flexDirection: column`).
+//
+// This is the first component in the repo to use a real `@media` query in
+// its own stylesheet — every other breakpoint-dependent value comes from
+// `vars.theme` swapping at `:root` (theme.css.ts), which works for a value
+// swap but not a structural row↔column switch. Deliberately scoped to this
+// component's own `leftMarker` (never applied to Card's `rootMediaLeft`), so
+// Card's own `left` placement — which stays row at every breakpoint — is
+// untouched.
+//
+// Viewport-based, not a container query (none exist yet in this repo): a
+// `left`-placed Linkbox squeezed into a narrow grid column on a wide
+// viewport still renders row layout. Known limitation, not a regression —
+// Card's own `left` placement never collapses at all, at any width.
+export const leftMarker = style({});
+
+const wideEnoughForRowSplit = `screen and (min-width: ${breakpoint.md.appWidth})`;
+
+globalStyle(leftMarker, {
+  '@media': { [wideEnoughForRowSplit]: { flexDirection: 'row' } },
+});
+globalStyle(`${leftMarker} > ${media}`, {
+  '@media': {
+    [wideEnoughForRowSplit]: { aspectRatio: 'auto', flex: `0 0 ${card.mediaSplit}` },
+  },
+});
+globalStyle(`${leftMarker} > ${content}`, {
+  '@media': { [wideEnoughForRowSplit]: { flex: `0 0 ${card.mediaSplit}` } },
 });

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -9,7 +9,6 @@ const {
     contrast,
     hover,
     focusRing,
-    focusRingInverted,
     components: { card },
   },
 } = vars;
@@ -80,11 +79,15 @@ export const link = style({
   },
 });
 
+// Only the tint differs when `inverted` — Figma's own Focus-visible/Outline
+// variable is the same dark #1e1e22 for both the Default and Inverted focus
+// cells (confirmed against the "Card link content" Figma frame), so the
+// outline itself doesn't need an inverted override the way e.g. Card's
+// nested TextLink focus ring does against its own (different) backgrounds.
 globalStyle(`${root}${inverted}.${link}:hover`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
 globalStyle(`${root}${inverted}.${link}:focus-visible`, {
-  ...focusRingInverted,
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
 
@@ -103,7 +106,6 @@ export const overlayLink = style({
 
 globalStyle(`${root}${inverted} .${overlayLink}:hover`, { backgroundColor: hover.overlayContrast });
 globalStyle(`${root}${inverted} .${overlayLink}:focus-visible`, {
-  ...focusRingInverted,
   backgroundColor: hover.overlayContrast,
 });
 

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -52,8 +52,14 @@ export const contentPadding = contentPaddingVariants.md;
 // Figma's "Kuvaava teksti" (P1) is styled with text/secondary, not
 // Typography's own p1 default (text/primary) — only the description needs
 // this override; the eyebrow (P2) and title (H3) already default to
-// text/secondary and text/header respectively.
-export const description = style({ color: text.secondary });
+// text/secondary and text/header respectively. `!important` isn't required to
+// beat Typography's own p1 class on specificity (this is a single class same
+// as that one, but applied via `className` alongside it, so source order
+// already decides) — same defensive reasoning as Card.css.ts's
+// `invertibleSelectors`: it guards against a same-specificity rule declared
+// later in source order (e.g. Typography's own stylesheet re-ordering, or a
+// consumer `className` override) winning the cascade regardless of intent.
+export const description = style({ color: `${text.secondary} !important` });
 
 // Icon row sits below the text block, matching Figma's arrow position.
 export const iconRow = style({ display: 'flex', alignItems: 'center', color: text.header });
@@ -99,11 +105,14 @@ export const link = style({
   },
 });
 
-// Only the tint differs when `inverted` — Figma's own Focus-visible/Outline
-// variable is the same dark #1e1e22 for both the Default and Inverted focus
-// cells (confirmed against the "Card link content" Figma frame), so the
+// Only the tint differs when `inverted` — as of the "Card link content" Figma
+// frame checked for this component, its Focus-visible/Outline variable is the
+// same dark #1e1e22 for both the Default and Inverted focus cells, so the
 // outline itself doesn't need an inverted override the way e.g. Card's
 // nested TextLink focus ring does against its own (different) backgrounds.
+// If that Figma variable is ever split per-background, this (and the
+// `InvertedFocusVisibleUsesSameOutlineAsDefault` story asserting it) will
+// need revisiting — nothing here re-derives it from a live source of truth.
 globalStyle(`${inverted}.${link}:hover`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
@@ -144,10 +153,11 @@ globalStyle(`${inverted}.${link}:focus-visible`, {
 // the container's own inline size as though it had no content, so without an
 // explicit width a `left`-placed Linkbox used as a flex item (the common case
 // — a row of cards) collapses to 0 width instead of sharing the row (verified
-// in Chromium: 0px vs. 226px for an otherwise-identical `top`-placed sibling).
-// A plain block-flow parent doesn't hit this — its `width: auto` already
-// fills the containing block regardless of content — which is why it went
-// unnoticed: every existing story wraps the box in a plain (non-flex) div.
+// in Chromium against a one-off repro — a non-zero width is what matters here,
+// the exact pixel figure measured isn't a maintained invariant). A plain
+// block-flow parent doesn't hit this — its `width: auto` already fills the
+// containing block regardless of content — which is why it went unnoticed:
+// every existing story wraps the box in a plain (non-flex) div.
 export const leftMarker = style({ containerType: 'inline-size', width: '100%' });
 
 // Intentionally not `breakpoint.md.appWidth` (the responsive viewport
@@ -160,14 +170,20 @@ export const leftMarker = style({ containerType: 'inline-size', width: '100%' })
 // any time the design system's `md` breakpoint changes for unrelated reasons.
 const wideEnoughForRowSplit = `(min-width: ${containerQueryBreakpoint.md})`;
 
+// Full child-combinator chains (`leftMarker > root > media`/`content`), not
+// `leftMarker`-to-descendant — `media`/`content` are Card's own shared
+// classes, so a plain descendant selector would also reach a `Card` (or
+// another Linkbox) nested two levels down inside this Linkbox's `media` slot,
+// force-splitting its layout too. The explicit chain scopes this strictly to
+// Linkbox's own direct structure.
 globalStyle(`${leftMarker} > ${root}`, {
   '@container': { [wideEnoughForRowSplit]: { flexDirection: 'row' } },
 });
-globalStyle(`${leftMarker} ${media}`, {
+globalStyle(`${leftMarker} > ${root} > ${media}`, {
   '@container': {
     [wideEnoughForRowSplit]: { aspectRatio: 'auto', flex: `0 0 ${card.mediaSplit}` },
   },
 });
-globalStyle(`${leftMarker} ${content}`, {
+globalStyle(`${leftMarker} > ${root} > ${content}`, {
   '@container': { [wideEnoughForRowSplit]: { flex: `0 0 ${card.mediaSplit}` } },
 });

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -17,15 +17,7 @@ const {
 // Linkbox's own eyebrow/title/description stack matches that exactly.
 export const textBlock = cardTextBlock;
 
-// Root needs `position: relative` so the nested-interactive overlay `<a>`
-// (`overlayLink` below) can size itself via `inset: 0` against this box
-// rather than the page.
-export const root = style({
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: card.spacing,
-});
+export const root = style({ display: 'flex', flexDirection: 'column', gap: card.spacing });
 
 // Figma's "Kuvaava teksti" (P1) is styled with text/secondary, not
 // Typography's own p1 default (text/primary) — only the description needs
@@ -46,8 +38,7 @@ export const inverted = style({});
 
 // Same allowlist-driven inversion technique as Card.css.ts's
 // `invertibleSelectors` — flips Linkbox's own text/icon to the contrast
-// color when `inverted`, without a blanket selector that would also force
-// invert something a consumer nests in `actions`.
+// color when `inverted`.
 const invertibleTextSelectors = Object.values(typography)
   .map((className) => `${root}${inverted} .${className}`)
   .join(', ');
@@ -55,19 +46,16 @@ const invertibleTextSelectors = Object.values(typography)
 globalStyle(invertibleTextSelectors, { color: `${contrast} !important` });
 globalStyle(`${root}${inverted} .${iconRow}`, { color: contrast });
 
-// ── Simple mode: the root itself is the `<a>` ────────────────────────────
-//
-// The overlay tint is applied via `backgroundImage` (a same-color-stop
-// linear-gradient), not `backgroundColor` — in this mode `link` is on the
-// exact same element as Paper's own `background-color` (white or, when
-// `inverted`, turquoise), so setting `backgroundColor` here would replace
-// that opaque color outright rather than tint over it: a translucent
-// `rgba(255,255,255,0.1)` `backgroundColor` on the turquoise surface erased
-// it down to ~10% opacity, making the whole box nearly disappear against
-// the page behind it. `backgroundImage` paints on top of `backgroundColor`
-// (CSS's own layering order) without touching the color underneath — the
-// nested mode's separate `overlayLink` element below doesn't have this
-// problem, since it has no `backgroundColor` of its own to begin with.
+// The whole box is a real `<a>` — Paper's `component="a"`. The overlay tint
+// is applied via `backgroundImage` (a same-color-stop linear-gradient), not
+// `backgroundColor`: `link` is on the exact same element as Paper's own
+// `background-color` (white or, when `inverted`, turquoise), so setting
+// `backgroundColor` here would replace that opaque color outright rather
+// than tint over it — a translucent `rgba(255,255,255,0.1)` `backgroundColor`
+// on the turquoise surface once erased it down to ~10% opacity, making the
+// whole box nearly disappear against the page behind it. `backgroundImage`
+// paints on top of `backgroundColor` (CSS's own layering order) without
+// touching the color underneath.
 export const link = style({
   textDecoration: 'none',
   selectors: {
@@ -89,44 +77,4 @@ globalStyle(`${root}${inverted}.${link}:hover`, {
 });
 globalStyle(`${root}${inverted}.${link}:focus-visible`, {
   backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
-});
-
-// ── Nested-interactive mode: a covering overlay `<a>`, plus a positioned
-// content wrapper so the real content/actions paint above it ────────────
-export const overlayLink = style({
-  position: 'absolute',
-  inset: 0,
-  zIndex: 0,
-  textDecoration: 'none',
-  selectors: {
-    '&:hover': { backgroundColor: hover.overlay },
-    '&:focus-visible': { ...focusRing, backgroundColor: hover.overlay },
-  },
-});
-
-globalStyle(`${root}${inverted} .${overlayLink}:hover`, { backgroundColor: hover.overlayContrast });
-globalStyle(`${root}${inverted} .${overlayLink}:focus-visible`, {
-  backgroundColor: hover.overlayContrast,
-});
-
-// `zIndex: 1` puts `content`/`actions` above `overlayLink` so a real pointer
-// click over e.g. a nested Button hits the button, not the covering link —
-// not caught by `ActionsRemainClickable`'s `userEvent.click` (which targets
-// the button node directly rather than hit-testing screen coordinates, the
-// same synthetic-event gap TextLink.css.ts documents for `:hover`); verified
-// manually via Storybook instead.
-//
-// Also carries its own flex-column + `card.spacing` gap: wrapping `content`
-// (textBlock + iconRow) in this div for the z-index above otherwise strands
-// them in plain block flow, losing the gap `root`'s own flex layout gives
-// its *direct* children — regression caught visually in Storybook (nested
-// mode's arrow sat flush against the description instead of Figma's 24px
-// gap). Reused for the `actions` wrapper too, where a single child is
-// unaffected and multiple children get the same sensible stacking.
-export const positionedContent = style({
-  position: 'relative',
-  zIndex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: card.spacing,
 });

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -57,18 +57,35 @@ globalStyle(invertibleTextSelectors, { color: `${contrast} !important` });
 globalStyle(`${root}${inverted} .${iconRow}`, { color: contrast });
 
 // ── Simple mode: the root itself is the `<a>` ────────────────────────────
+//
+// The overlay tint is applied via `backgroundImage` (a same-color-stop
+// linear-gradient), not `backgroundColor` — in this mode `link` is on the
+// exact same element as Paper's own `background-color` (white or, when
+// `inverted`, turquoise), so setting `backgroundColor` here would replace
+// that opaque color outright rather than tint over it: a translucent
+// `rgba(255,255,255,0.1)` `backgroundColor` on the turquoise surface erased
+// it down to ~10% opacity, making the whole box nearly disappear against
+// the page behind it. `backgroundImage` paints on top of `backgroundColor`
+// (CSS's own layering order) without touching the color underneath — the
+// nested mode's separate `overlayLink` element below doesn't have this
+// problem, since it has no `backgroundColor` of its own to begin with.
 export const link = style({
   textDecoration: 'none',
   selectors: {
-    '&:hover': { backgroundColor: hover.overlay },
-    '&:focus-visible': { ...focusRing, backgroundColor: hover.overlay },
+    '&:hover': { backgroundImage: `linear-gradient(${hover.overlay}, ${hover.overlay})` },
+    '&:focus-visible': {
+      ...focusRing,
+      backgroundImage: `linear-gradient(${hover.overlay}, ${hover.overlay})`,
+    },
   },
 });
 
-globalStyle(`${root}${inverted}.${link}:hover`, { backgroundColor: hover.overlayContrast });
+globalStyle(`${root}${inverted}.${link}:hover`, {
+  backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
+});
 globalStyle(`${root}${inverted}.${link}:focus-visible`, {
   ...focusRingInverted,
-  backgroundColor: hover.overlayContrast,
+  backgroundImage: `linear-gradient(${hover.overlayContrast}, ${hover.overlayContrast})`,
 });
 
 // ── Nested-interactive mode: a covering overlay `<a>`, plus a positioned

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -8,7 +8,7 @@ import {
   content as cardContent,
   contentPaddingVariants,
 } from '../Card/Card.css';
-import { breakpoint } from '../../theme/tokens/breakpoint';
+import { containerQueryBreakpoint } from '../../theme/tokens/breakpoint';
 
 const {
   theme: {
@@ -36,6 +36,8 @@ export const textBlock = cardTextBlock;
 export const root = cardRoot;
 export const media = cardMedia;
 export const content = cardContent;
+// Card exposes `sm`/`md`/`lg` padding via its own `size` prop; Linkbox has no
+// equivalent size variant, so it always uses Card's `md` tier.
 export const contentPadding = contentPaddingVariants.md;
 
 // Figma's "Kuvaava teksti" (P1) is styled with text/secondary, not
@@ -71,13 +73,12 @@ globalStyle(`${inverted} .${iconRow}`, { color: contrast });
 // The whole box is a real `<a>` — Paper's `component="a"`. The overlay tint
 // is applied via `backgroundImage` (a same-color-stop linear-gradient), not
 // `backgroundColor`: `link` is on the exact same element as Paper's own
-// `background-color` (white or, when `inverted`, turquoise), so setting
-// `backgroundColor` here would replace that opaque color outright rather
-// than tint over it — a translucent `rgba(255,255,255,0.1)` `backgroundColor`
-// on the turquoise surface once erased it down to ~10% opacity, making the
-// whole box nearly disappear against the page behind it. `backgroundImage`
-// paints on top of `backgroundColor` (CSS's own layering order) without
-// touching the color underneath.
+// `background-color` (white or, when `inverted`, turquoise), so a translucent
+// `backgroundColor` here would replace that opaque color outright rather than
+// tint over it — e.g. `rgba(255,255,255,0.1)` on the turquoise surface drops
+// it to ~10% opacity, nearly invisible against the page behind it.
+// `backgroundImage` paints on top of `backgroundColor` (CSS's own layering
+// order) without touching the color underneath.
 export const link = style({
   textDecoration: 'none',
   selectors: {
@@ -132,9 +133,26 @@ globalStyle(`${inverted}.${link}:focus-visible`, {
 // spec doesn't forbid it outright; splitting container and containee avoids
 // the issue entirely, since `root` is a genuine descendant, not the container
 // querying itself.
-export const leftMarker = style({ containerType: 'inline-size' });
+//
+// `width: '100%'` is required, not cosmetic: inline-size containment computes
+// the container's own inline size as though it had no content, so without an
+// explicit width a `left`-placed Linkbox used as a flex item (the common case
+// — a row of cards) collapses to 0 width instead of sharing the row (verified
+// in Chromium: 0px vs. 226px for an otherwise-identical `top`-placed sibling).
+// A plain block-flow parent doesn't hit this — its `width: auto` already
+// fills the containing block regardless of content — which is why it went
+// unnoticed: every existing story wraps the box in a plain (non-flex) div.
+export const leftMarker = style({ containerType: 'inline-size', width: '100%' });
 
-const wideEnoughForRowSplit = `(min-width: ${breakpoint.md.appWidth})`;
+// Intentionally not `breakpoint.md.appWidth` (the responsive viewport
+// breakpoint table in `theme/tokens/breakpoint.ts`, swapped in via CSS custom
+// properties at `:root`): `@container` conditions require a literal length,
+// not a `var()` reference, and — more importantly — this threshold is a
+// Linkbox-local layout decision (a 50/50 row split gets cramped below this
+// container width), not the site's responsive viewport grid. Reusing the
+// viewport token would silently retune this component's own collapse point
+// any time the design system's `md` breakpoint changes for unrelated reasons.
+const wideEnoughForRowSplit = `(min-width: ${containerQueryBreakpoint.md})`;
 
 globalStyle(`${leftMarker} > ${root}`, {
   '@container': { [wideEnoughForRowSplit]: { flexDirection: 'row' } },

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -33,7 +33,16 @@ export const textBlock = cardTextBlock;
 // below is Linkbox-specific — Card's own `left` placement stays row at every
 // breakpoint; that behaviour is untouched since Linkbox never applies Card's
 // `rootMediaLeft` class.
-export const root = cardRoot;
+//
+// One addition over Card's own `root`: `height: 100%`. Card's `root` sits
+// directly on the stretched flex/grid item (Paper) itself, so a parent row
+// of equal-height cards stretches it for free and `content`'s `flex: 1 0 0`
+// fills the box. Linkbox's `root` lives one level *down*, on an inner `<div>`
+// (see `leftMarker` below and Linkbox.tsx), and an `auto`-height div isn't
+// stretched by anything — without this, a Linkbox in a stretched flex/grid
+// row only grows to its content's intrinsic height, leaving bare surface
+// below the media/icon row instead of filling the box.
+export const root = style([cardRoot, { height: '100%' }]);
 export const media = cardMedia;
 export const content = cardContent;
 // Card exposes `sm`/`md`/`lg` padding via its own `size` prop; Linkbox has no
@@ -126,13 +135,10 @@ globalStyle(`${inverted}.${link}:focus-visible`, {
 //
 // `leftMarker` is on the outer element (Paper/the `<a>` itself); `root` is
 // the *inner* flex wrapper one level down (see Linkbox.tsx) — deliberately
-// two different elements, because a `@container` query cannot restyle
-// layout-mode properties (like `flexDirection`) on the very element that
-// establishes the container. Querying `leftMarker` from its own rule for its
-// own `flexDirection` silently no-ops in Chromium even though the containment
-// spec doesn't forbid it outright; splitting container and containee avoids
-// the issue entirely, since `root` is a genuine descendant, not the container
-// querying itself.
+// two different elements. Container queries cannot restyle the element that
+// establishes the container itself — a documented, cross-engine restriction
+// of the feature, not a browser-specific gap — so `root` has to be a genuine
+// descendant of `leftMarker`, not the same element being queried.
 //
 // `width: '100%'` is required, not cosmetic: inline-size containment computes
 // the container's own inline size as though it had no content, so without an

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -9,7 +9,7 @@ const {
     contrast,
     hover,
     focusRing,
-    components: { card },
+    components: { card, icon: iconTokens },
   },
 } = vars;
 
@@ -28,7 +28,7 @@ export const description = style({ color: text.secondary });
 // Icon row sits below the text block, matching Figma's arrow position.
 export const iconRow = style({ display: 'flex', alignItems: 'center', color: text.header });
 
-export const icon = style({ width: '1.5rem', height: '1.5rem' });
+export const icon = style({ width: iconTokens.size.large, height: iconTokens.size.large });
 
 // Marker class toggled when `inverted` — no rule of its own (the background
 // color itself comes from Paper's `background="turquoise"`), just a hook for

--- a/src/components/Linkbox/Linkbox.css.ts
+++ b/src/components/Linkbox/Linkbox.css.ts
@@ -68,22 +68,25 @@ export const icon = style({ width: iconTokens.size.large, height: iconTokens.siz
 
 // Marker class toggled when `inverted` — no rule of its own (the background
 // color itself comes from Paper's `background="turquoise"`), just a hook for
-// the invertible text/icon selectors below. Same technique as Card.css.ts's
-// `inverted` marker.
+// the invertible text/icon selectors below and for the link hover/focus
+// overlay tint further down. Same technique as Card.css.ts's `inverted`
+// marker, applied on Paper (see Linkbox.tsx) for that second purpose.
 export const inverted = style({});
 
 // Same allowlist-driven inversion technique as Card.css.ts's
-// `invertibleSelectors` — flips Linkbox's own text/icon to the contrast
-// color when `inverted`. `inverted` alone (not compounded with `root`) is
-// enough to scope this to Linkbox instances — it's a Linkbox-local marker,
-// and `root` lives on a different (inner) element now (see `leftMarker`
-// below), so the two are no longer ever on the same element.
+// `invertibleSelectors`, and — like Card — compounded with `content` (applied
+// together on Linkbox.tsx's content `<div>`, alongside Paper) rather than
+// matched bare: `media` is a sibling of `content`, not a descendant, so a
+// bare `${inverted} .${className}` selector (matched from Paper, where
+// `inverted` also lives for the link-hover rules below) would reach into
+// `media` too and force-invert any Typography a consumer nests there. The
+// `${content}${inverted}` compound keeps this scoped the same way Card's is.
 const invertibleTextSelectors = Object.values(typography)
-  .map((className) => `${inverted} .${className}`)
+  .map((className) => `${content}${inverted} .${className}`)
   .join(', ');
 
 globalStyle(invertibleTextSelectors, { color: `${contrast} !important` });
-globalStyle(`${inverted} .${iconRow}`, { color: contrast });
+globalStyle(`${content}${inverted} .${iconRow}`, { color: contrast });
 
 // The whole box is a real `<a>` — Paper's `component="a"`. The overlay tint
 // is applied via `backgroundImage` (a same-color-stop linear-gradient), not

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -96,6 +96,25 @@ export const InvertedFocusVisibleUsesInvertedOutline: Story = {
   },
 };
 
+export const InvertedFocusVisibleKeepsOpaqueBackground: Story = {
+  // Regression: the focus/hover overlay tint was applied via `backgroundColor`
+  // — on the same element as Paper's own opaque turquoise `backgroundColor` in
+  // simple mode, a translucent `rgba(255,255,255,0.1)` override replaced (not
+  // tinted) it, leaving the box ~90% transparent and effectively invisible
+  // against the page. Must stay layered via `backgroundImage` instead, so the
+  // underlying `backgroundColor` is untouched by focus/hover.
+  args: { inverted: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    (link as HTMLAnchorElement).focus();
+    const style = getComputedStyle(link);
+    await expect(style.backgroundColor).toBe('rgb(0, 116, 164)');
+    await expect(style.backgroundImage).not.toBe('none');
+  },
+};
+
 export const External: Story = {
   tags: docExample,
   args: { external: true, href: 'https://tampere.fi' },

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -76,6 +76,22 @@ export const FocusVisible: Story = {
   },
 };
 
+export const FocusVisibleKeepsOpaqueBackground: Story = {
+  // Same layering guarantee as `InvertedFocusVisibleKeepsOpaqueBackground`,
+  // asserted on the default (non-inverted) surface too — the hover/focus
+  // tint must stay layered via `backgroundImage`, not replace the white
+  // `backgroundColor` outright.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    (link as HTMLAnchorElement).focus();
+    const style = getComputedStyle(link);
+    await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
+    await expect(style.backgroundImage).not.toBe('none');
+  },
+};
+
 export const InvertedColor: Story = {
   tags: docExample,
   args: { inverted: true },
@@ -165,6 +181,22 @@ export const WithCustomComponent: Story = {
   },
 };
 
+export const WithCustomComponentAndExternal: Story = {
+  // `external`'s `target`/`rel`/accessible-name contract must still apply
+  // when the root element is swapped via `component` (e.g. a router `Link`),
+  // not just the default `<a>`.
+  args: { component: FakeRouterLink, external: true, href: 'https://tampere.fi' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /^Otsikko/ });
+
+    await expect(link).toHaveAttribute('data-router-link', 'true');
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(link).toHaveAccessibleName(/avautuu uuteen välilehteen/);
+  },
+};
+
 export const WithTitleOrderOverride: Story = {
   args: { titleOrder: 4 },
   play: async ({ canvasElement }) => {
@@ -224,6 +256,20 @@ export const WarnsWhenTargetIgnoredByExternal: Story = {
   play: async () => {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /`target` is ignored/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsWithInvalidTitleOrder: Story = {
+  // `titleOrder` isn't looked up in a `styleVariants` map (it drives a plain
+  // object lookup passed to `Typography`'s `component` prop), so an
+  // out-of-union value would otherwise silently drop the heading-tag
+  // override with no signal — same risk class Card's identical prop guards.
+  args: { titleOrder: 6 as unknown as 2 | 3 | 4 | 5 },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `titleOrder`/.test(m))).toBe(true)
     );
   },
 };

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -4,6 +4,40 @@ import { within, waitFor } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Linkbox } from './Linkbox';
 
+// A 1x1 GIF has no real intrinsic size, so it can't catch the media wrapper
+// collapsing to 0 height in the default (top) layout — this SVG has real
+// width/height and stands in for a real photo (same fixture Card's own media
+// stories use).
+const sizedMediaImage = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="260" height="195"><rect width="260" height="195" fill="#ccc"/></svg>'
+)}`;
+
+// `vitest/browser`'s `page.viewport` resizes the story's own iframe — the
+// only way to actually exercise a real `@media` breakpoint (Linkbox's
+// `left`-placement collapse is the first such rule in this repo; every other
+// breakpoint behaviour comes from `vars.theme` swapping value at `:root`,
+// which every ambient test already picks up regardless of viewport size).
+//
+// This module throws at evaluation time when loaded outside Vitest Browser
+// Mode — which is exactly what happens when this SAME `.stories.tsx` file is
+// loaded by Storybook's own plain dev server (not the Vitest test runner) to
+// render/browse these stories interactively. A static top-level import would
+// crash that module for the *entire* file, not just the stories that use it.
+// Dynamic-import it lazily instead, and swallow the "not in Browser Mode"
+// case as a no-op — outside Vitest there's no real viewport to resize, and
+// the two stories that need it are tagged test-only (`!dev`/`!autodocs`)
+// precisely because their assertions only hold under an actual resize.
+async function resizeViewport(width: number, height: number) {
+  try {
+    const { page } = await import('vitest/browser');
+    await page.viewport(width, height);
+  } catch {
+    // Not running under Vitest Browser Mode — nothing to resize.
+  }
+}
+
+const WIDE_VIEWPORT = [1024, 768] as const;
+
 const meta = {
   component: Linkbox,
   tags: ['!dev', '!autodocs'],
@@ -143,6 +177,81 @@ export const InvertedFocusVisibleKeepsOpaqueBackground: Story = {
     const style = getComputedStyle(link);
     await expect(style.backgroundColor).toBe('rgb(0, 116, 164)');
     await expect(style.backgroundImage).not.toBe('none');
+  },
+};
+
+export const WithMediaTop: Story = {
+  tags: docExample,
+  render: (args) => (
+    <div style={{ width: 600 }}>
+      <Linkbox {...args} />
+    </div>
+  ),
+  args: { media: <img alt="" src={sizedMediaImage} /> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    const media = canvas.getByRole('img');
+    const mediaWrapper = media.parentElement as HTMLElement;
+
+    // Media bleeds to the edge — no padding on its own wrapper (Card's same
+    // regression: padding lives on the text-content wrapper, not the root).
+    await expect(getComputedStyle(mediaWrapper).padding).toBe('0px');
+    const linkWidth = link.getBoundingClientRect().width;
+    const mediaHeight = mediaWrapper.getBoundingClientRect().height;
+    // Fixed 3:2 box — the image crops to fill it, not the other way around.
+    await expect(Math.abs(linkWidth / mediaHeight - 1.5)).toBeLessThan(0.05);
+    await expect(getComputedStyle(media).objectFit).toBe('cover');
+  },
+};
+
+export const WithMediaLeft: Story = {
+  // Plain visual example — no viewport manipulation, so it renders correctly
+  // in Storybook's own dev server too (see `resizeViewport` above). Whether
+  // it actually shows the row or the collapsed layout depends on the ambient
+  // canvas width; the two behaviours are asserted precisely (and test-only,
+  // since they need a real resize) by the two stories below.
+  tags: docExample,
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
+};
+
+export const WithMediaLeftUsesRowLayoutAtWideViewport: Story = {
+  // Test-only (not `docExample`): needs a real Vitest Browser Mode viewport
+  // resize to mean anything, which `WithMediaLeft` above deliberately avoids.
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
+  play: async ({ canvasElement }) => {
+    await resizeViewport(1280, 900);
+    try {
+      const canvas = within(canvasElement);
+      const link = canvas.getByRole('link', { name: 'Otsikko' });
+      await expect(getComputedStyle(link).flexDirection).toBe('row');
+    } finally {
+      await resizeViewport(...WIDE_VIEWPORT);
+    }
+  },
+};
+
+export const WithMediaLeftCollapsesToStackedBelowMdBreakpoint: Story = {
+  // A 50/50 row split gets cramped once the whole card narrows past tablet
+  // width — below the `md` (768px) breakpoint, `left` falls back to the same
+  // stacked layout `top` uses by default.
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
+  play: async ({ canvasElement }) => {
+    await resizeViewport(480, 900);
+    try {
+      const canvas = within(canvasElement);
+      const link = canvas.getByRole('link', { name: 'Otsikko' });
+      const media = canvas.getByRole('img');
+      const mediaWrapper = media.parentElement as HTMLElement;
+
+      await expect(getComputedStyle(link).flexDirection).toBe('column');
+      // Genuinely stacked like `top`, not just "not row" — full-width 3:2 box.
+      const linkWidth = link.getBoundingClientRect().width;
+      const mediaHeight = mediaWrapper.getBoundingClientRect().height;
+      await expect(Math.abs(linkWidth / mediaHeight - 1.5)).toBeLessThan(0.05);
+    } finally {
+      await resizeViewport(...WIDE_VIEWPORT);
+    }
   },
 };
 

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -82,17 +82,19 @@ export const InvertedColor: Story = {
   },
 };
 
-export const InvertedFocusVisibleUsesInvertedOutline: Story = {
+export const InvertedFocusVisibleUsesSameOutlineAsDefault: Story = {
+  // Unlike Card's nested TextLink focus ring (which does invert to white
+  // against Card's colored backgrounds), Figma's own "Card link content"
+  // Focus-visible/Outline variable is the same dark #1e1e22 for both the
+  // Default and Inverted focus cells — Linkbox's own box-level focus ring
+  // doesn't get an inverted variant.
   args: { inverted: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link');
 
     (link as HTMLAnchorElement).focus();
-    // Neutral outline (#1e1e22) fails WCAG's 3:1 non-text-contrast minimum
-    // against the turquoise background — must use the white inverted outline,
-    // same guarantee Card already gives nested TextLink focus on colored bg.
-    await expect(getComputedStyle(link).outlineColor).toBe('rgb(255, 255, 255)');
+    await expect(getComputedStyle(link).outlineColor).toBe('rgb(30, 30, 34)');
   },
 };
 

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -439,3 +439,35 @@ export const WithMediaLeftAsFlexItemFillsAvailableWidth: Story = {
     await expect(link.getBoundingClientRect().width).toBeGreaterThan(0);
   },
 };
+
+export const StretchedByFlexRowFillsFullHeight: Story = {
+  // Regression: the inner flex wrapper (`root` in Linkbox.css.ts) had no
+  // explicit height. Card's own `root` sits directly on the stretched
+  // flex/grid item, so it's stretched for free — Linkbox's `root` lives one
+  // level *down* on an inner `<div>` that a plain `align-items: stretch`
+  // doesn't reach, so it only grew to its content's intrinsic height,
+  // leaving bare surface below the media/icon row instead of filling the
+  // box. `WithMediaLeftAsFlexItemFillsAvailableWidth` above doesn't catch
+  // this — the Linkbox is that row's only item, so nothing stretches it.
+  // This story adds a much taller sibling to force a real stretch and
+  // asserts the media fills the full stretched height, not just its own
+  // intrinsic height.
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
+  render: (args) => (
+    <div style={{ display: 'flex', width: 1200 }}>
+      <Linkbox {...args} />
+      <div style={{ height: 600, width: 1 }} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    const media = canvas.getByRole('img');
+    const mediaWrapper = media.parentElement as HTMLElement;
+
+    const linkRect = link.getBoundingClientRect();
+    const mediaRect = mediaWrapper.getBoundingClientRect();
+    await expect(linkRect.height).toBeGreaterThanOrEqual(600);
+    await expect(Math.abs(mediaRect.bottom - linkRect.bottom)).toBeLessThan(1);
+  },
+};

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -38,7 +38,10 @@ export const Default: Story = {
     await expect(link).toHaveAttribute('href', '#');
     await expect(canvas.getByText('Lisätietoa')).not.toBeNull();
     await expect(canvas.getByText('Kuvaava teksti')).not.toBeNull();
-    await expect(link.querySelector('svg')).not.toBeNull();
+    // The internal `ArrowRightIcon` has 2 `<path>`s; `OpenExternalLinkIcon`
+    // (asserted in `External` below) has 3 — a stable, implementation-light
+    // way to confirm the *internal* icon renders here, not just "some SVG".
+    await expect(link.querySelectorAll('svg path').length).toBe(2);
 
     const style = getComputedStyle(link);
     // Figma "Card link content" — Background/Default = #ffffff.
@@ -241,6 +244,26 @@ export const External: Story = {
     await expect(link).toHaveAttribute('target', '_blank');
     await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     await expect(link).toHaveAccessibleName(/avautuu uuteen välilehteen/);
+    // The external `OpenExternalLinkIcon` has 3 `<path>`s, vs. the internal
+    // `ArrowRightIcon`'s 2 (asserted in `Default` above) — confirms the icon
+    // actually swapped, not just that `external`'s other side effects fired.
+    await expect(link.querySelectorAll('svg path').length).toBe(3);
+  },
+};
+
+export const AppendsExternalLabelToConsumerAriaLabelOverride: Story = {
+  // Regression guard: a consumer's own `aria-label` must not silently drop
+  // `external`'s screen-reader signal — see the comment on `baseAccessibleName`
+  // in Linkbox.tsx. Issue #75 requires external links to be flagged to AT
+  // regardless of whether the accessible name is the default `title` or a
+  // consumer override.
+  args: { external: true, href: 'https://tampere.fi', 'aria-label': 'Mukautettu nimi' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    await expect(link).toHaveAccessibleName(/^Mukautettu nimi/);
+    await expect(link).toHaveAccessibleName(/avautuu uuteen välilehteen/);
   },
 };
 
@@ -300,6 +323,33 @@ export const WithCustomClassName: Story = {
   },
 };
 
+let forwardedRefNode: HTMLElement | null = null;
+
+export const ForwardsRefToRenderedElement: Story = {
+  // `forwardRef<HTMLDivElement, LinkboxProps>` (see Linkbox.tsx) forwards
+  // straight through to `Paper` with no cast at this boundary — a regression
+  // that forwarded the ref to the wrong node, or dropped it, would still
+  // type-check cleanly, so only a test like this one catches it.
+  render: (args) => {
+    forwardedRefNode = null;
+    return (
+      <Linkbox
+        {...args}
+        ref={(node) => {
+          forwardedRefNode = node;
+        }}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+
+    await waitFor(() => expect(forwardedRefNode).not.toBeNull());
+    await expect(forwardedRefNode).toBe(link);
+  },
+};
+
 export const MergesRelWithExternal: Story = {
   args: { external: true, rel: 'nofollow' },
   play: async ({ canvasElement }) => {
@@ -325,16 +375,6 @@ const captureConsoleErrors = () => {
   };
 };
 
-export const WarnsWithoutDestination: Story = {
-  args: { href: undefined },
-  beforeEach: captureConsoleErrors,
-  play: async () => {
-    await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /provide `href`/.test(m))).toBe(true)
-    );
-  },
-};
-
 export const WarnsWhenTargetIgnoredByExternal: Story = {
   args: { external: true, target: '_self' },
   beforeEach: captureConsoleErrors,
@@ -356,5 +396,46 @@ export const WarnsWithInvalidTitleOrder: Story = {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /invalid `titleOrder`/.test(m))).toBe(true)
     );
+  },
+};
+
+export const WarnsWithInvalidMediaPlacement: Story = {
+  // Same risk class as `WarnsWithInvalidTitleOrder` above: an out-of-union
+  // `mediaPlacement` silently falls back to the `top`/stacked layout with no
+  // other signal (see the guard in Linkbox.tsx).
+  args: {
+    media: <img alt="" src={sizedMediaImage} />,
+    mediaPlacement: 'bottom' as unknown as 'top' | 'left',
+  },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `mediaPlacement`/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WithMediaLeftAsFlexItemFillsAvailableWidth: Story = {
+  // Regression: `leftMarker`'s `containerType: 'inline-size'` computes the
+  // container's own inline size as though it had no content — without an
+  // explicit width, a `left`-placed Linkbox used as a flex item (the common
+  // real-world layout: a row of cards) collapsed to 0 width instead of
+  // sharing the row. `WithMediaLeft`/`...CollapsesToStackedBelowMdBreakpoint`
+  // above don't catch this — they wrap in a plain block-level div, which
+  // doesn't hit the bug (a block box's `width: auto` already fills its
+  // containing block regardless of content). This story wraps in a flex row
+  // instead, with no explicit width on the Linkbox itself, to exercise the
+  // actual failure mode.
+  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
+  render: (args) => (
+    <div style={{ display: 'flex', width: 1200 }}>
+      <Linkbox {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+
+    await expect(link.getBoundingClientRect().width).toBeGreaterThan(0);
   },
 };

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -1,7 +1,7 @@
+import type { AnchorHTMLAttributes } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within, userEvent, waitFor } from '@storybook/testing-library';
-import { expect, fn } from 'storybook/test';
-import { Button } from '../Button';
+import { within, waitFor } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 import { Linkbox } from './Linkbox';
 
 const meta = {
@@ -40,8 +40,8 @@ export const Default: Story = {
 };
 
 export const AccessibleNameIsTitleOnly: Story = {
-  // Simple mode's whole box is the `<a>` — its accessible name must be just
-  // `title`, not eyebrow+title+description read together as one link name.
+  // The whole box is the `<a>` — its accessible name must be just `title`,
+  // not eyebrow+title+description read together as one link name.
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link');
@@ -100,11 +100,11 @@ export const InvertedFocusVisibleUsesSameOutlineAsDefault: Story = {
 
 export const InvertedFocusVisibleKeepsOpaqueBackground: Story = {
   // Regression: the focus/hover overlay tint was applied via `backgroundColor`
-  // — on the same element as Paper's own opaque turquoise `backgroundColor` in
-  // simple mode, a translucent `rgba(255,255,255,0.1)` override replaced (not
-  // tinted) it, leaving the box ~90% transparent and effectively invisible
-  // against the page. Must stay layered via `backgroundImage` instead, so the
-  // underlying `backgroundColor` is untouched by focus/hover.
+  // — on the same element as Paper's own opaque turquoise `backgroundColor`,
+  // a translucent `rgba(255,255,255,0.1)` override replaced (not tinted) it,
+  // leaving the box ~90% transparent and effectively invisible against the
+  // page. Must stay layered via `backgroundImage` instead, so the underlying
+  // `backgroundColor` is untouched by focus/hover.
   args: { inverted: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -130,90 +130,25 @@ export const External: Story = {
   },
 };
 
-export const WithActions: Story = {
+// A minimal stand-in for a router `Link` component (Next.js `Link`, React
+// Router's `Link`, etc.) — forwards everything through to a real `<a>`.
+function FakeRouterLink({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return <a href={href} data-router-link="true" {...props} />;
+}
+
+export const WithCustomComponent: Story = {
   tags: docExample,
-  args: {
-    actions: (
-      <Button variant="secondary" onClick={fn()}>
-        Lue lisää
-      </Button>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Nested mode: the box has a covering primary link, AND the Button in
-    // `actions` stays independently reachable/clickable — no nested
-    // anchor-in-anchor (the primary link and the Button are siblings, not
-    // ancestor/descendant), and only one accessible link name for the box.
-    const links = canvas.getAllByRole('link');
-    await expect(links).toHaveLength(1);
-    await expect(links[0]).toHaveAccessibleName('Otsikko');
-    await expect(links[0].querySelector('button')).toBeNull();
-
-    const button = canvas.getByRole('button', { name: 'Lue lisää' });
-    await expect(button.closest('a')).toBeNull();
-  },
-};
-
-export const NestedModeSpacingMatchesSimpleMode: Story = {
-  // Regression: wrapping content in the overlay mode's positioned div
-  // (`positionedContent`) previously stranded the icon row in plain block
-  // flow, losing `root`'s flex gap and leaving the arrow flush against the
-  // description instead of Figma's `card.spacing` (24px) gap — caught
-  // visually in Storybook, not by the other structural assertions above.
-  args: { actions: <Button variant="secondary">Lue lisää</Button> },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const description = canvas.getByText('Kuvaava teksti');
-    const icon = canvas.getByRole('link').parentElement!.querySelector('svg')!;
-
-    const gap = icon.getBoundingClientRect().top - description.getBoundingClientRect().bottom;
-    await expect(gap).toBeGreaterThan(16);
-  },
-};
-
-const handleActionsClick = fn();
-
-export const ActionsRemainClickable: Story = {
-  args: {
-    actions: (
-      <Button variant="secondary" onClick={handleActionsClick}>
-        Toiminto
-      </Button>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole('button', { name: 'Toiminto' });
-
-    await userEvent.click(button);
-    await expect(handleActionsClick).toHaveBeenCalledOnce();
-    await expect(button).toHaveFocus();
-  },
-};
-
-export const WithCustomLink: Story = {
-  args: { href: undefined },
-  render: (args) => (
-    <Linkbox
-      {...args}
-      renderLink={(className) => (
-        <a href="#custom" className={className} aria-label={args.title}>
-          {/* overlay link — no visible content of its own */}
-        </a>
-      )}
-    />
-  ),
+  args: { component: FakeRouterLink },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: 'Otsikko' });
 
-    await expect(link).toHaveAttribute('href', '#custom');
-    // renderLink (like `actions`) switches Linkbox to the overlay structure —
-    // the title text is still rendered as normal visible content, separately
-    // from the link element itself.
-    await expect(canvas.getByText('Otsikko')).not.toBe(link);
+    await expect(link).toHaveAttribute('data-router-link', 'true');
+    await expect(link).toHaveAttribute('href', '#');
+    // Paper's own styling (padding/background/etc.) still applies through
+    // the swapped element, same guarantee Paper's `PolymorphicComponent`
+    // story already gives `<Paper component="section">`.
+    await expect(getComputedStyle(link).backgroundColor).toBe('rgb(255, 255, 255)');
   },
 };
 
@@ -265,9 +200,7 @@ export const WarnsWithoutDestination: Story = {
   beforeEach: captureConsoleErrors,
   play: async () => {
     await waitFor(() =>
-      expect(
-        capturedConsoleErrors.some((m) => /provide either `href` or `renderLink`/.test(m))
-      ).toBe(true)
+      expect(capturedConsoleErrors.some((m) => /provide `href`/.test(m))).toBe(true)
     );
   },
 };
@@ -278,31 +211,6 @@ export const WarnsWhenTargetIgnoredByExternal: Story = {
   play: async () => {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /`target` is ignored/.test(m))).toBe(true)
-    );
-  },
-};
-
-export const WarnsWhenHrefIgnoredByRenderLink: Story = {
-  render: (args) => (
-    <Linkbox {...args} renderLink={(className) => <a href="#custom" className={className} />} />
-  ),
-  beforeEach: captureConsoleErrors,
-  play: async () => {
-    await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /`href` is ignored/.test(m))).toBe(true)
-    );
-  },
-};
-
-export const WarnsWhenExternalIgnoredByRenderLink: Story = {
-  args: { href: undefined, external: true },
-  render: (args) => (
-    <Linkbox {...args} renderLink={(className) => <a href="#custom" className={className} />} />
-  ),
-  beforeEach: captureConsoleErrors,
-  play: async () => {
-    await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /`external` has no effect/.test(m))).toBe(true)
     );
   },
 };

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -12,32 +12,6 @@ const sizedMediaImage = `data:image/svg+xml,${encodeURIComponent(
   '<svg xmlns="http://www.w3.org/2000/svg" width="260" height="195"><rect width="260" height="195" fill="#ccc"/></svg>'
 )}`;
 
-// `vitest/browser`'s `page.viewport` resizes the story's own iframe — the
-// only way to actually exercise a real `@media` breakpoint (Linkbox's
-// `left`-placement collapse is the first such rule in this repo; every other
-// breakpoint behaviour comes from `vars.theme` swapping value at `:root`,
-// which every ambient test already picks up regardless of viewport size).
-//
-// This module throws at evaluation time when loaded outside Vitest Browser
-// Mode — which is exactly what happens when this SAME `.stories.tsx` file is
-// loaded by Storybook's own plain dev server (not the Vitest test runner) to
-// render/browse these stories interactively. A static top-level import would
-// crash that module for the *entire* file, not just the stories that use it.
-// Dynamic-import it lazily instead, and swallow the "not in Browser Mode"
-// case as a no-op — outside Vitest there's no real viewport to resize, and
-// the two stories that need it are tagged test-only (`!dev`/`!autodocs`)
-// precisely because their assertions only hold under an actual resize.
-async function resizeViewport(width: number, height: number) {
-  try {
-    const { page } = await import('vitest/browser');
-    await page.viewport(width, height);
-  } catch {
-    // Not running under Vitest Browser Mode — nothing to resize.
-  }
-}
-
-const WIDE_VIEWPORT = [1024, 768] as const;
-
 const meta = {
   component: Linkbox,
   tags: ['!dev', '!autodocs'],
@@ -206,52 +180,54 @@ export const WithMediaTop: Story = {
 };
 
 export const WithMediaLeft: Story = {
-  // Plain visual example — no viewport manipulation, so it renders correctly
-  // in Storybook's own dev server too (see `resizeViewport` above). Whether
-  // it actually shows the row or the collapsed layout depends on the ambient
-  // canvas width; the two behaviours are asserted precisely (and test-only,
-  // since they need a real resize) by the two stories below.
   tags: docExample,
-  args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
-};
-
-export const WithMediaLeftUsesRowLayoutAtWideViewport: Story = {
-  // Test-only (not `docExample`): needs a real Vitest Browser Mode viewport
-  // resize to mean anything, which `WithMediaLeft` above deliberately avoids.
+  // `left`'s row split is driven by a container query on Linkbox's own
+  // rendered width (not the viewport) — a plain fixed-width wrapper is
+  // enough to exercise it deterministically, same as `WithMediaTop` above.
+  render: (args) => (
+    <div style={{ width: 1200 }}>
+      <Linkbox {...args} />
+    </div>
+  ),
   args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
   play: async ({ canvasElement }) => {
-    await resizeViewport(1280, 900);
-    try {
-      const canvas = within(canvasElement);
-      const link = canvas.getByRole('link', { name: 'Otsikko' });
-      await expect(getComputedStyle(link).flexDirection).toBe('row');
-    } finally {
-      await resizeViewport(...WIDE_VIEWPORT);
-    }
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    // The row/column flex layout lives on Linkbox's inner wrapper, not the
+    // `<a>` itself — see Linkbox.tsx's comment on why they're split.
+    const layout = link.firstElementChild as HTMLElement;
+    await expect(getComputedStyle(layout).flexDirection).toBe('row');
   },
 };
 
 export const WithMediaLeftCollapsesToStackedBelowMdBreakpoint: Story = {
-  // A 50/50 row split gets cramped once the whole card narrows past tablet
-  // width — below the `md` (768px) breakpoint, `left` falls back to the same
-  // stacked layout `top` uses by default.
+  // A 50/50 row split gets cramped once Linkbox's own rendered width narrows
+  // past tablet width — below the `md` (768px) container-query breakpoint,
+  // `left` falls back to the same stacked layout `top` uses by default. This
+  // is keyed off Linkbox's own width (a container query), not the viewport —
+  // so a `left`-placed Linkbox squeezed into a narrow grid column collapses
+  // correctly even on a wide screen, unlike a viewport `@media` query would.
+  tags: docExample,
+  render: (args) => (
+    <div style={{ width: 480 }}>
+      <Linkbox {...args} />
+    </div>
+  ),
   args: { media: <img alt="" src={sizedMediaImage} />, mediaPlacement: 'left' },
   play: async ({ canvasElement }) => {
-    await resizeViewport(480, 900);
-    try {
-      const canvas = within(canvasElement);
-      const link = canvas.getByRole('link', { name: 'Otsikko' });
-      const media = canvas.getByRole('img');
-      const mediaWrapper = media.parentElement as HTMLElement;
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    const media = canvas.getByRole('img');
+    const mediaWrapper = media.parentElement as HTMLElement;
+    // The row/column flex layout lives on Linkbox's inner wrapper, not the
+    // `<a>` itself — see Linkbox.tsx's comment on why they're split.
+    const layout = link.firstElementChild as HTMLElement;
 
-      await expect(getComputedStyle(link).flexDirection).toBe('column');
-      // Genuinely stacked like `top`, not just "not row" — full-width 3:2 box.
-      const linkWidth = link.getBoundingClientRect().width;
-      const mediaHeight = mediaWrapper.getBoundingClientRect().height;
-      await expect(Math.abs(linkWidth / mediaHeight - 1.5)).toBeLessThan(0.05);
-    } finally {
-      await resizeViewport(...WIDE_VIEWPORT);
-    }
+    await expect(getComputedStyle(layout).flexDirection).toBe('column');
+    // Genuinely stacked like `top`, not just "not row" — full-width 3:2 box.
+    const linkWidth = link.getBoundingClientRect().width;
+    const mediaHeight = mediaWrapper.getBoundingClientRect().height;
+    await expect(Math.abs(linkWidth / mediaHeight - 1.5)).toBeLessThan(0.05);
   },
 };
 

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -50,6 +50,19 @@ export const AccessibleNameIsTitleOnly: Story = {
   },
 };
 
+export const RespectsConsumerAriaLabelOverride: Story = {
+  // Regression: `aria-label` is a valid prop (via `AriaAttributes`) that used
+  // to land in the rest-spread and then get silently overwritten by the
+  // `title`-derived one — a consumer's accessibility override must win.
+  args: { 'aria-label': 'Mukautettu nimi' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    await expect(link).toHaveAccessibleName('Mukautettu nimi');
+  },
+};
+
 export const FocusVisible: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -47,6 +47,12 @@ export const Default: Story = {
     // Figma "Card link content" — Background/Default = #ffffff.
     await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
     await expect(link.tagName).toBe('A');
+    // Description's `text/secondary` override (neutral/600, #52525b) on the
+    // default (non-inverted) surface — the inverted case is covered
+    // separately by `InvertedColor` below.
+    await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
+      'rgb(82, 82, 91)'
+    );
   },
 };
 
@@ -119,6 +125,12 @@ export const InvertedColor: Story = {
     await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
       'rgb(255, 255, 255)'
     );
+    // The arrow icon (`fill="currentColor"`) inherits its color from
+    // `iconRow`'s own `${inverted} .${iconRow}` override — asserted
+    // separately from the text colors above since it isn't a `Typography`
+    // element and isn't covered by `invertibleTextSelectors`.
+    const icon = link.querySelector('svg') as SVGElement;
+    await expect(getComputedStyle(icon).color).toBe('rgb(255, 255, 255)');
   },
 };
 
@@ -267,6 +279,21 @@ export const AppendsExternalLabelToConsumerAriaLabelOverride: Story = {
   },
 };
 
+export const WithCustomExternalLabel: Story = {
+  // `externalLabel` overrides the default Finnish suffix — every other
+  // `external` story relies on the destructured default value
+  // (`'(avautuu uuteen välilehteen)'`), so a bug that hardcoded the default
+  // string into the accessible-name concatenation instead of reading the
+  // prop would otherwise slip through undetected.
+  args: { external: true, href: 'https://tampere.fi', externalLabel: '(opens in a new tab)' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /^Otsikko/ });
+
+    await expect(link).toHaveAccessibleName('Otsikko (opens in a new tab)');
+  },
+};
+
 // A minimal stand-in for a router `Link` component (Next.js `Link`, React
 // Router's `Link`, etc.) — forwards everything through to a real `<a>`.
 function FakeRouterLink({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
@@ -323,6 +350,21 @@ export const WithCustomClassName: Story = {
   },
 };
 
+export const WithoutEyebrowOrDescription: Story = {
+  // `eyebrow`/`description` are both optional and conditionally rendered
+  // (`eyebrow && <Typography>`/`description && <Typography>` in Linkbox.tsx)
+  // — every other story sets both via `meta.args`, so the omitted branch is
+  // otherwise never exercised.
+  args: { eyebrow: undefined, description: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.queryByText('Lisätietoa')).toBeNull();
+    await expect(canvas.queryByText('Kuvaava teksti')).toBeNull();
+    await expect(canvas.getByRole('link')).toHaveAccessibleName('Otsikko');
+  },
+};
+
 let forwardedRefNode: HTMLElement | null = null;
 
 export const ForwardsRefToRenderedElement: Story = {
@@ -360,6 +402,24 @@ export const MergesRelWithExternal: Story = {
   },
 };
 
+export const WithPlainTargetAndRel: Story = {
+  // `target`/`rel` pass straight through unmodified when `external` isn't
+  // set — `linkTarget`/`linkRel` in Linkbox.tsx only take the `external`
+  // branch (forced `_blank`/prepended `noopener noreferrer`) otherwise.
+  // Every other story exercising `target`/`rel` does so with `external: true`
+  // (`MergesRelWithExternal` above, `WithCustomComponentAndExternal`), so
+  // this fallthrough branch was otherwise untested — a regression that
+  // dropped it (e.g. always forcing `_blank`) would pass every other story.
+  args: { target: '_self', rel: 'nofollow' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+
+    await expect(link).toHaveAttribute('target', '_self');
+    await expect(link).toHaveAttribute('rel', 'nofollow');
+  },
+};
+
 // ── Dev-warning tests (verifies the console.error guards in Linkbox.tsx) ──
 
 let capturedConsoleErrors: string[] = [];
@@ -378,10 +438,15 @@ const captureConsoleErrors = () => {
 export const WarnsWhenTargetIgnoredByExternal: Story = {
   args: { external: true, target: '_self' },
   beforeEach: captureConsoleErrors,
-  play: async () => {
+  play: async ({ canvasElement }) => {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /`target` is ignored/.test(m))).toBe(true)
     );
+    // The warning fires alongside, not instead of, the actual override — a
+    // consumer's conflicting `target` must still lose to `external`'s
+    // `_blank`, not just get flagged.
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link')).toHaveAttribute('target', '_blank');
   },
 };
 
@@ -392,10 +457,15 @@ export const WarnsWithInvalidTitleOrder: Story = {
   // override with no signal — same risk class Card's identical prop guards.
   args: { titleOrder: 6 as unknown as 2 | 3 | 4 | 5 },
   beforeEach: captureConsoleErrors,
-  play: async () => {
+  play: async ({ canvasElement }) => {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /invalid `titleOrder`/.test(m))).toBe(true)
     );
+    // The warning fires alongside, not instead of, a safe fallback — an
+    // out-of-union value degrades to Typography's own `h3` default rather
+    // than losing the heading entirely.
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Otsikko' }).tagName).toBe('H3');
   },
 };
 
@@ -408,10 +478,17 @@ export const WarnsWithInvalidMediaPlacement: Story = {
     mediaPlacement: 'bottom' as unknown as 'top' | 'left',
   },
   beforeEach: captureConsoleErrors,
-  play: async () => {
+  play: async ({ canvasElement }) => {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /invalid `mediaPlacement`/.test(m))).toBe(true)
     );
+    // The warning fires alongside, not instead of, a safe fallback — an
+    // out-of-union value degrades to the stacked (`top`) layout rather than
+    // silently applying no layout at all.
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    const layout = link.firstElementChild as HTMLElement;
+    await expect(getComputedStyle(layout).flexDirection).toBe('column');
   },
 };
 

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -1,0 +1,287 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, waitFor } from '@storybook/testing-library';
+import { expect, fn } from 'storybook/test';
+import { Button } from '../Button';
+import { Linkbox } from './Linkbox';
+
+const meta = {
+  component: Linkbox,
+  tags: ['!dev', '!autodocs'],
+  args: {
+    href: '#',
+    title: 'Otsikko',
+    eyebrow: 'Lisätietoa',
+    description: 'Kuvaava teksti',
+    'data-testid': 'linkbox',
+  },
+} satisfies Meta<typeof Linkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const docExample = ['dev', 'autodocs'];
+
+export const Default: Story = {
+  tags: docExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+
+    await expect(link).toHaveAttribute('href', '#');
+    await expect(canvas.getByText('Lisätietoa')).not.toBeNull();
+    await expect(canvas.getByText('Kuvaava teksti')).not.toBeNull();
+    await expect(link.querySelector('svg')).not.toBeNull();
+
+    const style = getComputedStyle(link);
+    // Figma "Card link content" — Background/Default = #ffffff.
+    await expect(style.backgroundColor).toBe('rgb(255, 255, 255)');
+    await expect(link.tagName).toBe('A');
+  },
+};
+
+export const AccessibleNameIsTitleOnly: Story = {
+  // Simple mode's whole box is the `<a>` — its accessible name must be just
+  // `title`, not eyebrow+title+description read together as one link name.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    await expect(link).toHaveAccessibleName('Otsikko');
+  },
+};
+
+export const FocusVisible: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    (link as HTMLAnchorElement).focus();
+    const style = getComputedStyle(link);
+    await expect(style.outlineStyle).toBe('solid');
+    // Figma's focus-visible outline color, #1e1e22 = focus.visible.
+    await expect(style.outlineColor).toBe('rgb(30, 30, 34)');
+  },
+};
+
+export const InvertedColor: Story = {
+  tags: docExample,
+  args: { inverted: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+    const style = getComputedStyle(link);
+
+    // Figma "Card link content" Inverted = Turquoise/300 = #0074a4, the same
+    // token Paper's own `background="turquoise"` already uses.
+    await expect(style.backgroundColor).toBe('rgb(0, 116, 164)');
+    await expect(getComputedStyle(canvas.getByText('Otsikko')).color).toBe('rgb(255, 255, 255)');
+    await expect(getComputedStyle(canvas.getByText('Lisätietoa')).color).toBe('rgb(255, 255, 255)');
+    await expect(getComputedStyle(canvas.getByText('Kuvaava teksti')).color).toBe(
+      'rgb(255, 255, 255)'
+    );
+  },
+};
+
+export const InvertedFocusVisibleUsesInvertedOutline: Story = {
+  args: { inverted: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+
+    (link as HTMLAnchorElement).focus();
+    // Neutral outline (#1e1e22) fails WCAG's 3:1 non-text-contrast minimum
+    // against the turquoise background — must use the white inverted outline,
+    // same guarantee Card already gives nested TextLink focus on colored bg.
+    await expect(getComputedStyle(link).outlineColor).toBe('rgb(255, 255, 255)');
+  },
+};
+
+export const External: Story = {
+  tags: docExample,
+  args: { external: true, href: 'https://tampere.fi' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /^Otsikko/ });
+
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(link).toHaveAccessibleName(/avautuu uuteen välilehteen/);
+  },
+};
+
+export const WithActions: Story = {
+  tags: docExample,
+  args: {
+    actions: (
+      <Button variant="secondary" onClick={fn()}>
+        Lue lisää
+      </Button>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Nested mode: the box has a covering primary link, AND the Button in
+    // `actions` stays independently reachable/clickable — no nested
+    // anchor-in-anchor (the primary link and the Button are siblings, not
+    // ancestor/descendant), and only one accessible link name for the box.
+    const links = canvas.getAllByRole('link');
+    await expect(links).toHaveLength(1);
+    await expect(links[0]).toHaveAccessibleName('Otsikko');
+    await expect(links[0].querySelector('button')).toBeNull();
+
+    const button = canvas.getByRole('button', { name: 'Lue lisää' });
+    await expect(button.closest('a')).toBeNull();
+  },
+};
+
+export const NestedModeSpacingMatchesSimpleMode: Story = {
+  // Regression: wrapping content in the overlay mode's positioned div
+  // (`positionedContent`) previously stranded the icon row in plain block
+  // flow, losing `root`'s flex gap and leaving the arrow flush against the
+  // description instead of Figma's `card.spacing` (24px) gap — caught
+  // visually in Storybook, not by the other structural assertions above.
+  args: { actions: <Button variant="secondary">Lue lisää</Button> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const description = canvas.getByText('Kuvaava teksti');
+    const icon = canvas.getByRole('link').parentElement!.querySelector('svg')!;
+
+    const gap = icon.getBoundingClientRect().top - description.getBoundingClientRect().bottom;
+    await expect(gap).toBeGreaterThan(16);
+  },
+};
+
+const handleActionsClick = fn();
+
+export const ActionsRemainClickable: Story = {
+  args: {
+    actions: (
+      <Button variant="secondary" onClick={handleActionsClick}>
+        Toiminto
+      </Button>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Toiminto' });
+
+    await userEvent.click(button);
+    await expect(handleActionsClick).toHaveBeenCalledOnce();
+    await expect(button).toHaveFocus();
+  },
+};
+
+export const WithCustomLink: Story = {
+  args: { href: undefined },
+  render: (args) => (
+    <Linkbox
+      {...args}
+      renderLink={(className) => (
+        <a href="#custom" className={className} aria-label={args.title}>
+          {/* overlay link — no visible content of its own */}
+        </a>
+      )}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Otsikko' });
+
+    await expect(link).toHaveAttribute('href', '#custom');
+    // renderLink (like `actions`) switches Linkbox to the overlay structure —
+    // the title text is still rendered as normal visible content, separately
+    // from the link element itself.
+    await expect(canvas.getByText('Otsikko')).not.toBe(link);
+  },
+};
+
+export const WithTitleOrderOverride: Story = {
+  args: { titleOrder: 4 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Otsikko' }).tagName).toBe('H4');
+  },
+};
+
+export const WithCustomClassName: Story = {
+  args: { className: 'consumer-custom-class' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('linkbox').className).toContain('consumer-custom-class');
+  },
+};
+
+export const MergesRelWithExternal: Story = {
+  args: { external: true, rel: 'nofollow' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /^Otsikko/ });
+
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer nofollow');
+  },
+};
+
+// ── Dev-warning tests (verifies the console.error guards in Linkbox.tsx) ──
+
+let capturedConsoleErrors: string[] = [];
+
+const captureConsoleErrors = () => {
+  capturedConsoleErrors = [];
+  const original = console.error;
+  console.error = (...messageArgs: unknown[]) => {
+    capturedConsoleErrors.push(String(messageArgs[0]));
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+export const WarnsWithoutDestination: Story = {
+  args: { href: undefined },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(
+        capturedConsoleErrors.some((m) => /provide either `href` or `renderLink`/.test(m))
+      ).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenTargetIgnoredByExternal: Story = {
+  args: { external: true, target: '_self' },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`target` is ignored/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenHrefIgnoredByRenderLink: Story = {
+  render: (args) => (
+    <Linkbox {...args} renderLink={(className) => <a href="#custom" className={className} />} />
+  ),
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`href` is ignored/.test(m))).toBe(true)
+    );
+  },
+};
+
+export const WarnsWhenExternalIgnoredByRenderLink: Story = {
+  args: { href: undefined, external: true },
+  render: (args) => (
+    <Linkbox {...args} renderLink={(className) => <a href="#custom" className={className} />} />
+  ),
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /`external` has no effect/.test(m))).toBe(true)
+    );
+  },
+};

--- a/src/components/Linkbox/Linkbox.stories.tsx
+++ b/src/components/Linkbox/Linkbox.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, waitFor } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Linkbox } from './Linkbox';
+import { Typography } from '../Typography';
 
 // A 1x1 GIF has no real intrinsic size, so it can't catch the media wrapper
 // collapsing to 0 height in the default (top) layout — this SVG has real
@@ -131,6 +132,25 @@ export const InvertedColor: Story = {
     // element and isn't covered by `invertibleTextSelectors`.
     const icon = link.querySelector('svg') as SVGElement;
     await expect(getComputedStyle(icon).color).toBe('rgb(255, 255, 255)');
+  },
+};
+
+export const InvertedColorDoesNotForceMediaTextWhite: Story = {
+  // Regression: `invertibleTextSelectors` used to be a bare `${inverted}
+  // .${className}` selector matched from Paper (where `inverted` also lives
+  // for the link hover/focus rules), reaching every Typography descendant —
+  // including one nested inside `media`, which sits outside `content` as a
+  // sibling and is never meant to be force-inverted (`media` is a consumer
+  // slot, e.g. an image with its own caption). Must now compound with
+  // `content`, matching Card.tsx's own `content`+`inverted` pairing.
+  args: { inverted: true, media: <Typography variant="p1">Media-teksti</Typography> },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByText('Otsikko')).color).toBe('rgb(255, 255, 255)');
+    // `text.primary` (neutral/800, #2d2d32) — Typography's own default p1
+    // color, untouched by the `inverted` override that flips `content`'s text.
+    await expect(getComputedStyle(canvas.getByText('Media-teksti')).color).toBe('rgb(45, 45, 50)');
   },
 };
 

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -4,6 +4,7 @@ import {
   type AriaAttributes,
   type AriaRole,
   type ElementType,
+  type ReactNode,
   type Ref,
 } from 'react';
 import cx from 'clsx';
@@ -12,13 +13,19 @@ import { Typography } from '../Typography';
 import { ArrowRightIcon, OpenExternalLinkIcon } from '../../icons';
 import {
   root,
+  media as mediaClass,
+  content as contentClass,
+  contentPadding,
   textBlock,
   description as descriptionClass,
   iconRow,
   icon as iconClass,
   inverted as invertedMarker,
   link as linkClass,
+  leftMarker,
 } from './Linkbox.css';
+
+const mediaPlacementValues = { top: true, left: true } as const;
 
 export interface LinkboxProps extends AriaAttributes {
   href?: string;
@@ -27,6 +34,18 @@ export interface LinkboxProps extends AriaAttributes {
   titleOrder?: 2 | 3 | 4 | 5;
   eyebrow?: string;
   description?: string;
+  /**
+   * Rendered in a fixed 3:2 frame that bleeds to the box's edge — an `<img>`,
+   * `<video>`, `<svg>`, or a wrapped element, cropped with `object-fit: cover`.
+   */
+  media?: ReactNode;
+  /**
+   * Ignored when `media` is omitted. Default `'top'`. `'left'` is a 50/50 row
+   * split above the `md` (768px) breakpoint — below that it collapses to the
+   * same stacked layout `'top'` uses, since a row split gets cramped once the
+   * whole card narrows past tablet width.
+   */
+  mediaPlacement?: 'top' | 'left';
   /** `false` (default) is a white surface with dark text; `true` is a solid Paper `turquoise` surface with contrast text. */
   inverted?: boolean;
   /** Swaps the arrow icon, forces `target="_blank"`, prepends `rel="noopener noreferrer"` (merging with any existing `rel`), and appends `externalLabel` to the accessible name. */
@@ -53,6 +72,8 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
     titleOrder,
     eyebrow,
     description,
+    media,
+    mediaPlacement = 'top',
     inverted = false,
     external = false,
     externalLabel = '(avautuu uuteen välilehteen)',
@@ -82,7 +103,10 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
     if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
       console.error(`Linkbox: invalid \`titleOrder\` value "${titleOrder}".`);
     }
-  }, [href, external, target, titleOrder]);
+    if (!(mediaPlacement in mediaPlacementValues)) {
+      console.error(`Linkbox: invalid \`mediaPlacement\` value "${String(mediaPlacement)}".`);
+    }
+  }, [href, external, target, titleOrder, mediaPlacement]);
 
   // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
   // (its manually-typed wrapper can't infer per-element props the way
@@ -108,26 +132,35 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
       background={inverted ? 'turquoise' : 'default'}
       radius="sharp"
       withShadow={false}
-      padding="md"
-      className={cx(root, inverted && invertedMarker, linkClass, className)}
+      padding="none"
+      className={cx(
+        root,
+        media && mediaPlacement === 'left' && leftMarker,
+        inverted && invertedMarker,
+        linkClass,
+        className
+      )}
     >
-      <div className={textBlock}>
-        {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
-        <Typography variant="h3" component={titleOrder ? titleComponent[titleOrder] : undefined}>
-          {title}
-        </Typography>
-        {description && (
-          <Typography variant="p1" className={descriptionClass}>
-            {description}
+      {media && <div className={mediaClass}>{media}</div>}
+      <div className={cx(contentClass, contentPadding)}>
+        <div className={textBlock}>
+          {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+          <Typography variant="h3" component={titleOrder ? titleComponent[titleOrder] : undefined}>
+            {title}
           </Typography>
-        )}
-      </div>
-      <div className={iconRow}>
-        {external ? (
-          <OpenExternalLinkIcon aria-hidden className={iconClass} />
-        ) : (
-          <ArrowRightIcon aria-hidden className={iconClass} />
-        )}
+          {description && (
+            <Typography variant="p1" className={descriptionClass}>
+              {description}
+            </Typography>
+          )}
+        </div>
+        <div className={iconRow}>
+          {external ? (
+            <OpenExternalLinkIcon aria-hidden className={iconClass} />
+          ) : (
+            <ArrowRightIcon aria-hidden className={iconClass} />
+          )}
+        </div>
       </div>
     </Paper>
   );

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -78,7 +78,7 @@ export function Linkbox({
   // rather than losing type safety on the rest of `LinkboxProps`.
   const anchorProps = {
     href,
-    'aria-label': accessibleName,
+    'aria-label': props['aria-label'] ?? accessibleName,
     target: linkTarget,
     rel: linkRel,
   } as unknown as PaperProps;

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -1,4 +1,11 @@
-import { useEffect, type AriaAttributes, type AriaRole, type ElementType } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  type AriaAttributes,
+  type AriaRole,
+  type ElementType,
+  type Ref,
+} from 'react';
 import cx from 'clsx';
 import { Paper, type PaperProps } from '../Paper';
 import { Typography } from '../Typography';
@@ -22,7 +29,7 @@ export interface LinkboxProps extends AriaAttributes {
   description?: string;
   /** `false` (default) is a white surface with dark text; `true` is a solid Paper `turquoise` surface with contrast text. */
   inverted?: boolean;
-  /** Swaps the arrow icon, forces `target="_blank"` + `rel="noopener noreferrer"`, and appends `externalLabel` to the accessible name. */
+  /** Swaps the arrow icon, forces `target="_blank"`, prepends `rel="noopener noreferrer"` (merging with any existing `rel`), and appends `externalLabel` to the accessible name. */
   external?: boolean;
   /** Appended to the accessible name when `external` is set. */
   externalLabel?: string;
@@ -39,22 +46,25 @@ export interface LinkboxProps extends AriaAttributes {
 const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
 
 /** A card-shaped link — the whole box navigates to one destination, unlike `Card`, which is never itself a link. */
-export function Linkbox({
-  href,
-  title,
-  titleOrder,
-  eyebrow,
-  description,
-  inverted = false,
-  external = false,
-  externalLabel = ' (avautuu uuteen välilehteen)',
-  component,
-  target,
-  rel,
-  className,
-  ...props
-}: LinkboxProps) {
-  const accessibleName = external ? `${title}${externalLabel}` : title;
+export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Linkbox(
+  {
+    href,
+    title,
+    titleOrder,
+    eyebrow,
+    description,
+    inverted = false,
+    external = false,
+    externalLabel = '(avautuu uuteen välilehteen)',
+    component,
+    target,
+    rel,
+    className,
+    ...props
+  },
+  ref
+) {
+  const accessibleName = external ? `${title} ${externalLabel}` : title;
   const linkTarget = external ? '_blank' : target;
   const linkRel = external ? cx('noopener noreferrer', rel) : rel;
 
@@ -69,7 +79,10 @@ export function Linkbox({
         'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
       );
     }
-  }, [href, external, target]);
+    if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
+      console.error(`Linkbox: invalid \`titleOrder\` value "${titleOrder}".`);
+    }
+  }, [href, external, target, titleOrder]);
 
   // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
   // (its manually-typed wrapper can't infer per-element props the way
@@ -85,6 +98,10 @@ export function Linkbox({
 
   return (
     <Paper
+      // Paper's own forwardRef is typed to `HTMLDivElement` regardless of the
+      // polymorphic `component` it renders as — Linkbox is always an anchor,
+      // so cast at this one boundary the same way `anchorProps` above does.
+      ref={ref as unknown as Ref<HTMLDivElement>}
       {...props}
       component={component ?? 'a'}
       {...anchorProps}
@@ -114,6 +131,6 @@ export function Linkbox({
       </div>
     </Paper>
   );
-}
+});
 
 Linkbox.displayName = 'Linkbox';

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -1,14 +1,6 @@
-import {
-  forwardRef,
-  useEffect,
-  type AriaAttributes,
-  type AriaRole,
-  type ElementType,
-  type ReactNode,
-  type Ref,
-} from 'react';
+import { forwardRef, useEffect, type AnchorHTMLAttributes, type ReactNode } from 'react';
 import cx from 'clsx';
-import { Paper, type PaperProps } from '../Paper';
+import { Paper, type PaperProps, type SurfacePrimitiveProps } from '../Paper';
 import { Typography } from '../Typography';
 import { ArrowRightIcon, OpenExternalLinkIcon } from '../../icons';
 import {
@@ -25,10 +17,8 @@ import {
   leftMarker,
 } from './Linkbox.css';
 
-const mediaPlacementValues = { top: true, left: true } as const;
-
-export interface LinkboxProps extends AriaAttributes {
-  href?: string;
+export interface LinkboxProps extends SurfacePrimitiveProps {
+  href: string;
   title: string;
   /** Overrides the title's default heading level (3) — e.g. for a Linkbox nested under an existing H2. */
   titleOrder?: 2 | 3 | 4 | 5;
@@ -36,7 +26,8 @@ export interface LinkboxProps extends AriaAttributes {
   description?: string;
   /**
    * Rendered in a fixed 3:2 frame that bleeds to the box's edge — an `<img>`,
-   * `<video>`, `<svg>`, or a wrapped element, cropped with `object-fit: cover`.
+   * `<video>`, `<svg>`, `<iframe>`/`<canvas>` embed, or a wrapped element,
+   * cropped with `object-fit: cover`.
    */
   media?: ReactNode;
   /**
@@ -50,24 +41,25 @@ export interface LinkboxProps extends AriaAttributes {
   mediaPlacement?: 'top' | 'left';
   /** `false` (default) is a white surface with dark text; `true` is a solid Paper `turquoise` surface with contrast text. */
   inverted?: boolean;
-  /** Swaps the arrow icon, forces `target="_blank"`, prepends `rel="noopener noreferrer"` (merging with any existing `rel`), and appends `externalLabel` to the accessible name. */
+  /** Swaps the arrow icon, forces `target="_blank"`, prepends `rel="noopener noreferrer"` (merging with any existing `rel`), and appends `externalLabel` to the accessible name — including a consumer-supplied `aria-label` override. */
   external?: boolean;
-  /** Appended to the accessible name when `external` is set. */
+  /** Appended to the accessible name when `external` is set — to `title`, or to a consumer's own `aria-label` override if one is given. */
   externalLabel?: string;
-  /** Polymorphic root element, e.g. a router `Link` component. Mirrors Paper/Card's own `component` prop — the whole box is always this element. */
-  component?: ElementType;
   target?: string;
   rel?: string;
   className?: string;
-  id?: string;
-  role?: AriaRole;
-  'data-testid'?: string;
 }
 
 const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
 
 /** A card-shaped link — the whole box navigates to one destination, unlike `Card`, which is never itself a link. */
-export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Linkbox(
+// `HTMLDivElement`, not `HTMLAnchorElement`: `component` accepts any
+// `ElementType` (inherited from `SurfacePrimitiveProps`), so — same as
+// Paper/Card — the type can't promise callers a more specific element than
+// that. Promising `HTMLAnchorElement` while `component` stays fully open
+// would let a consumer swap in a non-anchor component with no compiler
+// warning that the ref's declared type no longer matches what's rendered.
+export const Linkbox = forwardRef<HTMLDivElement, LinkboxProps>(function Linkbox(
   {
     href,
     title,
@@ -87,16 +79,19 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
   },
   ref
 ) {
-  const accessibleName = external ? `${title} ${externalLabel}` : title;
+  // A consumer's own `aria-label` override (see `RespectsConsumerAriaLabelOverride`
+  // in the stories) replaces `title` as the base name, but `external`'s
+  // screen-reader signal must still be appended either way — dropping it
+  // whenever a consumer supplies their own label would silently fail issue
+  // #75's "external links flagged to assistive tech" requirement for that case.
+  const baseAccessibleName = props['aria-label'] ?? title;
+  const accessibleName = external ? `${baseAccessibleName} ${externalLabel}` : baseAccessibleName;
   const linkTarget = external ? '_blank' : target;
   const linkRel = external ? cx('noopener noreferrer', rel) : rel;
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') return;
 
-    if (!href) {
-      console.error('Linkbox: provide `href` so the link has a destination.');
-    }
     if (external && target) {
       console.error(
         'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
@@ -105,32 +100,33 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
     if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
       console.error(`Linkbox: invalid \`titleOrder\` value "${titleOrder}".`);
     }
-    if (!(mediaPlacement in mediaPlacementValues)) {
+    if (mediaPlacement !== 'top' && mediaPlacement !== 'left') {
       console.error(`Linkbox: invalid \`mediaPlacement\` value "${String(mediaPlacement)}".`);
     }
-  }, [href, external, target, titleOrder, mediaPlacement]);
+  }, [external, target, titleOrder, mediaPlacement]);
 
   // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
   // (its manually-typed wrapper can't infer per-element props the way
   // Mantine's raw polymorphic factory does — see Paper.tsx's own cast at
-  // its Mantine boundary for the same reason). Cast at this one boundary
-  // rather than losing type safety on the rest of `LinkboxProps`.
-  const anchorProps = {
+  // its Mantine boundary for the same reason). The object literal is typed
+  // explicitly (not inferred from an untyped `as unknown as PaperProps` cast
+  // directly on the literal) so a typo'd key still fails `tsc` before it ever
+  // reaches that boundary cast.
+  const anchorProps: Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
+    'aria-label': string;
+  } = {
     href,
-    'aria-label': props['aria-label'] ?? accessibleName,
+    'aria-label': accessibleName,
     target: linkTarget,
     rel: linkRel,
-  } as unknown as PaperProps;
+  };
 
   return (
     <Paper
-      // Paper's own forwardRef is typed to `HTMLDivElement` regardless of the
-      // polymorphic `component` it renders as — Linkbox is always an anchor,
-      // so cast at this one boundary the same way `anchorProps` above does.
-      ref={ref as unknown as Ref<HTMLDivElement>}
+      ref={ref}
       {...props}
       component={component ?? 'a'}
-      {...anchorProps}
+      {...(anchorProps as unknown as PaperProps)}
       background={inverted ? 'turquoise' : 'default'}
       radius="sharp"
       withShadow={false}

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -41,9 +41,11 @@ export interface LinkboxProps extends AriaAttributes {
   media?: ReactNode;
   /**
    * Ignored when `media` is omitted. Default `'top'`. `'left'` is a 50/50 row
-   * split above the `md` (768px) breakpoint — below that it collapses to the
-   * same stacked layout `'top'` uses, since a row split gets cramped once the
-   * whole card narrows past tablet width.
+   * split once Linkbox's own rendered width passes the `md` (768px)
+   * container-query breakpoint — narrower than that (its own width, not the
+   * viewport — e.g. a narrow grid column on an otherwise wide screen) it
+   * collapses to the same stacked layout `'top'` uses, since a row split gets
+   * cramped past that point.
    */
   mediaPlacement?: 'top' | 'left';
   /** `false` (default) is a white surface with dark text; `true` is a solid Paper `turquoise` surface with contrast text. */
@@ -134,32 +136,42 @@ export const Linkbox = forwardRef<HTMLAnchorElement, LinkboxProps>(function Link
       withShadow={false}
       padding="none"
       className={cx(
-        root,
         media && mediaPlacement === 'left' && leftMarker,
         inverted && invertedMarker,
         linkClass,
         className
       )}
     >
-      {media && <div className={mediaClass}>{media}</div>}
-      <div className={cx(contentClass, contentPadding)}>
-        <div className={textBlock}>
-          {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
-          <Typography variant="h3" component={titleOrder ? titleComponent[titleOrder] : undefined}>
-            {title}
-          </Typography>
-          {description && (
-            <Typography variant="p1" className={descriptionClass}>
-              {description}
+      {/* `root` (the flex row/column layout) lives on this inner wrapper, not
+          the outer element above — a `@container` query can't restyle the
+          same element that establishes the container (see `leftMarker` in
+          Linkbox.css.ts), so the container (outer) and the thing whose
+          `flexDirection` it toggles (this wrapper) have to be different
+          elements. */}
+      <div className={root}>
+        {media && <div className={mediaClass}>{media}</div>}
+        <div className={cx(contentClass, contentPadding)}>
+          <div className={textBlock}>
+            {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+            <Typography
+              variant="h3"
+              component={titleOrder ? titleComponent[titleOrder] : undefined}
+            >
+              {title}
             </Typography>
-          )}
-        </div>
-        <div className={iconRow}>
-          {external ? (
-            <OpenExternalLinkIcon aria-hidden className={iconClass} />
-          ) : (
-            <ArrowRightIcon aria-hidden className={iconClass} />
-          )}
+            {description && (
+              <Typography variant="p1" className={descriptionClass}>
+                {description}
+              </Typography>
+            )}
+          </div>
+          <div className={iconRow}>
+            {external ? (
+              <OpenExternalLinkIcon aria-hidden className={iconClass} />
+            ) : (
+              <ArrowRightIcon aria-hidden className={iconClass} />
+            )}
+          </div>
         </div>
       </div>
     </Paper>

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -1,0 +1,190 @@
+import {
+  useEffect,
+  type AriaAttributes,
+  type AriaRole,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import cx from 'clsx';
+import { Paper, type PaperProps } from '../Paper';
+import { Typography } from '../Typography';
+import { ArrowRightIcon, OpenExternalLinkIcon } from '../../icons';
+import {
+  root,
+  textBlock,
+  description as descriptionClass,
+  iconRow,
+  icon as iconClass,
+  inverted as invertedMarker,
+  link as linkClass,
+  overlayLink,
+  positionedContent,
+} from './Linkbox.css';
+
+export interface LinkboxProps extends AriaAttributes {
+  href?: string;
+  title: string;
+  /** Overrides the title's default heading level (3) — e.g. for a Linkbox nested under an existing H2. */
+  titleOrder?: 2 | 3 | 4 | 5;
+  eyebrow?: string;
+  description?: string;
+  /** `false` (default) is a white surface with dark text; `true` is a solid Paper `turquoise` surface with contrast text. */
+  inverted?: boolean;
+  /** Swaps the arrow icon, forces `target="_blank"` + `rel="noopener noreferrer"`, and appends `externalLabel` to the accessible name. */
+  external?: boolean;
+  /** Appended to the accessible name when `external` is set. */
+  externalLabel?: string;
+  /**
+   * Nested interactive content (e.g. a `Button`) rendered after the text
+   * content. Presence of `actions` (like `renderLink`) switches Linkbox from
+   * simple mode (the whole box is one real `<a>`) to the
+   * nested-interactive/overlay-link pattern, so `actions`' own links/buttons
+   * stay independently clickable.
+   */
+  actions?: ReactNode;
+  /**
+   * Escape hatch for router-integrated links (e.g. React Router's `Link`),
+   * mirroring TextLink's `renderLink`. Fully replaces the primary link
+   * element (the covering overlay anchor) — `href`/`external`/`target`/`rel`
+   * and the accessible name are NOT applied to it. Add them to the custom
+   * element yourself if you need them. Providing `renderLink` (like
+   * `actions`) switches Linkbox to the overlay-link structure.
+   */
+  renderLink?: (className: string) => ReactElement;
+  target?: string;
+  rel?: string;
+  className?: string;
+  id?: string;
+  role?: AriaRole;
+  'data-testid'?: string;
+}
+
+const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
+
+/** A card-shaped link — the whole box navigates to one destination, unlike `Card`, which is never itself a link. */
+export function Linkbox({
+  href,
+  title,
+  titleOrder,
+  eyebrow,
+  description,
+  inverted = false,
+  external = false,
+  externalLabel = ' (avautuu uuteen välilehteen)',
+  actions,
+  renderLink,
+  target,
+  rel,
+  className,
+  ...props
+}: LinkboxProps) {
+  // A custom router `renderLink` has no visible content of its own to carry
+  // Linkbox's generated eyebrow/title/description — same reason `actions`
+  // does, it needs the overlay structure rather than `Paper` itself being
+  // the anchor.
+  const nested = actions != null || renderLink != null;
+  const accessibleName = external ? `${title}${externalLabel}` : title;
+  const linkTarget = external ? '_blank' : target;
+  const linkRel = external ? cx('noopener noreferrer', rel) : rel;
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+
+    if (!href && !renderLink) {
+      console.error(
+        'Linkbox: provide either `href` or `renderLink` so the link has a destination.'
+      );
+    }
+    if (renderLink && href) {
+      console.error(
+        'Linkbox: `href` is ignored when `renderLink` is provided — remove one of them.'
+      );
+    }
+    if (renderLink && external) {
+      console.error(
+        'Linkbox: `external` has no effect when `renderLink` is provided — target, rel, and the external-link icon are only applied to the default `<a>` render. Add them to your custom link element instead.'
+      );
+    }
+    if (external && target) {
+      console.error(
+        'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
+      );
+    }
+  }, [href, renderLink, external, target]);
+
+  const content = (
+    <>
+      <div className={textBlock}>
+        {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+        <Typography variant="h3" component={titleOrder ? titleComponent[titleOrder] : undefined}>
+          {title}
+        </Typography>
+        {description && (
+          <Typography variant="p1" className={descriptionClass}>
+            {description}
+          </Typography>
+        )}
+      </div>
+      <div className={iconRow}>
+        {external ? (
+          <OpenExternalLinkIcon aria-hidden className={iconClass} />
+        ) : (
+          <ArrowRightIcon aria-hidden className={iconClass} />
+        )}
+      </div>
+    </>
+  );
+
+  const surfaceProps = {
+    ...props,
+    background: inverted ? ('turquoise' as const) : ('default' as const),
+    radius: 'sharp' as const,
+    withShadow: false,
+    padding: 'md' as const,
+  };
+
+  if (nested) {
+    return (
+      <Paper {...surfaceProps} className={cx(root, inverted && invertedMarker, className)}>
+        {renderLink ? (
+          renderLink(overlayLink)
+        ) : (
+          <a
+            href={href}
+            className={overlayLink}
+            aria-label={accessibleName}
+            target={linkTarget}
+            rel={linkRel}
+          />
+        )}
+        <div className={positionedContent}>{content}</div>
+        {actions && <div className={positionedContent}>{actions}</div>}
+      </Paper>
+    );
+  }
+
+  // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
+  // (its manually-typed wrapper can't infer per-element props the way
+  // Mantine's raw polymorphic factory does — see Paper.tsx's own cast at
+  // its Mantine boundary for the same reason). Cast at this one boundary
+  // rather than losing type safety on the rest of `LinkboxProps`.
+  const anchorProps = {
+    href,
+    'aria-label': accessibleName,
+    target: linkTarget,
+    rel: linkRel,
+  } as unknown as PaperProps;
+
+  return (
+    <Paper
+      {...surfaceProps}
+      component="a"
+      {...anchorProps}
+      className={cx(root, inverted && invertedMarker, linkClass, className)}
+    >
+      {content}
+    </Paper>
+  );
+}
+
+Linkbox.displayName = 'Linkbox';

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -25,9 +25,12 @@ export interface LinkboxProps extends SurfacePrimitiveProps {
   eyebrow?: string;
   description?: string;
   /**
-   * Rendered in a fixed 3:2 frame that bleeds to the box's edge — an `<img>`,
-   * `<video>`, `<svg>`, `<iframe>`/`<canvas>` embed, or a wrapped element,
-   * cropped with `object-fit: cover`.
+   * An `<img>`, `<video>`, `<svg>`, `<iframe>`/`<canvas>` embed, or a wrapped
+   * element, cropped with `object-fit: cover`. Rendered in a fixed 3:2 frame
+   * that bleeds to the box's edge in `top` placement (and in `left` once it
+   * collapses to stacked below the container breakpoint) — in `left`'s
+   * row-split above that breakpoint it's instead a 50%-width column
+   * stretched to the row's height. See `mediaPlacement`.
    */
   media?: ReactNode;
   /**
@@ -107,11 +110,12 @@ export const Linkbox = forwardRef<HTMLDivElement, LinkboxProps>(function Linkbox
 
   // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
   // (its manually-typed wrapper can't infer per-element props the way
-  // Mantine's raw polymorphic factory does — see Paper.tsx's own cast at
-  // its Mantine boundary for the same reason). The object literal is typed
-  // explicitly (not inferred from an untyped `as unknown as PaperProps` cast
-  // directly on the literal) so a typo'd key still fails `tsc` before it ever
-  // reaches that boundary cast.
+  // Mantine's raw polymorphic factory does — see Paper.tsx's own single `as`
+  // cast at its Mantine boundary for the same reason). The object literal
+  // below is typed explicitly first, so a typo'd key still fails `tsc`
+  // before the value ever reaches the `as PaperProps` cast at the JSX
+  // spread — going through `as unknown as` there would silently disable
+  // that check instead of just widening past it.
   const anchorProps: Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
     'aria-label': string;
   } = {
@@ -126,7 +130,7 @@ export const Linkbox = forwardRef<HTMLDivElement, LinkboxProps>(function Linkbox
       ref={ref}
       {...props}
       component={component ?? 'a'}
-      {...(anchorProps as unknown as PaperProps)}
+      {...(anchorProps as PaperProps)}
       background={inverted ? 'turquoise' : 'default'}
       radius="sharp"
       withShadow={false}

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  type AriaAttributes,
-  type AriaRole,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
+import { useEffect, type AriaAttributes, type AriaRole, type ElementType } from 'react';
 import cx from 'clsx';
 import { Paper, type PaperProps } from '../Paper';
 import { Typography } from '../Typography';
@@ -17,8 +11,6 @@ import {
   icon as iconClass,
   inverted as invertedMarker,
   link as linkClass,
-  overlayLink,
-  positionedContent,
 } from './Linkbox.css';
 
 export interface LinkboxProps extends AriaAttributes {
@@ -34,23 +26,8 @@ export interface LinkboxProps extends AriaAttributes {
   external?: boolean;
   /** Appended to the accessible name when `external` is set. */
   externalLabel?: string;
-  /**
-   * Nested interactive content (e.g. a `Button`) rendered after the text
-   * content. Presence of `actions` (like `renderLink`) switches Linkbox from
-   * simple mode (the whole box is one real `<a>`) to the
-   * nested-interactive/overlay-link pattern, so `actions`' own links/buttons
-   * stay independently clickable.
-   */
-  actions?: ReactNode;
-  /**
-   * Escape hatch for router-integrated links (e.g. React Router's `Link`),
-   * mirroring TextLink's `renderLink`. Fully replaces the primary link
-   * element (the covering overlay anchor) — `href`/`external`/`target`/`rel`
-   * and the accessible name are NOT applied to it. Add them to the custom
-   * element yourself if you need them. Providing `renderLink` (like
-   * `actions`) switches Linkbox to the overlay-link structure.
-   */
-  renderLink?: (className: string) => ReactElement;
+  /** Polymorphic root element, e.g. a router `Link` component. Mirrors Paper/Card's own `component` prop — the whole box is always this element. */
+  component?: ElementType;
   target?: string;
   rel?: string;
   className?: string;
@@ -71,18 +48,12 @@ export function Linkbox({
   inverted = false,
   external = false,
   externalLabel = ' (avautuu uuteen välilehteen)',
-  actions,
-  renderLink,
+  component,
   target,
   rel,
   className,
   ...props
 }: LinkboxProps) {
-  // A custom router `renderLink` has no visible content of its own to carry
-  // Linkbox's generated eyebrow/title/description — same reason `actions`
-  // does, it needs the overlay structure rather than `Paper` itself being
-  // the anchor.
-  const nested = actions != null || renderLink != null;
   const accessibleName = external ? `${title}${externalLabel}` : title;
   const linkTarget = external ? '_blank' : target;
   const linkRel = external ? cx('noopener noreferrer', rel) : rel;
@@ -90,30 +61,39 @@ export function Linkbox({
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') return;
 
-    if (!href && !renderLink) {
-      console.error(
-        'Linkbox: provide either `href` or `renderLink` so the link has a destination.'
-      );
-    }
-    if (renderLink && href) {
-      console.error(
-        'Linkbox: `href` is ignored when `renderLink` is provided — remove one of them.'
-      );
-    }
-    if (renderLink && external) {
-      console.error(
-        'Linkbox: `external` has no effect when `renderLink` is provided — target, rel, and the external-link icon are only applied to the default `<a>` render. Add them to your custom link element instead.'
-      );
+    if (!href) {
+      console.error('Linkbox: provide `href` so the link has a destination.');
     }
     if (external && target) {
       console.error(
         'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
       );
     }
-  }, [href, renderLink, external, target]);
+  }, [href, external, target]);
 
-  const content = (
-    <>
+  // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
+  // (its manually-typed wrapper can't infer per-element props the way
+  // Mantine's raw polymorphic factory does — see Paper.tsx's own cast at
+  // its Mantine boundary for the same reason). Cast at this one boundary
+  // rather than losing type safety on the rest of `LinkboxProps`.
+  const anchorProps = {
+    href,
+    'aria-label': accessibleName,
+    target: linkTarget,
+    rel: linkRel,
+  } as unknown as PaperProps;
+
+  return (
+    <Paper
+      {...props}
+      component={component ?? 'a'}
+      {...anchorProps}
+      background={inverted ? 'turquoise' : 'default'}
+      radius="sharp"
+      withShadow={false}
+      padding="md"
+      className={cx(root, inverted && invertedMarker, linkClass, className)}
+    >
       <div className={textBlock}>
         {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
         <Typography variant="h3" component={titleOrder ? titleComponent[titleOrder] : undefined}>
@@ -132,57 +112,6 @@ export function Linkbox({
           <ArrowRightIcon aria-hidden className={iconClass} />
         )}
       </div>
-    </>
-  );
-
-  const surfaceProps = {
-    ...props,
-    background: inverted ? ('turquoise' as const) : ('default' as const),
-    radius: 'sharp' as const,
-    withShadow: false,
-    padding: 'md' as const,
-  };
-
-  if (nested) {
-    return (
-      <Paper {...surfaceProps} className={cx(root, inverted && invertedMarker, className)}>
-        {renderLink ? (
-          renderLink(overlayLink)
-        ) : (
-          <a
-            href={href}
-            className={overlayLink}
-            aria-label={accessibleName}
-            target={linkTarget}
-            rel={linkRel}
-          />
-        )}
-        <div className={positionedContent}>{content}</div>
-        {actions && <div className={positionedContent}>{actions}</div>}
-      </Paper>
-    );
-  }
-
-  // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
-  // (its manually-typed wrapper can't infer per-element props the way
-  // Mantine's raw polymorphic factory does — see Paper.tsx's own cast at
-  // its Mantine boundary for the same reason). Cast at this one boundary
-  // rather than losing type safety on the rest of `LinkboxProps`.
-  const anchorProps = {
-    href,
-    'aria-label': accessibleName,
-    target: linkTarget,
-    rel: linkRel,
-  } as unknown as PaperProps;
-
-  return (
-    <Paper
-      {...surfaceProps}
-      component="a"
-      {...anchorProps}
-      className={cx(root, inverted && invertedMarker, linkClass, className)}
-    >
-      {content}
     </Paper>
   );
 }

--- a/src/components/Linkbox/Linkbox.tsx
+++ b/src/components/Linkbox/Linkbox.tsx
@@ -62,120 +62,128 @@ const titleComponent = { 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5' } as const;
 // that. Promising `HTMLAnchorElement` while `component` stays fully open
 // would let a consumer swap in a non-anchor component with no compiler
 // warning that the ref's declared type no longer matches what's rendered.
-export const Linkbox = forwardRef<HTMLDivElement, LinkboxProps>(function Linkbox(
-  {
-    href,
-    title,
-    titleOrder,
-    eyebrow,
-    description,
-    media,
-    mediaPlacement = 'top',
-    inverted = false,
-    external = false,
-    externalLabel = '(avautuu uuteen välilehteen)',
-    component,
-    target,
-    rel,
-    className,
-    ...props
-  },
-  ref
-) {
-  // A consumer's own `aria-label` override (see `RespectsConsumerAriaLabelOverride`
-  // in the stories) replaces `title` as the base name, but `external`'s
-  // screen-reader signal must still be appended either way — dropping it
-  // whenever a consumer supplies their own label would silently fail issue
-  // #75's "external links flagged to assistive tech" requirement for that case.
-  const baseAccessibleName = props['aria-label'] ?? title;
-  const accessibleName = external ? `${baseAccessibleName} ${externalLabel}` : baseAccessibleName;
-  const linkTarget = external ? '_blank' : target;
-  const linkRel = external ? cx('noopener noreferrer', rel) : rel;
+export const Linkbox = forwardRef<HTMLDivElement, LinkboxProps>(
+  (
+    {
+      href,
+      title,
+      titleOrder,
+      eyebrow,
+      description,
+      media,
+      mediaPlacement = 'top',
+      inverted = false,
+      external = false,
+      externalLabel = '(avautuu uuteen välilehteen)',
+      component,
+      target,
+      rel,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    // A consumer's own `aria-label` override (see `RespectsConsumerAriaLabelOverride`
+    // in the stories) replaces `title` as the base name, but `external`'s
+    // screen-reader signal must still be appended either way — dropping it
+    // whenever a consumer supplies their own label would silently fail issue
+    // #75's "external links flagged to assistive tech" requirement for that case.
+    const baseAccessibleName = props['aria-label'] ?? title;
+    const accessibleName = external ? `${baseAccessibleName} ${externalLabel}` : baseAccessibleName;
+    const linkTarget = external ? '_blank' : target;
+    const linkRel = external ? cx('noopener noreferrer', rel) : rel;
 
-  useEffect(() => {
-    if (process.env.NODE_ENV === 'production') return;
+    useEffect(() => {
+      if (process.env.NODE_ENV === 'production') return;
 
-    if (external && target) {
-      console.error(
-        'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
-      );
-    }
-    if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
-      console.error(`Linkbox: invalid \`titleOrder\` value "${titleOrder}".`);
-    }
-    if (mediaPlacement !== 'top' && mediaPlacement !== 'left') {
-      console.error(`Linkbox: invalid \`mediaPlacement\` value "${String(mediaPlacement)}".`);
-    }
-  }, [external, target, titleOrder, mediaPlacement]);
+      if (external && target) {
+        console.error(
+          'Linkbox: `target` is ignored when `external` is set — external links always open in a new tab.'
+        );
+      }
+      if (titleOrder !== undefined && !(titleOrder in titleComponent)) {
+        console.error(`Linkbox: invalid \`titleOrder\` value "${titleOrder}".`);
+      }
+      if (mediaPlacement !== 'top' && mediaPlacement !== 'left') {
+        console.error(`Linkbox: invalid \`mediaPlacement\` value "${String(mediaPlacement)}".`);
+      }
+    }, [external, target, titleOrder, mediaPlacement]);
 
-  // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
-  // (its manually-typed wrapper can't infer per-element props the way
-  // Mantine's raw polymorphic factory does — see Paper.tsx's own single `as`
-  // cast at its Mantine boundary for the same reason). The object literal
-  // below is typed explicitly first, so a typo'd key still fails `tsc`
-  // before the value ever reaches the `as PaperProps` cast at the JSX
-  // spread — going through `as unknown as` there would silently disable
-  // that check instead of just widening past it.
-  const anchorProps: Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
-    'aria-label': string;
-  } = {
-    href,
-    'aria-label': accessibleName,
-    target: linkTarget,
-    rel: linkRel,
-  };
+    // `Paper`'s own type doesn't widen anchor attributes when `component="a"`
+    // (its manually-typed wrapper can't infer per-element props the way
+    // Mantine's raw polymorphic factory does — see Paper.tsx's own single `as`
+    // cast at its Mantine boundary for the same reason). The object literal
+    // below is typed explicitly first, so a typo'd key still fails `tsc`
+    // before the value ever reaches the `as PaperProps` cast at the JSX
+    // spread — going through `as unknown as` there would silently disable
+    // that check instead of just widening past it.
+    const anchorProps: Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'> & {
+      'aria-label': string;
+    } = {
+      href,
+      'aria-label': accessibleName,
+      target: linkTarget,
+      rel: linkRel,
+    };
 
-  return (
-    <Paper
-      ref={ref}
-      {...props}
-      component={component ?? 'a'}
-      {...(anchorProps as PaperProps)}
-      background={inverted ? 'turquoise' : 'default'}
-      radius="sharp"
-      withShadow={false}
-      padding="none"
-      className={cx(
-        media && mediaPlacement === 'left' && leftMarker,
-        inverted && invertedMarker,
-        linkClass,
-        className
-      )}
-    >
-      {/* `root` (the flex row/column layout) lives on this inner wrapper, not
-          the outer element above — a `@container` query can't restyle the
-          same element that establishes the container (see `leftMarker` in
-          Linkbox.css.ts), so the container (outer) and the thing whose
-          `flexDirection` it toggles (this wrapper) have to be different
-          elements. */}
-      <div className={root}>
-        {media && <div className={mediaClass}>{media}</div>}
-        <div className={cx(contentClass, contentPadding)}>
-          <div className={textBlock}>
-            {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
-            <Typography
-              variant="h3"
-              component={titleOrder ? titleComponent[titleOrder] : undefined}
-            >
-              {title}
-            </Typography>
-            {description && (
-              <Typography variant="p1" className={descriptionClass}>
-                {description}
+    return (
+      <Paper
+        ref={ref}
+        {...props}
+        component={component ?? 'a'}
+        {...(anchorProps as PaperProps)}
+        background={inverted ? 'turquoise' : 'default'}
+        radius="sharp"
+        withShadow={false}
+        padding="none"
+        className={cx(
+          media && mediaPlacement === 'left' && leftMarker,
+          inverted && invertedMarker,
+          linkClass,
+          className
+        )}
+      >
+        {/* `root` (the flex row/column layout) lives on this inner wrapper, not
+            the outer element above — a `@container` query can't restyle the
+            same element that establishes the container (see `leftMarker` in
+            Linkbox.css.ts), so the container (outer) and the thing whose
+            `flexDirection` it toggles (this wrapper) have to be different
+            elements. */}
+        <div className={root}>
+          {media && <div className={mediaClass}>{media}</div>}
+          {/* `invertedMarker` is applied here too (in addition to Paper, where
+              it's needed for the link hover/focus overlay tint) so the
+              text/icon inversion selectors in Linkbox.css.ts can compound it
+              with `content` — scoping the forced-white text color to this
+              block and excluding `media`, which sits outside it as a sibling.
+              Same technique as Card.tsx's own `content`+`inverted` pairing. */}
+          <div className={cx(contentClass, contentPadding, inverted && invertedMarker)}>
+            <div className={textBlock}>
+              {eyebrow && <Typography variant="p2">{eyebrow}</Typography>}
+              <Typography
+                variant="h3"
+                component={titleOrder ? titleComponent[titleOrder] : undefined}
+              >
+                {title}
               </Typography>
-            )}
-          </div>
-          <div className={iconRow}>
-            {external ? (
-              <OpenExternalLinkIcon aria-hidden className={iconClass} />
-            ) : (
-              <ArrowRightIcon aria-hidden className={iconClass} />
-            )}
+              {description && (
+                <Typography variant="p1" className={descriptionClass}>
+                  {description}
+                </Typography>
+              )}
+            </div>
+            <div className={iconRow}>
+              {external ? (
+                <OpenExternalLinkIcon aria-hidden className={iconClass} />
+              ) : (
+                <ArrowRightIcon aria-hidden className={iconClass} />
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    </Paper>
-  );
-});
+      </Paper>
+    );
+  }
+);
 
 Linkbox.displayName = 'Linkbox';

--- a/src/components/Linkbox/index.ts
+++ b/src/components/Linkbox/index.ts
@@ -1,0 +1,1 @@
+export { Linkbox, type LinkboxProps } from './Linkbox';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -5,11 +5,11 @@ export { Card, type CardProps } from './Card/Card';
 export { Checkbox } from './Checkbox/Checkbox';
 export { Chip, type ChipProps } from './Chip/Chip';
 export { IconButton } from './IconButton/IconButton';
-export { Linkbox, type LinkboxProps } from './Linkbox/Linkbox';
 export {
   LabeledIconButton,
   type LabeledIconButtonProps,
 } from './LabeledIconButton/LabeledIconButton';
+export { Linkbox, type LinkboxProps } from './Linkbox/Linkbox';
 export { LoadingSpinner } from './LoadingSpinner/LoadingSpinner';
 export { Modal } from './Modal/Modal';
 export { NavigationLink } from './NavigationLink/NavigationLink';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -5,6 +5,7 @@ export { Card, type CardProps } from './Card/Card';
 export { Checkbox } from './Checkbox/Checkbox';
 export { Chip, type ChipProps } from './Chip/Chip';
 export { IconButton } from './IconButton/IconButton';
+export { Linkbox, type LinkboxProps } from './Linkbox/Linkbox';
 export {
   LabeledIconButton,
   type LabeledIconButtonProps,

--- a/src/theme/tokens/breakpoint.ts
+++ b/src/theme/tokens/breakpoint.ts
@@ -254,6 +254,16 @@ export const breakpoint = {
 export type Breakpoint = typeof breakpoint;
 export type BreakpointKey = keyof Breakpoint;
 
+// Literal (non-responsive) thresholds for `@container` queries in component
+// stylesheets. Deliberately separate from the `breakpoint` table above: that
+// table's values are consumed through `vars.theme` and swapped via CSS custom
+// properties at `:root` for viewport `@media` queries — `@container`
+// conditions require an actual literal length, not a `var()` reference, and a
+// component's own container-query threshold is that component's layout
+// decision, not the site's responsive viewport grid, so it shouldn't drift
+// just because the viewport `md` breakpoint is retuned for unrelated reasons.
+export const containerQueryBreakpoint = { md: '768px' } as const;
+
 // Sorted explicitly by appWidth — do not rely on object key declaration order.
 // That was a prior bug (see commit 58f906c): a reorder/insert in the object
 // above must not silently invert this widest-first ordering.


### PR DESCRIPTION
## Summary
- Adds `Linkbox` — a card-shaped, single-destination link built on `Paper` (`component="a"`), visually consistent with `Card`
- Default/Inverted colour (Inverted reuses Paper's existing `turquoise` background token), internal/external link-type icon (reusing `ArrowRightIcon`/`OpenExternalLinkIcon`), Default/Hover/Focus states per Figma's "Card link content"
- Accessible name pinned to `title` via `aria-label`; router integration via a `component` prop mirroring Paper/Card's existing polymorphism
- Nested-interactive/`.Multi link` support intentionally dropped from scope — see issue #75 for rationale (HDS convention: a Linkbox is a single destination, not a container for extra interactive elements)
- Exported from the component barrel and package entry

## Notes for reviewers
Two real bugs were caught and fixed after initial implementation, both while checking the inverted colour variant against Figma:
- Hover/focus tint was applied via `backgroundColor`, which replaced (rather than layered over) Paper's own opaque background — made the inverted surface nearly disappear on focus. Fixed by layering via `backgroundImage` instead.
- Inverted focus-visible incorrectly used a white outline (copying Card's nested-TextLink precedent) — Figma's own `Focus-visible/Outline` variable is the same dark `#1e1e22` for both Default and Inverted; fixed to match.

## Test plan
- [x] `npm test` — 298/298 passing (13 new Linkbox stories/tests)
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all clean
- [x] `npm run build` succeeds, `Linkbox` confirmed present in `dist/`
- [x] Visually verified Default/Inverted/External/focus states against the Figma "Card link content" frame via Storybook + Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)