### PR TITLE
feat(#50): add Fieldset component

### DIFF
--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -30,6 +30,12 @@ export const root = style({
 // its own, so this must be applied explicitly.
 export const legend = style({
   margin: 0,
+  // A flex `<fieldset>`'s `<legend>` is excluded from the flex formatting
+  // context per the CSS Fieldsets spec (browsers wrap the rest of the
+  // children in an anonymous "fieldset content box"), so `root`'s flex `gap`
+  // never applies between the legend and its next sibling — only among the
+  // children after it. Close that gap explicitly here instead.
+  marginBottom: forms.fieldset.spacing,
   color: text.primary,
   fontSize: input.font.label.fontSize,
   fontWeight: typography.subheader.fontWeight,
@@ -60,6 +66,20 @@ export const childrenWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   gap: forms.fieldset.fieldGroupSpacing,
+});
+
+// Groups same-type selection controls (Checkbox/RadioButton items) into a
+// single Fieldset child, matching Figma's "Checkbox group"/"Radio button
+// group" sub-components. TREDS has no dedicated CheckboxGroup/RadioGroup
+// component yet, so this is used directly by Fieldset.stories.tsx's doc
+// examples. Figma's `Forms/Selection-items-spacing` aliases to the exact same
+// `Breakpoint/Spacing/Small` chain as `Components/Fieldset/Spacing` (16px at
+// 1024+, 12px at 768 and below) — reuse that token, not the larger
+// `fieldGroupSpacing` (24/16px) meant for grouping distinct field types.
+export const selectionGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: forms.fieldset.spacing,
 });
 
 // Shared with TextField/TextArea's own helper text style (Figma's "Inputs and

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -2,7 +2,6 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 
 const {
-  primitives: { spacing },
   theme: {
     components: { forms, input, typography },
     states,
@@ -10,7 +9,7 @@ const {
     font,
     cornerRadius,
     strokeWeight,
-    divider,
+    inputStates,
   },
 } = vars;
 
@@ -31,11 +30,6 @@ export const root = style({
 // its own, so this must be applied explicitly.
 export const legend = style({
   margin: 0,
-  // A flex `<fieldset>`'s `<legend>` always renders flush with the fieldset's
-  // own top edge, straddling its border line — a small top padding here (not
-  // on the fieldset, which has no effect on the legend's own position, see
-  // `withBorder`'s comment) keeps the glyphs off the stroke.
-  paddingTop: spacing['0,5'],
   // A flex `<fieldset>`'s `<legend>` is excluded from the flex formatting
   // context per the CSS Fieldsets spec (browsers wrap the rest of the
   // children in an anonymous "fieldset content box"), so `root`'s flex `gap`
@@ -62,25 +56,24 @@ export const asterisk = style({
 // token actually named for general form-container spacing (sitting unused
 // next to `forms.fieldset.spacing`) — rather than hugging the border with 0
 // padding or inventing a new token with no source of truth to check it against.
-// `paddingTop` stays 0: a flex `<fieldset>`'s `<legend>` always renders flush
-// with the fieldset's own top edge regardless of padding-top (browsers
-// exclude it from the padding box entirely, per the CSS Fieldsets spec — see
-// `legend`'s own comment below), so a nonzero padding-top here would only
-// double up with the legend's `marginBottom`, not give the legend itself any
-// more clearance from the top border.
+// Border color matches the resting border color inputs use (`inputStates.default`),
+// not the lighter `divider` token, so the box reads as part of the same form
+// surface family as the fields inside it. `paddingTop` stays 0: a flex
+// `<fieldset>`'s `<legend>` always renders flush with the fieldset's own top
+// edge regardless of padding-top (browsers exclude it from the padding box
+// entirely, per the CSS Fieldsets spec — see `legend`'s own comment above),
+// so a nonzero padding-top here would only double up with the legend's
+// `marginBottom`, not give the legend itself any more clearance from the top
+// border.
 export const withBorder = style({
   borderWidth: strokeWeight,
   borderStyle: 'solid',
-  borderColor: divider,
+  borderColor: inputStates.default,
   paddingTop: 0,
   paddingRight: forms.spacing,
   paddingBottom: forms.spacing,
   paddingLeft: forms.spacing,
 });
-
-// Same `sharp`/`pill` pair as Paper's `radius` prop — `sharp` is already
-// `root`'s own default, so only `pill` needs its own class.
-export const pill = style({ borderRadius: cornerRadius.rounded });
 
 export const childrenWrapper = style({
   display: 'flex',

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -51,11 +51,16 @@ export const asterisk = style({
 });
 
 // Opt-in bordered variant (Mantine's own default Fieldset look) — TREDS's own
-// default (per Figma, #70) stays borderless.
+// default (per Figma, #70) stays borderless. No Figma spec exists for this
+// addition, so the padding reuses `forms.spacing` — the only pre-existing
+// token actually named for general form-container spacing (sitting unused
+// next to `forms.fieldset.spacing`) — rather than hugging the border with 0
+// padding or inventing a new token with no source of truth to check it against.
 export const withBorder = style({
   borderWidth: strokeWeight,
   borderStyle: 'solid',
   borderColor: divider,
+  padding: forms.spacing,
 });
 
 // Same `sharp`/`pill` pair as Paper's `radius` prop — `sharp` is already

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -1,0 +1,58 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: {
+    components: { forms, input },
+    states,
+    text,
+    cornerRadius,
+    strokeWeight,
+    divider,
+  },
+} = vars;
+
+export const root = style({
+  border: 'none',
+  borderRadius: cornerRadius.sharp,
+  padding: 0,
+  margin: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: forms.fieldset.spacing,
+});
+
+export const asterisk = style({
+  color: states.error,
+  marginLeft: forms.fieldset.requiredIndicatorGap,
+});
+
+// Opt-in bordered variant (Mantine's own default Fieldset look) — TREDS's own
+// default (per Figma, #70) stays borderless.
+export const withBorder = style({
+  borderWidth: strokeWeight,
+  borderStyle: 'solid',
+  borderColor: divider,
+});
+
+// Same `sharp`/`pill` pair as Paper's `radius` prop — `sharp` is already
+// `root`'s own default, so only `pill` needs its own class.
+export const pill = style({ borderRadius: cornerRadius.rounded });
+
+export const childrenWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: forms.fieldset.fieldGroupSpacing,
+});
+
+// Shared with TextField/TextArea's own helper text style (Figma's "Inputs and
+// forms/Helper text" — same size/line-height across all form components).
+const descriptionFont = {
+  margin: 0, // reset the <p>'s default UA margin — spacing is via the root flex `gap`
+  fontSize: input.font.helperText.fontSize,
+  lineHeight: input.font.helperText.lineHeight,
+};
+
+export const helperText = style({ ...descriptionFont, color: text.secondary });
+
+export const errorText = style({ ...descriptionFont, color: states.error });

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -2,6 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '../../theme';
 
 const {
+  primitives: { spacing },
   theme: {
     components: { forms, input, typography },
     states,
@@ -30,6 +31,11 @@ export const root = style({
 // its own, so this must be applied explicitly.
 export const legend = style({
   margin: 0,
+  // A flex `<fieldset>`'s `<legend>` always renders flush with the fieldset's
+  // own top edge, straddling its border line — a small top padding here (not
+  // on the fieldset, which has no effect on the legend's own position, see
+  // `withBorder`'s comment) keeps the glyphs off the stroke.
+  paddingTop: spacing['0,5'],
   // A flex `<fieldset>`'s `<legend>` is excluded from the flex formatting
   // context per the CSS Fieldsets spec (browsers wrap the rest of the
   // children in an anonymous "fieldset content box"), so `root`'s flex `gap`
@@ -56,11 +62,20 @@ export const asterisk = style({
 // token actually named for general form-container spacing (sitting unused
 // next to `forms.fieldset.spacing`) — rather than hugging the border with 0
 // padding or inventing a new token with no source of truth to check it against.
+// `paddingTop` stays 0: a flex `<fieldset>`'s `<legend>` always renders flush
+// with the fieldset's own top edge regardless of padding-top (browsers
+// exclude it from the padding box entirely, per the CSS Fieldsets spec — see
+// `legend`'s own comment below), so a nonzero padding-top here would only
+// double up with the legend's `marginBottom`, not give the legend itself any
+// more clearance from the top border.
 export const withBorder = style({
   borderWidth: strokeWeight,
   borderStyle: 'solid',
   borderColor: divider,
-  padding: forms.spacing,
+  paddingTop: 0,
+  paddingRight: forms.spacing,
+  paddingBottom: forms.spacing,
+  paddingLeft: forms.spacing,
 });
 
 // Same `sharp`/`pill` pair as Paper's `radius` prop — `sharp` is already

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -3,9 +3,10 @@ import { vars } from '../../theme';
 
 const {
   theme: {
-    components: { forms, input },
+    components: { forms, input, typography },
     states,
     text,
+    font,
     cornerRadius,
     strokeWeight,
     divider,
@@ -20,6 +21,22 @@ export const root = style({
   display: 'flex',
   flexDirection: 'column',
   gap: forms.fieldset.spacing,
+});
+
+// Figma's "Inputs and forms/Input label" style — same recipe as TextField's
+// own label (TextField.css.ts's `labelRoot`): P2 size, Subheader/Semi-Bold
+// weight (no dedicated weight token of its own, per project convention),
+// text.primary color. Mantine's bare `<legend>` has no type-scale styling of
+// its own, so this must be applied explicitly.
+export const legend = style({
+  margin: 0,
+  color: text.primary,
+  fontSize: input.font.label.fontSize,
+  fontWeight: typography.subheader.fontWeight,
+  lineHeight: input.font.label.lineHeight,
+  letterSpacing: font.letterSpacing,
+  display: 'flex',
+  alignItems: 'center',
 });
 
 export const asterisk = style({

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -85,14 +85,13 @@ export const childrenWrapper = style({
 // single Fieldset child, matching Figma's "Checkbox group"/"Radio button
 // group" sub-components. TREDS has no dedicated CheckboxGroup/RadioGroup
 // component yet, so this is used directly by Fieldset.stories.tsx's doc
-// examples. Figma's `Forms/Selection-items-spacing` aliases to the exact same
-// `Breakpoint/Spacing/Small` chain as `Components/Fieldset/Spacing` (16px at
-// 1024+, 12px at 768 and below) — reuse that token, not the larger
-// `fieldGroupSpacing` (24/16px) meant for grouping distinct field types.
+// examples. Uses its own `selectionItemsSpacing` token (not the larger
+// `fieldGroupSpacing` meant for grouping distinct field types) — see that
+// token's own comment in theme.ts for why it's separate from `spacing`.
 export const selectionGroup = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: forms.fieldset.spacing,
+  gap: forms.fieldset.selectionItemsSpacing,
 });
 
 // Shared with TextField/TextArea's own helper text style (Figma's "Inputs and

--- a/src/components/Fieldset/Fieldset.css.ts
+++ b/src/components/Fieldset/Fieldset.css.ts
@@ -94,12 +94,23 @@ export const selectionGroup = style({
   gap: forms.fieldset.selectionItemsSpacing,
 });
 
+// Groups helperText+error into one tight unit before the description→content
+// gap applies, matching TextField's own description-to-error spacing
+// (`inputVars.spacing.verticalSpacing`, the gap on TextField.css.ts's `root`)
+// rather than the looser legend-stack gap the two sit inside.
+export const descriptionGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: input.spacing.verticalSpacing,
+});
+
 // Shared with TextField/TextArea's own helper text style (Figma's "Inputs and
 // forms/Helper text" — same size/line-height across all form components).
 const descriptionFont = {
-  margin: 0, // reset the <p>'s default UA margin — spacing is via the root flex `gap`
+  margin: 0, // reset the <p>'s default UA margin — spacing is via `descriptionGroup`'s flex `gap`
   fontSize: input.font.helperText.fontSize,
   lineHeight: input.font.helperText.lineHeight,
+  letterSpacing: font.letterSpacing,
 };
 
 export const helperText = style({ ...descriptionFont, color: text.secondary });

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,0 +1,269 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, waitFor } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
+import { Fieldset } from './Fieldset';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { RadioButton } from '../RadioButton/RadioButton';
+import { TextField } from '../TextField/TextField';
+import { Select } from '../Select/Select';
+import { DateField } from '../DateField';
+
+const meta = {
+  component: Fieldset,
+  tags: ['!dev', '!autodocs'],
+  args: {
+    legend: 'Hakijan tiedot',
+    'data-testid': 'fieldset',
+  },
+} satisfies Meta<typeof Fieldset>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const docExample = ['dev', 'autodocs'];
+
+export const Default: Story = {
+  tags: docExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+
+    await expect(group.tagName).toBe('FIELDSET');
+  },
+};
+
+export const Required: Story = {
+  tags: docExample,
+  args: { required: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The visual asterisk is decorative (aria-hidden) — the accessible name
+    // stays just the legend text, since `required` isn't a native `<fieldset>`
+    // concept; individual inputs inside carry their own `required` attribute.
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+    const asterisk = group.querySelector('[aria-hidden="true"]');
+
+    await expect(asterisk?.textContent).toBe('*');
+    await expect(getComputedStyle(asterisk as Element).color).toBe('rgb(174, 30, 32)');
+    // Visual gap from the legend text — without it, "<legend>*" reads as
+    // flush/cramped rather than "<legend> *".
+    await expect(parseFloat(getComputedStyle(asterisk as Element).marginLeft)).toBeGreaterThan(0);
+  },
+};
+
+export const WithHelperText: Story = {
+  tags: docExample,
+  args: { helperText: 'Ohjeteksti' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+    const helper = canvas.getByText('Ohjeteksti');
+
+    await expect(group).toHaveAttribute('aria-describedby', helper.id);
+  },
+};
+
+export const WithError: Story = {
+  tags: docExample,
+  args: { helperText: 'Ohjeteksti', error: 'Virheteksti' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+
+    // Error replaces helper text, matching TextField's error/helperText convention
+    await expect(canvas.queryByText('Ohjeteksti')).toBeNull();
+    const error = canvas.getByText('Virheteksti');
+    await expect(group).toHaveAttribute('aria-describedby', error.id);
+    await expect(getComputedStyle(error).color).toBe('rgb(174, 30, 32)');
+  },
+};
+
+export const MultipleChildrenAreSpaced: Story = {
+  args: {
+    helperText: 'Ohjeteksti',
+    children: (
+      <>
+        <div data-testid="field-a" style={{ height: 20 }} />
+        <div data-testid="field-b" style={{ height: 20 }} />
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const helper = canvas.getByText('Ohjeteksti');
+    const a = canvas.getByTestId('field-a');
+    const b = canvas.getByTestId('field-b');
+
+    // Both gaps are responsive (legend-stack: 16/12, field-group: 24/16), so
+    // don't assume which breakpoint tier the test viewport lands on — instead
+    // assert the relationship that holds at every tier: the gap between two
+    // distinct fields must be strictly larger than the tighter legend-stack
+    // gap (helper text → first field), proving they're driven by two
+    // different tokens rather than one gap value applied uniformly.
+    const legendStackGap = a.getBoundingClientRect().top - helper.getBoundingClientRect().bottom;
+    const fieldGroupGap = b.getBoundingClientRect().top - a.getBoundingClientRect().bottom;
+
+    await expect(fieldGroupGap).toBeGreaterThan(legendStackGap);
+  },
+};
+
+export const WithoutBorderByDefault: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const style = getComputedStyle(canvas.getByTestId('fieldset'));
+
+    // Figma's default Fieldset (per #70) has no visible border — this is the
+    // opt-in Mantine-style bordered variant added on top of that.
+    await expect(style.borderStyle).toBe('none');
+  },
+};
+
+export const WithBorder: Story = {
+  tags: docExample,
+  args: { withBorder: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const style = getComputedStyle(canvas.getByTestId('fieldset'));
+
+    await expect(style.borderStyle).toBe('solid');
+    await expect(style.borderWidth).toBe('2px');
+    await expect(style.borderColor).toBe('rgb(222, 222, 226)');
+    // Default radius is 'sharp' — matches Paper's own default.
+    await expect(style.borderRadius).toBe('0px');
+  },
+};
+
+export const WithBorderAndPillRadius: Story = {
+  tags: docExample,
+  args: { withBorder: true, radius: 'pill' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('fieldset')).borderRadius).toBe('9999px');
+  },
+};
+
+export const RadiusIgnoredWithoutBorder: Story = {
+  // `radius` only affects the bordered variant's corners — must not leak a
+  // pill radius onto the borderless default Fieldset.
+  args: { radius: 'pill' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('fieldset')).borderRadius).toBe('0px');
+  },
+};
+
+export const WithCheckboxGroup: Story = {
+  tags: docExample,
+  args: {
+    legend: 'Minulle sopivimmat työskentelypäivät',
+    required: true,
+    helperText: 'Valitse päivät, jotka useimmiten sopivat',
+    // Checkbox is a controlled component — always pass `checked` explicitly
+    // (see Checkbox.stories.tsx's own convention).
+    children: (
+      <>
+        <Checkbox label="Maanantai" checked={false} onChange={() => {}} />
+        <Checkbox label="Tiistai" checked={false} onChange={() => {}} />
+        <Checkbox label="Keskiviikko" checked={false} onChange={() => {}} />
+        <Checkbox label="Torstai" checked={false} onChange={() => {}} />
+        <Checkbox label="Perjantai" checked={false} onChange={() => {}} />
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getAllByRole('checkbox')).toHaveLength(5);
+  },
+};
+
+export const WithRadioGroup: Story = {
+  tags: docExample,
+  args: {
+    legend: 'Minulle sopivin työskentelypaikka',
+    required: true,
+    helperText: 'Voit vaihtaa valintaa myöhemmin uudelleen',
+    children: (
+      <>
+        <RadioButton name="workplace" label="Toimistolla" />
+        <RadioButton name="workplace" label="Etänä" />
+        <RadioButton name="workplace" label="Hybridi" />
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+  },
+};
+
+export const WithMixedInputs: Story = {
+  tags: docExample,
+  args: {
+    legend: 'Yhteydenottopyyntö',
+    required: true,
+    helperText: 'Täytä tiedot, niin olemme sinuun yhteydessä',
+    children: (
+      <>
+        <TextField inputLabel="Nimi" />
+        <Select inputLabel="Yhteydenottotapa" options={['Puhelin', 'Sähköposti']} />
+        <DateField
+          label="Toivottu ajankohta"
+          calendarButtonLabel="Avaa kalenteri"
+          prevMonthLabel="Edellinen kuukausi"
+          nextMonthLabel="Seuraava kuukausi"
+        />
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fields = [
+      canvas.getByRole('textbox', { name: 'Nimi' }),
+      canvas.getByRole('textbox', { name: 'Yhteydenottotapa' }),
+    ];
+
+    // Each field keeps its own label — unlike a single-field Fieldset, a
+    // mixed group can't rely on the legend to disambiguate which is which.
+    for (const field of fields) {
+      await expect(field).toBeVisible();
+    }
+  },
+};
+
+export const WithCustomClassName: Story = {
+  args: { className: 'consumer-custom-class' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('fieldset').className).toContain('consumer-custom-class');
+  },
+};
+
+// ── Dev-warning test (verifies the console.error guard in Fieldset.tsx) ────
+
+let capturedConsoleErrors: string[] = [];
+
+const captureConsoleErrors = () => {
+  capturedConsoleErrors = [];
+  const original = console.error;
+  console.error = (...messageArgs: unknown[]) => {
+    capturedConsoleErrors.push(String(messageArgs[0]));
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+export const WarnsOnInvalidRadius: Story = {
+  args: { radius: 'invalid' as never },
+  beforeEach: captureConsoleErrors,
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /invalid `radius` value/.test(m))).toBe(true)
+    );
+  },
+};

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -32,6 +32,22 @@ export const Default: Story = {
   },
 };
 
+export const LegendUsesInputLabelTypography: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const legend = canvas.getByText('Hakijan tiedot');
+    const style = getComputedStyle(legend);
+
+    // Same recipe as TextField's own label (TextField.css.ts): Figma's "Inputs
+    // and forms/Input label" style — P2 size, Subheader/Semi-Bold weight,
+    // text.primary color. A bare <legend> otherwise falls back to the
+    // browser's own small default legend font, not any TREDS type scale.
+    await expect(style.fontWeight).toBe('600');
+    await expect(style.color).toBe('rgb(45, 45, 50)');
+    await expect(parseFloat(style.fontSize)).toBeGreaterThanOrEqual(14);
+  },
+};
+
 export const Required: Story = {
   tags: docExample,
   args: { required: true },

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -179,8 +179,35 @@ export const WithBorder: Story = {
     await expect(style.borderRadius).toBe('0px');
     // The legend and content must not hug the border — no Figma spec exists
     // for this Mantine-style addition, so this reuses `forms.spacing` (24px),
-    // the only pre-existing token actually named for this purpose.
-    await expect(style.padding).toBe('24px');
+    // the only pre-existing token actually named for this purpose. `top` is
+    // 0: a flex `<fieldset>`'s `<legend>` always renders flush with the
+    // fieldset's own top edge regardless of padding-top (browsers exclude it
+    // from the padding box entirely), so a nonzero padding-top would only
+    // double up with the legend's own marginBottom below (see the regression
+    // check further down) without giving the legend itself any more
+    // clearance from the top border.
+    await expect(style.paddingTop).toBe('0px');
+    await expect(style.paddingRight).toBe('24px');
+    await expect(style.paddingBottom).toBe('24px');
+    await expect(style.paddingLeft).toBe('24px');
+
+    // Regression: the gap from the legend to the first content below it must
+    // match the fieldset's normal legend-stack gap (`forms.fieldset.spacing`,
+    // the same value `root`'s own flex `rowGap` resolves to), not double up
+    // with `withBorder`'s own padding-top stacking on top of the legend's
+    // marginBottom.
+    const legend = canvas.getByText('Hakijan tiedot');
+    const firstField = canvas.getByText('Etunimi');
+    const fieldset = canvas.getByTestId('fieldset');
+    const gapAfterLegend =
+      firstField.getBoundingClientRect().top - legend.getBoundingClientRect().bottom;
+    const legendStackGapToken = parseFloat(getComputedStyle(fieldset).rowGap);
+
+    await expect(Math.abs(gapAfterLegend - legendStackGapToken)).toBeLessThan(1);
+
+    // A little breathing room between the legend text and the border line it
+    // straddles, so the glyphs don't render flush against the stroke.
+    await expect(parseFloat(getComputedStyle(legend).paddingTop)).toBeGreaterThan(0);
   },
 };
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -177,6 +177,20 @@ export const WithBorder: Story = {
     await expect(style.borderColor).toBe('rgb(222, 222, 226)');
     // Default radius is 'sharp' — matches Paper's own default.
     await expect(style.borderRadius).toBe('0px');
+    // The legend and content must not hug the border — no Figma spec exists
+    // for this Mantine-style addition, so this reuses `forms.spacing` (24px),
+    // the only pre-existing token actually named for this purpose.
+    await expect(style.padding).toBe('24px');
+  },
+};
+
+export const WithoutBorderHasNoPadding: Story = {
+  // Figma's default Fieldset (per #70) has no border and no padding — must
+  // not gain padding just because `withBorder`'s style exists in the CSS.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(getComputedStyle(canvas.getByTestId('fieldset')).padding).toBe('0px');
   },
 };
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within, waitFor } from '@storybook/testing-library';
+import { within, userEvent } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Fieldset } from './Fieldset';
 import { selectionGroup } from './Fieldset.css';
@@ -174,8 +175,12 @@ export const WithBorder: Story = {
 
     await expect(style.borderStyle).toBe('solid');
     await expect(style.borderWidth).toBe('2px');
-    await expect(style.borderColor).toBe('rgb(222, 222, 226)');
-    // Default radius is 'sharp' — matches Paper's own default.
+    // Same resting border color inputs use (`inputStates.default`), not the
+    // lighter `divider` token, so the box reads as part of the same form
+    // surface family as the fields inside it.
+    await expect(style.borderColor).toBe('rgb(82, 82, 91)');
+    // Sharp corners only — no rounded/pill radius option (needs more design
+    // work before it's offered here).
     await expect(style.borderRadius).toBe('0px');
     // The legend and content must not hug the border — no Figma spec exists
     // for this Mantine-style addition, so this reuses `forms.spacing` (24px),
@@ -204,10 +209,6 @@ export const WithBorder: Story = {
     const legendStackGapToken = parseFloat(getComputedStyle(fieldset).rowGap);
 
     await expect(Math.abs(gapAfterLegend - legendStackGapToken)).toBeLessThan(1);
-
-    // A little breathing room between the legend text and the border line it
-    // straddles, so the glyphs don't render flush against the stroke.
-    await expect(parseFloat(getComputedStyle(legend).paddingTop)).toBeGreaterThan(0);
   },
 };
 
@@ -221,52 +222,53 @@ export const WithoutBorderHasNoPadding: Story = {
   },
 };
 
-export const WithBorderAndPillRadius: Story = {
-  tags: docExample,
-  args: { withBorder: true, radius: 'pill' },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    await expect(getComputedStyle(canvas.getByTestId('fieldset')).borderRadius).toBe('9999px');
-  },
-};
-
-export const RadiusIgnoredWithoutBorder: Story = {
-  // `radius` only affects the bordered variant's corners — must not leak a
-  // pill radius onto the borderless default Fieldset.
-  args: { radius: 'pill' },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    await expect(getComputedStyle(canvas.getByTestId('fieldset')).borderRadius).toBe('0px');
-  },
-};
-
 export const WithCheckboxGroup: Story = {
   tags: docExample,
   args: {
     legend: 'Minulle sopivimmat työskentelypäivät',
     required: true,
     helperText: 'Valitse päivät, jotka useimmiten sopivat',
-    // Checkbox is a controlled component — always pass `checked` explicitly
-    // (see Checkbox.stories.tsx's own convention). Grouped as a single
-    // Fieldset child (via `selectionGroup`) so the items get the tight
-    // Figma "Selection-items-spacing" gap, not the larger field-group gap
-    // meant for stacking distinct field types.
-    children: (
-      <div data-testid="checkbox-group" className={selectionGroup}>
-        <Checkbox label="Maanantai" checked={false} onChange={() => {}} />
-        <Checkbox label="Tiistai" checked={false} onChange={() => {}} />
-        <Checkbox label="Keskiviikko" checked={false} onChange={() => {}} />
-        <Checkbox label="Torstai" checked={false} onChange={() => {}} />
-        <Checkbox label="Perjantai" checked={false} onChange={() => {}} />
-      </div>
-    ),
+  },
+  // Checkbox is a controlled component with its own internal state, toggled
+  // via `onClick` (not `onChange` — see Checkbox.stories.tsx's own
+  // convention) — a story-local `useState` is required for the checkboxes to
+  // actually respond to clicks, not just render a static unchecked snapshot.
+  // Grouped as a single Fieldset child (via `selectionGroup`) so the items
+  // get the tight Figma "Selection-items-spacing" gap, not the larger
+  // field-group gap meant for stacking distinct field types.
+  render: (args) => {
+    const days = ['Maanantai', 'Tiistai', 'Keskiviikko', 'Torstai', 'Perjantai'];
+    const [checked, setChecked] = useState(days.map(() => false));
+
+    return (
+      <Fieldset {...args}>
+        <div data-testid="checkbox-group" className={selectionGroup}>
+          {days.map((label, i) => (
+            <Checkbox
+              key={label}
+              label={label}
+              checked={checked[i]}
+              onClick={() => setChecked(checked.map((c, idx) => (idx === i ? !c : c)))}
+            />
+          ))}
+        </div>
+      </Fieldset>
+    );
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const checkboxes = canvas.getAllByRole('checkbox');
 
-    await expect(canvas.getAllByRole('checkbox')).toHaveLength(5);
+    await expect(checkboxes).toHaveLength(5);
+
+    // Regression: checkboxes must actually respond to clicks (the earlier
+    // static `checked={false}` demo looked right but was unclickable —
+    // Checkbox's own render-phase `checked`/prop-sync logic immediately
+    // reverted any click back to the hardcoded `false`).
+    const first = checkboxes[0] as HTMLInputElement;
+    await expect(first.checked).toBe(false);
+    await userEvent.click(first);
+    await expect(first.checked).toBe(true);
 
     // Regression: checkbox items must use the tight legend-stack gap
     // (`forms.fieldset.spacing` — Figma's `Forms/Selection-items-spacing`
@@ -288,19 +290,48 @@ export const WithRadioGroup: Story = {
     legend: 'Minulle sopivin työskentelypaikka',
     required: true,
     helperText: 'Voit vaihtaa valintaa myöhemmin uudelleen',
-    // Grouped as a single Fieldset child — same rationale as WithCheckboxGroup.
-    children: (
-      <div data-testid="radio-group" className={selectionGroup}>
-        <RadioButton name="workplace" label="Toimistolla" />
-        <RadioButton name="workplace" label="Etänä" />
-        <RadioButton name="workplace" label="Hybridi" />
-      </div>
-    ),
+  },
+  // RadioButton is fully controlled (no internal state of its own) — a
+  // story-local `useState` drives mutual exclusivity, matching
+  // RadioButton.stories.tsx's own `onClick`-driven convention.
+  render: (args) => {
+    const options = [
+      { value: 'office', label: 'Toimistolla' },
+      { value: 'remote', label: 'Etänä' },
+      { value: 'hybrid', label: 'Hybridi' },
+    ];
+    const [selected, setSelected] = useState<string>();
+
+    return (
+      <Fieldset {...args}>
+        <div data-testid="radio-group" className={selectionGroup}>
+          {options.map((option) => (
+            <RadioButton
+              key={option.value}
+              name="workplace"
+              label={option.label}
+              checked={selected === option.value}
+              onClick={() => setSelected(option.value)}
+            />
+          ))}
+        </div>
+      </Fieldset>
+    );
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const radios = canvas.getAllByRole('radio') as HTMLInputElement[];
 
-    await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+    await expect(radios).toHaveLength(3);
+
+    // Regression: radios must actually respond to clicks and stay mutually
+    // exclusive (the earlier demo passed neither `checked` nor `onClick` at
+    // all, so nothing happened on click).
+    await userEvent.click(radios[0]);
+    await expect(radios[0].checked).toBe(true);
+    await userEvent.click(radios[1]);
+    await expect(radios[1].checked).toBe(true);
+    await expect(radios[0].checked).toBe(false);
 
     // Regression: same gap check as WithCheckboxGroup.
     const fieldsetGap = parseFloat(getComputedStyle(canvas.getByTestId('fieldset')).rowGap);
@@ -350,30 +381,5 @@ export const WithCustomClassName: Story = {
     const canvas = within(canvasElement);
 
     await expect(canvas.getByTestId('fieldset').className).toContain('consumer-custom-class');
-  },
-};
-
-// ── Dev-warning test (verifies the console.error guard in Fieldset.tsx) ────
-
-let capturedConsoleErrors: string[] = [];
-
-const captureConsoleErrors = () => {
-  capturedConsoleErrors = [];
-  const original = console.error;
-  console.error = (...messageArgs: unknown[]) => {
-    capturedConsoleErrors.push(String(messageArgs[0]));
-  };
-  return () => {
-    console.error = original;
-  };
-};
-
-export const WarnsOnInvalidRadius: Story = {
-  args: { radius: 'invalid' as never },
-  beforeEach: captureConsoleErrors,
-  play: async () => {
-    await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /invalid `radius` value/.test(m))).toBe(true)
-    );
   },
 };

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -2,11 +2,23 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, waitFor } from '@storybook/testing-library';
 import { expect } from 'storybook/test';
 import { Fieldset } from './Fieldset';
+import { selectionGroup } from './Fieldset.css';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { RadioButton } from '../RadioButton/RadioButton';
 import { TextField } from '../TextField/TextField';
 import { Select } from '../Select/Select';
 import { DateField } from '../DateField';
+
+// Finnish translation of HDS (Helsinki Design System)'s canonical Fieldset
+// example (hds.hel.fi/components/fieldset/#example), matching the Figma
+// branch's "Fieldset with applicant information" example (node 14047:1146).
+const applicantInfoFields = (
+  <>
+    <TextField inputLabel="Etunimi" />
+    <TextField inputLabel="Sukunimi" />
+    <TextField inputLabel="Henkilötunnus" placeholder="Esim. 111299-1234" />
+  </>
+);
 
 const meta = {
   component: Fieldset,
@@ -14,6 +26,7 @@ const meta = {
   args: {
     legend: 'Hakijan tiedot',
     'data-testid': 'fieldset',
+    children: applicantInfoFields,
   },
 } satisfies Meta<typeof Fieldset>;
 
@@ -76,6 +89,24 @@ export const WithHelperText: Story = {
     const helper = canvas.getByText('Ohjeteksti');
 
     await expect(group).toHaveAttribute('aria-describedby', helper.id);
+
+    // Regression: a flex `<fieldset>`'s `<legend>` is excluded from the flex
+    // formatting context (browsers wrap the rest of the children in an
+    // anonymous "fieldset content box" per the CSS Fieldsets spec) — the
+    // root's flex `gap` therefore never applies between the legend and its
+    // next sibling, only among children after it (that gap measures 0
+    // without an explicit margin on the legend). Assert equality against the
+    // helper→children gap (both use the same `forms.fieldset.spacing` token)
+    // rather than a breakpoint-dependent hardcoded pixel value.
+    const legend = canvas.getByText('Hakijan tiedot');
+    const childrenWrapper = helper.nextElementSibling as HTMLElement;
+    const legendToHelperGap =
+      helper.getBoundingClientRect().top - legend.getBoundingClientRect().bottom;
+    const helperToChildrenGap =
+      childrenWrapper.getBoundingClientRect().top - helper.getBoundingClientRect().bottom;
+
+    await expect(legendToHelperGap).toBeGreaterThan(0);
+    await expect(Math.abs(legendToHelperGap - helperToChildrenGap)).toBeLessThan(1);
   },
 };
 
@@ -177,21 +208,36 @@ export const WithCheckboxGroup: Story = {
     required: true,
     helperText: 'Valitse päivät, jotka useimmiten sopivat',
     // Checkbox is a controlled component — always pass `checked` explicitly
-    // (see Checkbox.stories.tsx's own convention).
+    // (see Checkbox.stories.tsx's own convention). Grouped as a single
+    // Fieldset child (via `selectionGroup`) so the items get the tight
+    // Figma "Selection-items-spacing" gap, not the larger field-group gap
+    // meant for stacking distinct field types.
     children: (
-      <>
+      <div data-testid="checkbox-group" className={selectionGroup}>
         <Checkbox label="Maanantai" checked={false} onChange={() => {}} />
         <Checkbox label="Tiistai" checked={false} onChange={() => {}} />
         <Checkbox label="Keskiviikko" checked={false} onChange={() => {}} />
         <Checkbox label="Torstai" checked={false} onChange={() => {}} />
         <Checkbox label="Perjantai" checked={false} onChange={() => {}} />
-      </>
+      </div>
     ),
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await expect(canvas.getAllByRole('checkbox')).toHaveLength(5);
+
+    // Regression: checkbox items must use the tight legend-stack gap
+    // (`forms.fieldset.spacing` — Figma's `Forms/Selection-items-spacing`
+    // aliases to that exact same token), not the larger `fieldGroupSpacing`
+    // meant for grouping distinct field types. Compare the group's own
+    // computed row-gap against the Fieldset root's (both should resolve to
+    // the same token, at whatever breakpoint the test viewport lands on)
+    // rather than asserting a breakpoint-dependent hardcoded pixel value.
+    const fieldsetGap = parseFloat(getComputedStyle(canvas.getByTestId('fieldset')).rowGap);
+    const groupGap = parseFloat(getComputedStyle(canvas.getByTestId('checkbox-group')).rowGap);
+
+    await expect(groupGap).toBe(fieldsetGap);
   },
 };
 
@@ -201,18 +247,25 @@ export const WithRadioGroup: Story = {
     legend: 'Minulle sopivin työskentelypaikka',
     required: true,
     helperText: 'Voit vaihtaa valintaa myöhemmin uudelleen',
+    // Grouped as a single Fieldset child — same rationale as WithCheckboxGroup.
     children: (
-      <>
+      <div data-testid="radio-group" className={selectionGroup}>
         <RadioButton name="workplace" label="Toimistolla" />
         <RadioButton name="workplace" label="Etänä" />
         <RadioButton name="workplace" label="Hybridi" />
-      </>
+      </div>
     ),
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await expect(canvas.getAllByRole('radio')).toHaveLength(3);
+
+    // Regression: same gap check as WithCheckboxGroup.
+    const fieldsetGap = parseFloat(getComputedStyle(canvas.getByTestId('fieldset')).rowGap);
+    const groupGap = parseFloat(getComputedStyle(canvas.getByTestId('radio-group')).rowGap);
+
+    await expect(groupGap).toBe(fieldsetGap);
   },
 };
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -436,3 +436,28 @@ export const WithCustomClassName: Story = {
     await expect(canvas.getByTestId('fieldset').className).toContain('consumer-custom-class');
   },
 };
+
+export const WithoutChildrenRendersNoWrapper: Story = {
+  args: { children: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+
+    // No wrapper div should render when there are no children to group —
+    // the fieldset's only DOM child is its own <legend>.
+    await expect(group.children).toHaveLength(1);
+  },
+};
+
+export const CustomClassNamesMergeWithInternalStyles: Story = {
+  args: { classNames: { legend: 'consumer-legend-class' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const legend = canvas.getByText('Hakijan tiedot');
+
+    // A caller's classNames.legend must merge with (cx), not replace, the
+    // internal legend typography class.
+    await expect(legend.className).toContain('consumer-legend-class');
+    await expect(getComputedStyle(legend).fontWeight).toBe('600');
+  },
+};

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -118,11 +118,64 @@ export const WithError: Story = {
     const canvas = within(canvasElement);
     const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
 
-    // Error replaces helper text, matching TextField's error/helperText convention
-    await expect(canvas.queryByText('Ohjeteksti')).toBeNull();
+    // Error is shown alongside helper text, not replacing it — matches
+    // TextField/Mantine's InputWrapper, which renders description and error
+    // together, both wired into aria-describedby.
+    const helper = canvas.getByText('Ohjeteksti');
     const error = canvas.getByText('Virheteksti');
-    await expect(group).toHaveAttribute('aria-describedby', error.id);
+
+    await expect(group).toHaveAttribute('aria-describedby', `${helper.id} ${error.id}`);
     await expect(getComputedStyle(error).color).toBe('rgb(174, 30, 32)');
+    await expect(getComputedStyle(helper).color).not.toBe('rgb(174, 30, 32)');
+  },
+};
+
+export const ErrorOnlyDescribedBy: Story = {
+  args: { error: 'Virheteksti' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+    const error = canvas.getByText('Virheteksti');
+
+    await expect(canvas.queryByText('Ohjeteksti')).toBeNull();
+    await expect(group).toHaveAttribute('aria-describedby', error.id);
+  },
+};
+
+export const EmptyStringErrorFallsBackToHelperText: Story = {
+  args: { helperText: 'Ohjeteksti', error: '' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+
+    // Regression: an empty-string `error` (common from controlled form
+    // state) must not swallow `helperText` — only a truthy `error` shows.
+    const helper = canvas.getByText('Ohjeteksti');
+    await expect(helper).toBeVisible();
+    await expect(group).toHaveAttribute('aria-describedby', helper.id);
+  },
+};
+
+export const DescribedByMergesWithConsumerValue: Story = {
+  args: { helperText: 'Ohjeteksti', 'aria-describedby': 'external-hint' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+    const helper = canvas.getByText('Ohjeteksti');
+
+    // A caller-supplied aria-describedby must be merged with, not clobbered
+    // by, the internal helperText/error ids.
+    await expect(group).toHaveAttribute('aria-describedby', `${helper.id} external-hint`);
+  },
+};
+
+export const DescribedByFallsBackToConsumerValueWhenNoDescription: Story = {
+  args: { 'aria-describedby': 'external-hint' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: 'Hakijan tiedot' });
+
+    await expect(group).toHaveAttribute('aria-describedby', 'external-hint');
   },
 };
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -97,17 +97,18 @@ export const WithHelperText: Story = {
     // root's flex `gap` therefore never applies between the legend and its
     // next sibling, only among children after it (that gap measures 0
     // without an explicit margin on the legend). Assert equality against the
-    // helper→children gap (both use the same `forms.fieldset.spacing` token)
-    // rather than a breakpoint-dependent hardcoded pixel value.
+    // description→children gap (both use the same `forms.fieldset.spacing`
+    // token) rather than a breakpoint-dependent hardcoded pixel value.
     const legend = canvas.getByText('Hakijan tiedot');
-    const childrenWrapper = helper.nextElementSibling as HTMLElement;
+    const descriptionGroup = helper.parentElement as HTMLElement;
+    const childrenWrapper = descriptionGroup.nextElementSibling as HTMLElement;
     const legendToHelperGap =
       helper.getBoundingClientRect().top - legend.getBoundingClientRect().bottom;
-    const helperToChildrenGap =
-      childrenWrapper.getBoundingClientRect().top - helper.getBoundingClientRect().bottom;
+    const descriptionToChildrenGap =
+      childrenWrapper.getBoundingClientRect().top - descriptionGroup.getBoundingClientRect().bottom;
 
     await expect(legendToHelperGap).toBeGreaterThan(0);
-    await expect(Math.abs(legendToHelperGap - helperToChildrenGap)).toBeLessThan(1);
+    await expect(Math.abs(legendToHelperGap - descriptionToChildrenGap)).toBeLessThan(1);
   },
 };
 
@@ -120,13 +121,25 @@ export const WithError: Story = {
 
     // Error is shown alongside helper text, not replacing it — matches
     // TextField/Mantine's InputWrapper, which renders description and error
-    // together, both wired into aria-describedby.
+    // together at TextField's own tighter spacing (input.spacing.verticalSpacing),
+    // both wired into aria-describedby.
     const helper = canvas.getByText('Ohjeteksti');
     const error = canvas.getByText('Virheteksti');
 
     await expect(group).toHaveAttribute('aria-describedby', `${helper.id} ${error.id}`);
     await expect(getComputedStyle(error).color).toBe('rgb(174, 30, 32)');
     await expect(getComputedStyle(helper).color).not.toBe('rgb(174, 30, 32)');
+
+    // Regression: helper→error gap must be the tight TextField-matching gap
+    // (input.spacing.verticalSpacing), strictly smaller than the looser
+    // legend→helper gap (forms.fieldset.spacing) the pair sits inside.
+    const legend = canvas.getByText('Hakijan tiedot');
+    const legendToHelperGap =
+      helper.getBoundingClientRect().top - legend.getBoundingClientRect().bottom;
+    const helperToErrorGap =
+      error.getBoundingClientRect().top - helper.getBoundingClientRect().bottom;
+
+    await expect(helperToErrorGap).toBeLessThan(legendToHelperGap);
   },
 };
 
@@ -323,17 +336,20 @@ export const WithCheckboxGroup: Story = {
     await userEvent.click(first);
     await expect(first.checked).toBe(true);
 
-    // Regression: checkbox items must use `selectionItemsSpacing`'s value
-    // (currently identical to the legend-stack gap, since both alias the
-    // same Figma breakpoint chain today), not the larger `fieldGroupSpacing`
-    // meant for grouping distinct field types. Compare the group's own
-    // computed row-gap against the Fieldset root's (both should resolve to
-    // the same token, at whatever breakpoint the test viewport lands on)
-    // rather than asserting a breakpoint-dependent hardcoded pixel value.
-    const fieldsetGap = parseFloat(getComputedStyle(canvas.getByTestId('fieldset')).rowGap);
-    const groupGap = parseFloat(getComputedStyle(canvas.getByTestId('checkbox-group')).rowGap);
+    // Regression: checkbox items must use the tighter `selectionItemsSpacing`
+    // gap, strictly less than `fieldGroupSpacing` (the larger gap meant for
+    // stacking distinct field types) — compared against the actual
+    // field-group gap (the checkbox group's own parent, Fieldset's
+    // `childrenWrapper`) so this survives `selectionItemsSpacing` and
+    // `spacing` diverging from each other later, which is the whole point of
+    // giving them separate tokens.
+    const checkboxGroup = canvas.getByTestId('checkbox-group');
+    const fieldGroupGap = parseFloat(
+      getComputedStyle(checkboxGroup.parentElement as HTMLElement).rowGap
+    );
+    const groupGap = parseFloat(getComputedStyle(checkboxGroup).rowGap);
 
-    await expect(groupGap).toBe(fieldsetGap);
+    await expect(groupGap).toBeLessThan(fieldGroupGap);
   },
 };
 
@@ -387,10 +403,13 @@ export const WithRadioGroup: Story = {
     await expect(radios[0].checked).toBe(false);
 
     // Regression: same gap check as WithCheckboxGroup.
-    const fieldsetGap = parseFloat(getComputedStyle(canvas.getByTestId('fieldset')).rowGap);
-    const groupGap = parseFloat(getComputedStyle(canvas.getByTestId('radio-group')).rowGap);
+    const radioGroup = canvas.getByTestId('radio-group');
+    const fieldGroupGap = parseFloat(
+      getComputedStyle(radioGroup.parentElement as HTMLElement).rowGap
+    );
+    const groupGap = parseFloat(getComputedStyle(radioGroup).rowGap);
 
-    await expect(groupGap).toBe(fieldsetGap);
+    await expect(groupGap).toBeLessThan(fieldGroupGap);
   },
 };
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -64,7 +64,7 @@ export const LegendUsesInputLabelTypography: Story = {
 
 export const Required: Story = {
   tags: docExample,
-  args: { required: true },
+  args: { showRequiredMarker: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // The visual asterisk is decorative (aria-hidden) — the accessible name
@@ -279,7 +279,7 @@ export const WithCheckboxGroup: Story = {
   tags: docExample,
   args: {
     legend: 'Minulle sopivimmat työskentelypäivät',
-    required: true,
+    showRequiredMarker: true,
     helperText: 'Valitse päivät, jotka useimmiten sopivat',
   },
   // Checkbox is a controlled component with its own internal state, toggled
@@ -341,7 +341,7 @@ export const WithRadioGroup: Story = {
   tags: docExample,
   args: {
     legend: 'Minulle sopivin työskentelypaikka',
-    required: true,
+    showRequiredMarker: true,
     helperText: 'Voit vaihtaa valintaa myöhemmin uudelleen',
   },
   // RadioButton is fully controlled (no internal state of its own) — a
@@ -398,7 +398,7 @@ export const WithMixedInputs: Story = {
   tags: docExample,
   args: {
     legend: 'Yhteydenottopyyntö',
-    required: true,
+    showRequiredMarker: true,
     helperText: 'Täytä tiedot, niin olemme sinuun yhteydessä',
     children: (
       <>

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -287,8 +287,8 @@ export const WithCheckboxGroup: Story = {
   // convention) — a story-local `useState` is required for the checkboxes to
   // actually respond to clicks, not just render a static unchecked snapshot.
   // Grouped as a single Fieldset child (via `selectionGroup`) so the items
-  // get the tight Figma "Selection-items-spacing" gap, not the larger
-  // field-group gap meant for stacking distinct field types.
+  // get their own dedicated "Selection-items-spacing" gap token, not the
+  // larger field-group gap meant for stacking distinct field types.
   render: (args) => {
     const days = ['Maanantai', 'Tiistai', 'Keskiviikko', 'Torstai', 'Perjantai'];
     const [checked, setChecked] = useState(days.map(() => false));
@@ -323,9 +323,9 @@ export const WithCheckboxGroup: Story = {
     await userEvent.click(first);
     await expect(first.checked).toBe(true);
 
-    // Regression: checkbox items must use the tight legend-stack gap
-    // (`forms.fieldset.spacing` — Figma's `Forms/Selection-items-spacing`
-    // aliases to that exact same token), not the larger `fieldGroupSpacing`
+    // Regression: checkbox items must use `selectionItemsSpacing`'s value
+    // (currently identical to the legend-stack gap, since both alias the
+    // same Figma breakpoint chain today), not the larger `fieldGroupSpacing`
     // meant for grouping distinct field types. Compare the group's own
     // computed row-gap against the Fieldset root's (both should resolve to
     // the same token, at whatever breakpoint the test viewport lands on)

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -4,11 +4,13 @@ import {
   Fieldset as MantineFieldset,
   type FieldsetProps as MantineFieldsetProps,
 } from '@mantine/core';
+import { mergeClassNames } from '../../utils.ts';
 import {
   asterisk,
   childrenWrapper,
   errorText,
   helperText as helperTextStyle,
+  legend as legendStyle,
   pill,
   root,
   withBorder as withBorderStyle,
@@ -40,6 +42,7 @@ export const Fieldset = ({
   radius = 'sharp',
   children,
   className,
+  classNames,
   ...props
 }: FieldsetProps) => {
   const descriptionId = useId();
@@ -76,6 +79,7 @@ export const Fieldset = ({
         hasBorder && radius === 'pill' && pill,
         className
       )}
+      classNames={mergeClassNames({ root: '', legend: legendStyle }, classNames)}
       aria-describedby={description ? descriptionId : props['aria-describedby']}
     >
       {description && (

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useId } from 'react';
+import cx from 'clsx';
+import {
+  Fieldset as MantineFieldset,
+  type FieldsetProps as MantineFieldsetProps,
+} from '@mantine/core';
+import {
+  asterisk,
+  childrenWrapper,
+  errorText,
+  helperText as helperTextStyle,
+  pill,
+  root,
+  withBorder as withBorderStyle,
+} from './Fieldset.css';
+
+export interface FieldsetProps
+  extends Omit<MantineFieldsetProps, 'legend' | 'variant' | 'radius'>, React.AriaAttributes {
+  legend: React.ReactNode;
+  /** Renders a decorative `*` next to the legend. Individual inputs inside still need their own `required` attribute — this isn't a native `<fieldset>` concept. */
+  required?: boolean;
+  helperText?: React.ReactNode;
+  /** Presence of an error replaces `helperText`, same convention as TextField. */
+  error?: string;
+  /** Mantine's bordered "default" variant vs TREDS's borderless default (per Figma, #70). Default `false`. */
+  withBorder?: boolean;
+  /** Corner shape when `withBorder`. Same values as Paper's `radius`. Default `'sharp'`. */
+  radius?: 'sharp' | 'pill';
+  children?: React.ReactNode;
+  'data-testid'?: string;
+}
+
+/** Groups related form inputs under a common legend, using native `<fieldset>`/`<legend>` semantics. */
+export const Fieldset = ({
+  legend,
+  required,
+  helperText,
+  error,
+  withBorder: hasBorder = false,
+  radius = 'sharp',
+  children,
+  className,
+  ...props
+}: FieldsetProps) => {
+  const descriptionId = useId();
+  const description = error ?? helperText;
+
+  // Dev-only guard: an out-of-union `radius` value silently falls back to the
+  // sharp-corner default with no other signal — same risk class Paper already
+  // guards for its own `radius` prop.
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+
+    if (radius !== 'sharp' && radius !== 'pill') {
+      console.error(`Fieldset: invalid \`radius\` value "${String(radius)}".`);
+    }
+  }, [radius]);
+
+  return (
+    <MantineFieldset
+      {...props}
+      variant="unstyled"
+      legend={
+        <>
+          {legend}
+          {required && (
+            <span aria-hidden="true" className={asterisk}>
+              *
+            </span>
+          )}
+        </>
+      }
+      className={cx(
+        root,
+        hasBorder && withBorderStyle,
+        hasBorder && radius === 'pill' && pill,
+        className
+      )}
+      aria-describedby={description ? descriptionId : props['aria-describedby']}
+    >
+      {description && (
+        <p id={descriptionId} className={error ? errorText : helperTextStyle}>
+          {description}
+        </p>
+      )}
+      {children && <div className={childrenWrapper}>{children}</div>}
+    </MantineFieldset>
+  );
+};

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from 'react';
+import { useId } from 'react';
 import cx from 'clsx';
 import {
   Fieldset as MantineFieldset,
@@ -11,7 +11,6 @@ import {
   errorText,
   helperText as helperTextStyle,
   legend as legendStyle,
-  pill,
   root,
   withBorder as withBorderStyle,
 } from './Fieldset.css';
@@ -24,10 +23,8 @@ export interface FieldsetProps
   helperText?: React.ReactNode;
   /** Presence of an error replaces `helperText`, same convention as TextField. */
   error?: string;
-  /** Mantine's bordered "default" variant vs TREDS's borderless default (per Figma, #70). Default `false`. */
+  /** Mantine's bordered "default" variant vs TREDS's borderless default (per Figma, #70). Default `false`. Sharp corners only — a rounded/pill radius needs more design work before it's offered here. */
   withBorder?: boolean;
-  /** Corner shape when `withBorder`. Same values as Paper's `radius`. Default `'sharp'`. */
-  radius?: 'sharp' | 'pill';
   children?: React.ReactNode;
   'data-testid'?: string;
 }
@@ -39,7 +36,6 @@ export const Fieldset = ({
   helperText,
   error,
   withBorder: hasBorder = false,
-  radius = 'sharp',
   children,
   className,
   classNames,
@@ -47,17 +43,6 @@ export const Fieldset = ({
 }: FieldsetProps) => {
   const descriptionId = useId();
   const description = error ?? helperText;
-
-  // Dev-only guard: an out-of-union `radius` value silently falls back to the
-  // sharp-corner default with no other signal — same risk class Paper already
-  // guards for its own `radius` prop.
-  useEffect(() => {
-    if (process.env.NODE_ENV === 'production') return;
-
-    if (radius !== 'sharp' && radius !== 'pill') {
-      console.error(`Fieldset: invalid \`radius\` value "${String(radius)}".`);
-    }
-  }, [radius]);
 
   return (
     <MantineFieldset
@@ -73,12 +58,7 @@ export const Fieldset = ({
           )}
         </>
       }
-      className={cx(
-        root,
-        hasBorder && withBorderStyle,
-        hasBorder && radius === 'pill' && pill,
-        className
-      )}
+      className={cx(root, hasBorder && withBorderStyle, className)}
       classNames={mergeClassNames({ root: '', legend: legendStyle }, classNames)}
       aria-describedby={description ? descriptionId : props['aria-describedby']}
     >

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -15,8 +15,7 @@ import {
   withBorder as withBorderStyle,
 } from './Fieldset.css';
 
-export interface FieldsetProps
-  extends Omit<MantineFieldsetProps, 'legend' | 'variant' | 'radius'>, React.AriaAttributes {
+export interface FieldsetProps extends Omit<MantineFieldsetProps, 'legend' | 'variant' | 'radius'> {
   legend: React.ReactNode;
   /** Renders a decorative `*` next to the legend. Individual inputs inside still need their own `required` attribute — this isn't a native `<fieldset>` concept. */
   showRequiredMarker?: boolean;
@@ -63,7 +62,7 @@ export const Fieldset = ({
         </>
       }
       className={cx(root, hasBorder && withBorderStyle, className)}
-      classNames={mergeClassNames({ root: '', legend: legendStyle }, classNames)}
+      classNames={mergeClassNames<{ legend: string }>({ legend: legendStyle }, classNames)}
       aria-describedby={describedBy}
     >
       {helperText && (

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -19,7 +19,7 @@ export interface FieldsetProps
   extends Omit<MantineFieldsetProps, 'legend' | 'variant' | 'radius'>, React.AriaAttributes {
   legend: React.ReactNode;
   /** Renders a decorative `*` next to the legend. Individual inputs inside still need their own `required` attribute — this isn't a native `<fieldset>` concept. */
-  required?: boolean;
+  showRequiredMarker?: boolean;
   helperText?: React.ReactNode;
   /** Rendered alongside `helperText`, not replacing it — matches TextField/Mantine's InputWrapper, which shows description and error together. */
   error?: string;
@@ -32,7 +32,7 @@ export interface FieldsetProps
 /** Groups related form inputs under a common legend, using native `<fieldset>`/`<legend>` semantics. */
 export const Fieldset = ({
   legend,
-  required,
+  showRequiredMarker,
   helperText,
   error,
   withBorder: hasBorder = false,
@@ -55,7 +55,7 @@ export const Fieldset = ({
       legend={
         <>
           {legend}
-          {required && (
+          {showRequiredMarker && (
             <span aria-hidden="true" className={asterisk}>
               *
             </span>

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -8,10 +8,12 @@ import { mergeClassNames } from '../../utils.ts';
 import {
   asterisk,
   childrenWrapper,
+  descriptionGroup,
   errorText,
   helperText as helperTextStyle,
   legend as legendStyle,
   root,
+  selectionGroup,
   withBorder as withBorderStyle,
 } from './Fieldset.css';
 
@@ -27,6 +29,9 @@ export interface FieldsetProps extends Omit<MantineFieldsetProps, 'legend' | 'va
   children?: React.ReactNode;
   'data-testid'?: string;
 }
+
+/** Flex-column wrapper class for grouping Checkbox/RadioButton items inside one Fieldset — see the WithCheckboxGroup/WithRadioGroup doc examples. */
+export const fieldsetSelectionGroup = selectionGroup;
 
 /** Groups related form inputs under a common legend, using native `<fieldset>`/`<legend>` semantics. */
 export const Fieldset = ({
@@ -65,15 +70,19 @@ export const Fieldset = ({
       classNames={mergeClassNames<{ legend: string }>({ legend: legendStyle }, classNames)}
       aria-describedby={describedBy}
     >
-      {helperText && (
-        <p id={helperTextId} className={helperTextStyle}>
-          {helperText}
-        </p>
-      )}
-      {error && (
-        <p id={errorId} className={errorText}>
-          {error}
-        </p>
+      {(helperText || error) && (
+        <div className={descriptionGroup}>
+          {helperText && (
+            <p id={helperTextId} className={helperTextStyle}>
+              {helperText}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className={errorText}>
+              {error}
+            </p>
+          )}
+        </div>
       )}
       {children && <div className={childrenWrapper}>{children}</div>}
     </MantineFieldset>

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -21,7 +21,7 @@ export interface FieldsetProps
   /** Renders a decorative `*` next to the legend. Individual inputs inside still need their own `required` attribute — this isn't a native `<fieldset>` concept. */
   required?: boolean;
   helperText?: React.ReactNode;
-  /** Presence of an error replaces `helperText`, same convention as TextField. */
+  /** Rendered alongside `helperText`, not replacing it — matches TextField/Mantine's InputWrapper, which shows description and error together. */
   error?: string;
   /** Mantine's bordered "default" variant vs TREDS's borderless default (per Figma, #70). Default `false`. Sharp corners only — a rounded/pill radius needs more design work before it's offered here. */
   withBorder?: boolean;
@@ -41,8 +41,12 @@ export const Fieldset = ({
   classNames,
   ...props
 }: FieldsetProps) => {
-  const descriptionId = useId();
-  const description = error ?? helperText;
+  const helperTextId = useId();
+  const errorId = useId();
+  const describedBy =
+    [helperText && helperTextId, error && errorId, props['aria-describedby']]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   return (
     <MantineFieldset
@@ -60,11 +64,16 @@ export const Fieldset = ({
       }
       className={cx(root, hasBorder && withBorderStyle, className)}
       classNames={mergeClassNames({ root: '', legend: legendStyle }, classNames)}
-      aria-describedby={description ? descriptionId : props['aria-describedby']}
+      aria-describedby={describedBy}
     >
-      {description && (
-        <p id={descriptionId} className={error ? errorText : helperTextStyle}>
-          {description}
+      {helperText && (
+        <p id={helperTextId} className={helperTextStyle}>
+          {helperText}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className={errorText}>
+          {error}
         </p>
       )}
       {children && <div className={childrenWrapper}>{children}</div>}

--- a/src/components/Fieldset/index.ts
+++ b/src/components/Fieldset/index.ts
@@ -1,0 +1,1 @@
+export * from './Fieldset';

--- a/src/components/Fieldset/index.ts
+++ b/src/components/Fieldset/index.ts
@@ -1,1 +1,2 @@
 export * from './Fieldset';
+export { selectionGroup as fieldsetSelectionGroup } from './Fieldset.css';

--- a/src/components/Fieldset/index.ts
+++ b/src/components/Fieldset/index.ts
@@ -1,2 +1,1 @@
 export * from './Fieldset';
-export { selectionGroup as fieldsetSelectionGroup } from './Fieldset.css';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -35,3 +35,4 @@ export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider';
 export { Typography } from './Typography/Typography';
 export { DateField, type DateFieldProps, type DateFieldClassNames } from './DateField';
 export { TextLink, type TextLinkProps, type TextLinkSize } from './TextLink/TextLink';
+export { Fieldset, type FieldsetProps } from './Fieldset/Fieldset';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -35,4 +35,4 @@ export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider';
 export { Typography } from './Typography/Typography';
 export { DateField, type DateFieldProps, type DateFieldClassNames } from './DateField';
 export { TextLink, type TextLinkProps, type TextLinkSize } from './TextLink/TextLink';
-export { Fieldset, type FieldsetProps } from './Fieldset/Fieldset';
+export { Fieldset, type FieldsetProps, fieldsetSelectionGroup } from './Fieldset';

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -80,7 +80,9 @@ exports[`Token Values Match Snapshot > lg 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },
@@ -430,7 +432,9 @@ exports[`Token Values Match Snapshot > md 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },
@@ -780,7 +784,9 @@ exports[`Token Values Match Snapshot > sm 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },
@@ -1544,7 +1550,9 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
       },
       "forms": {
         "fieldset": {
-          "spacing": "calc(0.5rem * var(--mantine-scale))",
+          "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
+          "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+          "spacing": "calc(0.75rem * var(--mantine-scale))",
         },
         "spacing": "calc(1.5rem * var(--mantine-scale))",
       },
@@ -1895,7 +1903,9 @@ exports[`Token Values Match Snapshot > xl 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },
@@ -2245,7 +2255,9 @@ exports[`Token Values Match Snapshot > xs 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },
@@ -2595,7 +2607,9 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
     },
     "forms": {
       "fieldset": {
-        "spacing": "calc(0.5rem * var(--mantine-scale))",
+        "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
+        "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
     },

--- a/src/theme/__snapshots__/tokens.stories.tsx.snap
+++ b/src/theme/__snapshots__/tokens.stories.tsx.snap
@@ -82,6 +82,7 @@ exports[`Token Values Match Snapshot > lg 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(1rem * var(--mantine-scale))",
         "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -434,6 +435,7 @@ exports[`Token Values Match Snapshot > md 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(0.75rem * var(--mantine-scale))",
         "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -786,6 +788,7 @@ exports[`Token Values Match Snapshot > sm 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(0.75rem * var(--mantine-scale))",
         "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -1552,6 +1555,7 @@ exports[`Token Values Match Snapshot > themeVariables 1`] = `
         "fieldset": {
           "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
           "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+          "selectionItemsSpacing": "calc(0.75rem * var(--mantine-scale))",
           "spacing": "calc(0.75rem * var(--mantine-scale))",
         },
         "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -1905,6 +1909,7 @@ exports[`Token Values Match Snapshot > xl 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(1rem * var(--mantine-scale))",
         "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -2257,6 +2262,7 @@ exports[`Token Values Match Snapshot > xs 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(0.75rem * var(--mantine-scale))",
         "spacing": "calc(0.75rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",
@@ -2609,6 +2615,7 @@ exports[`Token Values Match Snapshot > xxl 1`] = `
       "fieldset": {
         "fieldGroupSpacing": "calc(1.5rem * var(--mantine-scale))",
         "requiredIndicatorGap": "calc(0.25rem * var(--mantine-scale))",
+        "selectionItemsSpacing": "calc(1rem * var(--mantine-scale))",
         "spacing": "calc(1rem * var(--mantine-scale))",
       },
       "spacing": "calc(1.5rem * var(--mantine-scale))",

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -315,7 +315,28 @@ export function getTheme(bp: BreakpointKey) {
       headerGap: primitives.spacing['1,5'],
       todayMarkerInset: primitives.spacing['0,5'],
     },
-    forms: { spacing: primitives.spacing['3'], fieldset: { spacing: primitives.spacing['1'] } },
+    forms: {
+      spacing: primitives.spacing['3'],
+      fieldset: {
+        // Figma's `Components/Fieldset/Spacing`, aliased through
+        // `Breakpoint/Spacing/Small` — 16px at 1024/1440/1920, 12px at
+        // 320/480/768. Was previously a flat, non-responsive 8px
+        // (`primitives.spacing['1']`) that didn't match Figma at all —
+        // corrected as part of #50 (see #70's spacing decision comment).
+        spacing: bpTokens.spacing.sm,
+        // New for #50/#70: `Components/Fieldset/Field-group-spacing`, aliased
+        // through `Breakpoint/Spacing/Medium` — 24px at 1024/1440/1920, 16px
+        // at 320/480/768. Gap between multiple distinct input elements
+        // composed directly inside one Fieldset (e.g. TextField + Select +
+        // DateField) — distinct from the tighter Checkbox/Radio item-to-item
+        // gap, which lives inside those components and is untouched.
+        fieldGroupSpacing: bpTokens.spacing.md,
+        // Figma's Fieldset `.Required` instance sits at x=336, right after the
+        // `.Input label` ending at x=332 — a fixed 4px gap, not per-breakpoint
+        // (same precedent as `labeledIconButton.spacing` above).
+        requiredIndicatorGap: primitives.spacing['0,5'],
+      },
+    },
     icon: {
       size: {
         extraSmall: rem('16px'),
@@ -354,8 +375,7 @@ export function getTheme(bp: BreakpointKey) {
       },
     },
     labeledIconButton: {
-      // Figma Spacing/1 = 8, a fixed constant (not per-breakpoint) — same
-      // precedent as forms.fieldset.spacing above.
+      // Figma Spacing/1 = 8, a fixed constant (not per-breakpoint).
       spacing: primitives.spacing['1'],
     },
     input: {

--- a/src/theme/tokens/theme.ts
+++ b/src/theme/tokens/theme.ts
@@ -333,8 +333,14 @@ export function getTheme(bp: BreakpointKey) {
         fieldGroupSpacing: bpTokens.spacing.md,
         // Figma's Fieldset `.Required` instance sits at x=336, right after the
         // `.Input label` ending at x=332 — a fixed 4px gap, not per-breakpoint
-        // (same precedent as `labeledIconButton.spacing` above).
+        // (same precedent as `labeledIconButton.spacing` below).
         requiredIndicatorGap: primitives.spacing['0,5'],
+        // Figma's `Forms/Selection-items-spacing` (gap between Checkbox/Radio
+        // items grouped under one Fieldset) aliases through the same
+        // `Breakpoint/Spacing/Small` chain as `spacing` above — same values
+        // today, but kept as its own token since the two Figma variables are
+        // independent and could diverge later.
+        selectionItemsSpacing: bpTokens.spacing.sm,
       },
     },
     icon: {


### PR DESCRIPTION
## Summary
- Adds `Fieldset` — wraps Mantine's bare `Fieldset` primitive (`variant="unstyled"` + TREDS classNames), same wrapping pattern as `TextField`→`TextInput` / `Card`→`Paper`
- `legend` (required), `showRequiredMarker?` (decorative `*`), `helperText?`/`error?` (shown together, not replacing, wired via `aria-describedby`), `withBorder?` (default `false`, TREDS's borderless-by-default per Figma #70)
- New responsive tokens under `components.forms.fieldset`: `spacing` (corrected from a wrong flat 8px to the real 16/12 responsive chain), `fieldGroupSpacing` (new, 24/16), `requiredIndicatorGap` (new, 4px), `selectionItemsSpacing` (new, own token separate from `spacing`)
- `fieldsetSelectionGroup` exported for grouping Checkbox/RadioButton items inside a Fieldset
- Doc stories mirror the #70 Figma examples using real TREDS components (Checkbox, RadioButton, TextField, Select, DateField)
- Exported from the component barrel and package entry

## Notes for reviewers
- CSS Fieldset spec gotcha: a flex `<fieldset>`'s `<legend>` sits outside the flex formatting context, so `legend.top === fieldset.top` regardless of padding — verified geometry via `getBoundingClientRect()`, not just computed styles, before trusting the spacing was structurally correct.
- Found the Selection-items-spacing (checkbox/radio item gap) aliases to the *same* Figma variable as the legend→content gap (16/12px) — not the larger field-group gap (24/16px) — given its own token (`selectionItemsSpacing`) since the two Figma variables are independent and could diverge later.
- `radius: 'sharp' | 'pill'` was prototyped then removed — sharp corners only for now, pending more design input.
- Final review round (multi-agent code/test/comment/type review) caught and fixed: a doc-example story importing the private `selectionGroup` CSS class instead of the public `fieldsetSelectionGroup` export, several spacing regression tests using weak ordering assertions instead of pinned token values, and duplicated CSS-quirk/rationale comments.

## Test plan
- [x] `npm test` — 339/339 passing
- [x] `tsc --noEmit` clean
- [x] `npm run eslint` / `npm run prettier:check` clean
- [x] `npm run build` — `Fieldset`/`FieldsetProps`/`fieldsetSelectionGroup` present and clean (no dangling `.css` module reference) in `dist/index.d.ts`
- [x] Visual-checked against the #70 Figma reference in a live Storybook session

Closes #50
