### PR TITLE
feat(#53): add TimeField component

### DIFF
--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,7 +1,8 @@
+import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-// react hooks not required here; story state is managed via Storybook args
 import { useArgs } from '@storybook/client-api';
-import { expect, within } from 'storybook/test';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect } from 'storybook/test';
 import { TextField } from './TextField';
 
 const meta = {
@@ -113,4 +114,26 @@ export const SizeSmall: Story = {
 export const SizeLarge: Story = {
   args: { inputLabel: 'Large', size: 'lg', placeholder: 'Large input' },
   render: (args) => <TextField {...args} />,
+};
+
+export const ForwardsRefToInput: Story = {
+  render: function Render(args) {
+    const ref = useRef<HTMLInputElement>(null);
+    const [tag, setTag] = useState('none');
+    return (
+      <>
+        <TextField {...args} ref={ref} inputLabel="Ref test" />
+        <button type="button" onClick={() => setTag(ref.current?.tagName ?? 'null')}>
+          read ref
+        </button>
+        <span data-testid="ref-tag">{tag}</span>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'read ref' }));
+    // The ref must land on the <input>, not on a wrapper div.
+    await expect(canvas.getByTestId('ref-tag')).toHaveTextContent('INPUT');
+  },
 };

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -117,6 +117,10 @@ export const SizeLarge: Story = {
 };
 
 export const ForwardsRefToInput: Story = {
+  // Test-only: this exercises ref forwarding, not a visual example — keep it
+  // off TextField's public docs page (unlike the rest of this file, whose
+  // stories are all genuine visual examples).
+  tags: ['!dev', '!autodocs'],
   render: function Render(args) {
     const ref = useRef<HTMLInputElement>(null);
     const [tag, setTag] = useState('none');

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,6 +1,6 @@
 import { TextInput, type TextInputProps } from '@mantine/core';
 import cx from 'clsx';
-import { Children, useEffect, useState } from 'react';
+import { Children, forwardRef, useEffect, useState } from 'react';
 import { CloseIcon } from '../../icons/CloseIcon.tsx';
 import { SearchIcon } from '../../icons/SearchIcon.tsx';
 import { mergeClassNames } from '../../utils.ts';
@@ -67,88 +67,96 @@ const InputContainer = ({
 };
 
 /** A text field component with optional search and clear icons. */
-export const TextField = ({
-  inputLabel,
-  helperText,
-  error,
-  disabled,
-  showSearchIcon,
-  showClearButton,
-  clearButtonLabel,
-  endInstance,
-  onChange,
-  onClearButtonClick,
-  classNames,
-  ...props
-}: TextFieldProps) => {
-  const inputStatus = getInputStatus(error, disabled);
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  (
+    {
+      inputLabel,
+      helperText,
+      error,
+      disabled,
+      showSearchIcon,
+      showClearButton,
+      clearButtonLabel,
+      endInstance,
+      onChange,
+      onClearButtonClick,
+      classNames,
+      ...props
+    },
+    ref
+  ) => {
+    const inputStatus = getInputStatus(error, disabled);
 
-  const [textValue, setTextValue] = useState('');
+    const [textValue, setTextValue] = useState('');
 
-  // TextField padding is calculated based on which icons are shown in
-  // right and left sections
-  const hasClearButton = !!showClearButton && textValue.length > 0;
-  const rightIconCount = hasClearButton ? 1 : Children.count(props.rightSection);
-  const hasRightSection = rightIconCount > 0;
-  const hasLeftSection = !!showSearchIcon || !!props.leftSection;
+    // TextField padding is calculated based on which icons are shown in
+    // right and left sections
+    const hasClearButton = !!showClearButton && textValue.length > 0;
+    const rightIconCount = hasClearButton ? 1 : Children.count(props.rightSection);
+    const hasRightSection = rightIconCount > 0;
+    const hasLeftSection = !!showSearchIcon || !!props.leftSection;
 
-  // Dev-only guard: padding is only sized for up to 2 icons (see
-  // `getRightSectionSize`/`rightSectionPadding`)
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'production' && rightIconCount > 2) {
-      console.error(
-        `TextField: \`rightSection\` has ${rightIconCount} icons, but padding is only reserved for up to 2 — text may run underneath.`
-      );
-    }
-  }, [rightIconCount]);
+    // Dev-only guard: padding is only sized for up to 2 icons (see
+    // `getRightSectionSize`/`rightSectionPadding`)
+    useEffect(() => {
+      if (process.env.NODE_ENV !== 'production' && rightIconCount > 2) {
+        console.error(
+          `TextField: \`rightSection\` has ${rightIconCount} icons, but padding is only reserved for up to 2 — text may run underneath.`
+        );
+      }
+    }, [rightIconCount]);
 
-  const defaultClassNames = {
-    section: section,
-    root: root,
-    wrapper: wrapper,
-    input: cx(
-      input[inputStatus],
-      hasLeftSection && leftSectionPadding,
-      hasRightSection && rightSectionPadding[getRightSectionSize(rightIconCount)]
-    ),
-    label: label[inputStatus],
-    description: description[inputStatus],
-    error: cx(errorRoot, errorText),
-  };
+    const defaultClassNames = {
+      section: section,
+      root: root,
+      wrapper: wrapper,
+      input: cx(
+        input[inputStatus],
+        hasLeftSection && leftSectionPadding,
+        hasRightSection && rightSectionPadding[getRightSectionSize(rightIconCount)]
+      ),
+      label: label[inputStatus],
+      description: description[inputStatus],
+      error: cx(errorRoot, errorText),
+    };
 
-  return (
-    <TextInput
-      {...props}
-      onChange={(e) => {
-        onChange?.(e);
-        setTextValue(e.currentTarget.value);
-      }}
-      value={props.value ?? textValue}
-      unstyled
-      classNames={mergeClassNames(defaultClassNames, classNames)}
-      disabled={disabled}
-      label={inputLabel}
-      description={helperText}
-      error={error}
-      inputContainer={(children) => (
-        <InputContainer endInstance={endInstance}>{children}</InputContainer>
-      )}
-      {...(showSearchIcon && { leftSection: <SearchIcon /> })}
-      {...(hasClearButton && {
-        rightSection: (
-          <IconButton
-            aria-label={clearButtonLabel}
-            onClick={() => {
-              setTextValue('');
-              onClearButtonClick?.();
-            }}
-            size={'sm'}
-            variant="default"
-          >
-            <CloseIcon />
-          </IconButton>
-        ),
-      })}
-    />
-  );
-};
+    return (
+      <TextInput
+        {...props}
+        ref={ref}
+        onChange={(e) => {
+          onChange?.(e);
+          setTextValue(e.currentTarget.value);
+        }}
+        value={props.value ?? textValue}
+        unstyled
+        classNames={mergeClassNames(defaultClassNames, classNames)}
+        disabled={disabled}
+        label={inputLabel}
+        description={helperText}
+        error={error}
+        inputContainer={(children) => (
+          <InputContainer endInstance={endInstance}>{children}</InputContainer>
+        )}
+        {...(showSearchIcon && { leftSection: <SearchIcon /> })}
+        {...(hasClearButton && {
+          rightSection: (
+            <IconButton
+              aria-label={clearButtonLabel}
+              onClick={() => {
+                setTextValue('');
+                onClearButtonClick?.();
+              }}
+              size={'sm'}
+              variant="default"
+            >
+              <CloseIcon />
+            </IconButton>
+          ),
+        })}
+      />
+    );
+  }
+);
+
+TextField.displayName = 'TextField';

--- a/src/components/TimeField/TimeField.css.ts
+++ b/src/components/TimeField/TimeField.css.ts
@@ -25,18 +25,24 @@ export const timeInput = style({
     '&::-webkit-clear-button': { display: 'none' },
     '&::-webkit-inner-spin-button': { display: 'none' },
     // The segment editor is a shadow-DOM widget that does not inherit the
-    // input's font, so the input type scale has to be restated on it.
+    // input's font, so the input type scale has to be restated on it. Filled
+    // segments (and the `:` separator between them) inherit this text.primary
+    // colour from here — there is no separate rule for them below.
     '&::-webkit-datetime-edit': {
       fontSize: inputVars.font.text.fontSize,
       lineHeight: inputVars.font.text.lineHeight,
       color: text.primary,
     },
-    // Unfilled segments render as `--`; match the placeholder colour
-    // TextField.css.ts uses for `::placeholder`.
-    '&::-webkit-datetime-edit-hour-field:not([aria-valuenow])': { color: text.secondary },
-    '&::-webkit-datetime-edit-minute-field:not([aria-valuenow])': { color: text.secondary },
-    '&::-webkit-datetime-edit-text': { color: text.secondary },
+    // When every segment is still unfilled (`--:--`), colour the whole edit
+    // region — segments and the `:` separator alike — in the placeholder
+    // colour TextField.css.ts uses for `::placeholder`. `data-empty` is set by
+    // TimeField.tsx from component state: Chromium's `-webkit-datetime-edit-*`
+    // pseudo-elements are UA-shadow constructs that do not support
+    // `:not([attr])` matching (confirmed empirically — a prior version of
+    // this rule used `:not([aria-valuenow])` and never matched, filled or
+    // not), so the browser's own per-segment fill state can't be selected
+    // from CSS directly.
+    '&[data-empty="true"]::-webkit-datetime-edit': { color: text.secondary },
     '&:disabled::-webkit-datetime-edit': { color: text.disabled },
-    '&:disabled::-webkit-datetime-edit-text': { color: text.disabled },
   },
 });

--- a/src/components/TimeField/TimeField.css.ts
+++ b/src/components/TimeField/TimeField.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../theme';
+
+const {
+  theme: {
+    text,
+    components: { input: inputVars, button: buttonVars },
+  },
+} = vars;
+
+// The trigger icon scales with the responsive control size, exactly as
+// DateField's calendar icon does (Figma Components/Button/Icon/Size).
+export const triggerIcon = style({
+  width: buttonVars.lineHeight,
+  height: 'auto',
+});
+
+export const timeInput = style({
+  selectors: {
+    // Figma places the clock control outside the field as a separate Button, so
+    // the browser's in-field indicator (and any native clear affordance beside
+    // it) must be suppressed — otherwise the field shows two clock icons and
+    // two ✕ controls.
+    '&::-webkit-calendar-picker-indicator': { display: 'none' },
+    '&::-webkit-clear-button': { display: 'none' },
+    '&::-webkit-inner-spin-button': { display: 'none' },
+    // The segment editor is a shadow-DOM widget that does not inherit the
+    // input's font, so the input type scale has to be restated on it.
+    '&::-webkit-datetime-edit': {
+      fontSize: inputVars.font.text.fontSize,
+      lineHeight: inputVars.font.text.lineHeight,
+      color: text.primary,
+    },
+    // Unfilled segments render as `--`; match the placeholder colour
+    // TextField.css.ts uses for `::placeholder`.
+    '&::-webkit-datetime-edit-hour-field:not([aria-valuenow])': { color: text.secondary },
+    '&::-webkit-datetime-edit-minute-field:not([aria-valuenow])': { color: text.secondary },
+    '&::-webkit-datetime-edit-text': { color: text.secondary },
+    '&:disabled::-webkit-datetime-edit': { color: text.disabled },
+    '&:disabled::-webkit-datetime-edit-text': { color: text.disabled },
+  },
+});

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -320,9 +320,10 @@ export const StepIsClampedToWholeMinutes: Story = {
     // A sub-60 step would make the browser render a seconds segment; the
     // component clamps it to a whole minute so only hh:mm segments exist.
     await expect(input).toHaveAttribute('step', '60');
-    // The invalid sub-60 step also fires a dev-only warning.
+    // The invalid sub-60 step also fires a dev-only warning naming both the
+    // value that was passed and the value actually used.
     await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => /step.*must be at least 60/i.test(m))).toBe(true)
+      expect(capturedConsoleErrors.some((m) => m.includes('got 5, using 60'))).toBe(true)
     );
     // With the browser only ever seeing the clamped step, a normal
     // minute-granularity entry must not be flagged as a step mismatch.
@@ -330,5 +331,132 @@ export const StepIsClampedToWholeMinutes: Story = {
     await expect(
       canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
     ).not.toBeInTheDocument();
+  },
+};
+
+// A step that IS >= 60 but isn't a multiple of it (e.g. 90s = 1.5min) would
+// otherwise slip through a floor-only clamp unchanged, breaking the same
+// "no seconds segment" contract as a sub-60 step: 90 rounds to 120, not 60.
+export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
+  args: { step: 90 },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    // 90s rounds to the nearer of 60/120 by whole minutes, i.e. 120.
+    await expect(input).toHaveAttribute('step', '120');
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => m.includes('got 90, using 120'))).toBe(true)
+    );
+  },
+};
+
+// With the clamp rounding to a whole-minute multiple, `stepMismatch` becomes
+// reachable (and meaningful) for a legitimate granularity like 15 minutes —
+// the booking-flow case the plan calls out. This is the only story in this
+// file that actually drives `stepMismatch` true/false, as distinct from the
+// two stories above, which only check the clamped `step` attribute and the
+// dev warning — they never assert on validity itself.
+//
+// `min` is required here, not incidental: empirically (verified against the
+// real Chromium instance this suite runs in, not by reading the spec),
+// Chromium only evaluates `stepMismatch` for a time input once a `min` is
+// present to anchor the step base — omitting `min` here, `0905` and `0915`
+// were both accepted with `stepMismatch: false` regardless of `step`. This
+// is worth knowing: a consumer who sets `step` without `min` gets no
+// off-grid enforcement at all.
+export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
+  args: { step: 900, min: '00:00' }, // 15 minutes; already a whole-minute multiple, so no dev warning.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('step', '900');
+    // On the 15-minute grid (00, 15, 30, 45) — no error.
+    await userEvent.type(input, '0915');
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    // Off the grid by 5 minutes — `stepMismatch` fires.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0905');
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    // Back on the grid — clears again.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0930');
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      ).not.toBeInTheDocument()
+    );
+  },
+};
+
+// Controlled: the parent resets `value` programmatically (a button click, not
+// typing or blurring the input itself) — the stale range error must clear
+// purely from the value becoming valid again, proving validation is driven
+// by an effect over `currentValue` rather than only by the input's own
+// change/blur events.
+export const RangeErrorClearsOnProgrammaticValueReset: Story = {
+  args: { min: '08:00', max: '17:00' },
+  render: function Render(args) {
+    const [value, setValue] = useState('06:00');
+    return (
+      <>
+        <TimeField {...args} value={value} onChange={setValue} />
+        <button onClick={() => setValue('09:00')}>Set to 09:00</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The field mounts already out of range — the error must show without
+    // any user interaction with the input at all.
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    await userEvent.click(canvas.getByText('Set to 09:00'));
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      ).not.toBeInTheDocument()
+    );
+  },
+};
+
+// Changing `min`/`max` themselves — not the value — must re-evaluate the
+// already-displayed value against the new bounds.
+export const RangeErrorFollowsMinMaxChanges: Story = {
+  render: function Render(args) {
+    const [min, setMin] = useState('08:00');
+    return (
+      <>
+        <TimeField {...args} min={min} max="17:00" defaultValue="09:00" />
+        <button onClick={() => setMin('10:00')}>Raise min to 10:00</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // 09:00 is within the initial [08:00, 17:00].
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    // Raising `min` past the already-displayed value flags it — no
+    // interaction with the input itself.
+    await userEvent.click(canvas.getByText('Raise min to 10:00'));
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -176,16 +176,67 @@ export const ClearButtonEmptiesTheField: Story = {
   args: { defaultValue: '09:30', onChange: fn() },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
     await userEvent.click(canvas.getByRole('button', { name: 'Tyhjennä kellonaika' }));
-    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveValue('');
+    await expect(input).toHaveValue('');
     await expect(args.onChange).toHaveBeenLastCalledWith('');
+    // Task 3's empty-segment placeholder mechanism keys off this attribute —
+    // clearing must flip it back to 'true', the same as a manually emptied field.
+    await expect(input).toHaveAttribute('data-empty', 'true');
   },
 };
 
-export const ClearButtonOnlyWhenPopulatedAndEnabled: Story = {
+// Mirrors DateField.stories.tsx's ClearButtonClearsValue: every other clear story
+// here uses defaultValue (uncontrolled), which collapses the distinction between
+// `currentValue`/`showClear` reading `internalValue` vs. the controlled-aware
+// value — a regression there would pass all of them. This one proves the clear
+// button also works, and drives the *parent's* state, in controlled mode.
+export const ClearButtonClearsControlledValue: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('09:30');
+    return (
+      <>
+        <TimeField {...args} value={value} onChange={setValue} />
+        <span data-testid="echo">{value}</span>
+      </>
+    );
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Empty field: nothing to clear.
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveValue('09:30');
+    await userEvent.click(canvas.getByRole('button', { name: 'Tyhjennä kellonaika' }));
+    await expect(input).toHaveValue('');
+    // The parent's state, not internal state, must have emptied — toHaveTextContent('')
+    // would pass vacuously (empty string is a substring match), so compare textContent directly.
+    await expect(canvas.getByTestId('echo').textContent).toBe('');
+    // The ✕ is removed once the field is empty; focus moves to the trigger so it
+    // isn't lost to <body> when the button it sat on disappears.
+    await expect(
+      canvas.queryByRole('button', { name: 'Tyhjennä kellonaika' })
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' })).toHaveFocus()
+    );
+  },
+};
+
+export const ClearButtonHiddenWhenEmpty: Story = {
+  // Nothing to clear on an empty field, so the ✕ must not be present.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole('button', { name: 'Tyhjennä kellonaika' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const ClearButtonHiddenWhenDisabled: Story = {
+  // A disabled field can't be edited, so the clear affordance is suppressed even
+  // though there is a value present.
+  args: { disabled: true, defaultValue: '09:30' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
     await expect(
       canvas.queryByRole('button', { name: 'Tyhjennä kellonaika' })
     ).not.toBeInTheDocument();

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, userEvent, waitFor } from '@storybook/testing-library';
-import { userEvent as browserUserEvent } from '@vitest/browser/context';
+import { userEvent as browserUserEvent } from 'vitest/browser';
 import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
 import { timeInput } from './TimeField.css';
@@ -610,14 +610,24 @@ export const RangeErrorFollowsMinMaxChanges: Story = {
 // - `@storybook/testing-library`'s `userEvent` is inert for reaching this
 //   native input's `badInput` state at all (typing '09' never flips
 //   `validity.badInput`), so these four stories use the Playwright-backed
-//   driver from `@vitest/browser/context` instead.
+//   driver from `vitest/browser` instead.
 // - Even with that driver, `userEvent.tab()` does NOT blur the field: a
 //   multi-segment time input treats Tab as moving between its internal
 //   hour/minute segments (confirmed via `document.activeElement` staying on
 //   the input after `.tab()`), not as leaving the control. A click on a
 //   different focusable element is used instead to actually trigger blur.
-const blurTimeInput = (canvas: ReturnType<typeof within>) =>
-  browserUserEvent.click(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' }));
+//
+// That element is the picker-trigger button, whose `onClick` calls
+// `input.showPicker()` — real OS-level chrome Playwright cannot see into
+// (see `TriggerOpensNativePicker`/`TriggerFallsBackToFocus` above, which
+// stub it for the same reason). Stub it here too so the click still moves
+// focus for real without depending on whatever headless Chromium does with
+// an unmocked `showPicker()` call.
+const blurTimeInput = (canvas: ReturnType<typeof within>) => {
+  const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
+  Object.defineProperty(input, 'showPicker', { value: () => {}, configurable: true });
+  return browserUserEvent.click(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' }));
+};
 
 export const IncompleteEntryShowsError: Story = {
   args: { onChange: fn() },
@@ -672,16 +682,37 @@ export const CompletingTheTimeClearsIncompleteError: Story = {
   },
 };
 
-// A consumer-supplied error still outranks the internal incomplete message.
+// A consumer-supplied error still outranks the internal incomplete message —
+// and, distinctly, `incomplete` is still genuinely computed underneath it
+// rather than never evaluated at all. `error` is toggleable via a button
+// rather than a fixed arg so the story can prove both halves: with `error` a
+// naive/absent `incomplete` computation would pass this identically (the
+// consumer error masks it either way), but once `error` is cleared, the
+// incomplete message must appear — which only happens if `revalidate` really
+// set `validity.incomplete` while `error` was still masking it.
 export const ConsumerErrorWinsOverIncompleteError: Story = {
-  args: { error: 'Varaus on jo täynnä' },
+  render: function Render(args) {
+    const [error, setError] = useState<string | undefined>('Varaus on jo täynnä');
+    return (
+      <>
+        <TimeField {...args} error={error} />
+        <button onClick={() => setError(undefined)}>Clear consumer error</button>
+      </>
+    );
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await browserUserEvent.type(canvas.getByLabelText('Valitse kellonaika'), '09');
     await blurTimeInput(canvas);
+    // Both are live: the consumer error wins.
     await expect(canvas.getByText('Varaus on jo täynnä')).toBeVisible();
     await expect(
       canvas.queryByText('Anna kellonaika muodossa tunnit:minuutit')
     ).not.toBeInTheDocument();
+    // Clearing the consumer error reveals the incomplete message underneath.
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear consumer error' }));
+    await waitFor(() =>
+      expect(canvas.getByText('Anna kellonaika muodossa tunnit:minuutit')).toBeVisible()
+    );
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -140,6 +140,30 @@ export const IsANativeTimeInput: Story = {
   },
 };
 
+export const AccessibleNameViaAriaLabel: Story = {
+  // With no visible label, an aria-label must give the input an accessible name.
+  args: { inputLabel: undefined, 'aria-label': 'Kellonaika' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Kellonaika');
+    await expect(input).toHaveAccessibleName('Kellonaika');
+  },
+};
+
+// When both `inputLabel` and `aria-label` are supplied, the visible label must
+// win the accessible-name computation — forwarding `aria-label` unconditionally
+// would let it silently override the visible label's text (WCAG 2.5.3 Label in
+// Name), breaking voice-control activation by the visible label's wording.
+export const VisibleLabelWinsOverAriaLabel: Story = {
+  args: { 'aria-label': 'Should not win' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAccessibleName('Valitse kellonaika');
+    await expect(input).not.toHaveAccessibleName('Should not win');
+  },
+};
+
 export const WarnsWithoutAccessibleName: Story = {
   // With neither inputLabel nor aria-label/aria-labelledby, the component must
   // warn the developer in dev (the input would otherwise be unnamed).

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -4,6 +4,7 @@ import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
 import { timeInput } from './TimeField.css';
+import { DateField } from '../DateField';
 
 const meta = {
   component: TimeField,
@@ -15,6 +16,17 @@ const meta = {
     inputLabel: 'Valitse kellonaika',
     pickerButtonLabel: 'Avaa kellonaikavalitsin',
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Aikakenttä käyttää selaimen omaa kellonaikavalitsinta. Huomaa: `<input type="time">` ' +
+          'näyttää kellonajan katsojan käyttöjärjestelmän kieliasetuksen mukaan, joten esimerkiksi ' +
+          'en-US-asetuksella kenttä näyttää muodon `09:30 AM`. Luettu ja kirjoitettu arvo on aina ' +
+          '24 tunnin `HH:mm` riippumatta näyttömuodosta.',
+      },
+    },
+  },
 } satisfies Meta<typeof TimeField>;
 
 export default meta;
@@ -25,6 +37,64 @@ const docExample = ['dev', 'autodocs'];
 let capturedConsoleErrors: string[] = [];
 
 export const Default: Story = { tags: docExample };
+
+export const WithValue: Story = {
+  tags: docExample,
+  args: { defaultValue: '09:30' },
+};
+
+export const WithHelperText: Story = {
+  tags: docExample,
+  args: { helperText: 'Muoto: tunnit:minuutit' },
+};
+
+export const WithError: Story = {
+  tags: docExample,
+  args: { error: 'Kellonaika on virheellinen', defaultValue: '09:30' },
+};
+
+export const WithMinMax: Story = {
+  tags: docExample,
+  args: { min: '08:00', max: '17:00', defaultValue: '09:30', helperText: 'Valittavissa 8–17' },
+};
+
+// Shows how DateField and TimeField compose: TimeField returns a plain "HH:mm"
+// string while DateField returns a Date, so a consumer combining them into a
+// single timestamp does so themselves — see the description below.
+export const BookingFlow: Story = {
+  tags: docExample,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`TimeField` palauttaa arvon merkkijonona muodossa `"HH:mm"`, kun taas `DateField` ' +
+          'palauttaa `Date`-olion. Komponentit eivät yhdistä arvojaan automaattisesti — kuluttaja ' +
+          'tekee sen itse, esimerkiksi: ' +
+          '`dayjs(date).hour(+time.slice(0, 2)).minute(+time.slice(3))`.',
+      },
+    },
+  },
+  render: function Render(args) {
+    const [date, setDate] = useState<Date | null>(null);
+    const [time, setTime] = useState('');
+    return (
+      // flexWrap prevents the pairing from overflowing the viewport at narrow
+      // widths (e.g. the 320px check in the brief) — the brief's sample style
+      // omitted it, but the two fields together don't fit a 320px canvas.
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
+        <DateField
+          label="Valitse päivämäärä"
+          calendarButtonLabel="Avaa kalenteri"
+          prevMonthLabel="Edellinen kuukausi"
+          nextMonthLabel="Seuraava kuukausi"
+          value={date}
+          onChange={setDate}
+        />
+        <TimeField {...args} value={time} onChange={setTime} />
+      </div>
+    );
+  },
+};
 
 export const Uncontrolled: Story = {
   args: { defaultValue: '09:30', onChange: fn() },

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -358,6 +358,29 @@ export const ClearMovesFocusToTrigger: Story = {
   },
 };
 
+// The other side of ClearButtonClearsControlledValue: a controlled consumer that
+// ignores `onChange` keeps the value, so the ✕ stays and the clear did nothing
+// visible. Moving focus to the trigger anyway would be the visible half of an
+// action that had no effect — and unlike the uncontrolled case, there is no
+// re-render to notice, so the component has to check the value itself.
+export const IgnoredControlledClearLeavesFocusAlone: Story = {
+  args: { value: '09:30', onChange: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const clearButton = canvas.getByRole('button', { name: 'Tyhjennä kellonaika' });
+    await userEvent.click(clearButton);
+    await expect(args.onChange).toHaveBeenLastCalledWith('');
+    // The parent ignored the call, so the value — and with it the ✕ — is unchanged.
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveValue('09:30');
+    await expect(clearButton).toBeInTheDocument();
+    // Give an (incorrect) deferred focus move a chance to happen, then assert
+    // that focus is still on the ✕ the user actually clicked.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await expect(clearButton).toHaveFocus();
+    await expect(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' })).not.toHaveFocus();
+  },
+};
+
 // Controlled (not uncontrolled): also proves the
 // out-of-range value is still committed up to the parent — TimeField flags
 // it rather than blocking entry, matching how the native input itself never

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -920,3 +920,66 @@ export const KeyboardArrowsDecrementByStep: Story = {
     await expect(input).toHaveValue('10:00');
   },
 };
+
+// Without `name` the field contributes nothing to a native form submission,
+// and the closed prop set leaves no way to reach the input from outside.
+export const SubmitsUnderItsName: Story = {
+  args: { name: 'appointmentTime', defaultValue: '09:30' },
+  render: function Render(args) {
+    const [submitted, setSubmitted] = useState('');
+    return (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSubmitted(String(new FormData(event.currentTarget).get('appointmentTime')));
+        }}
+      >
+        <TimeField {...args} />
+        <button type="submit">Lähetä</button>
+        <span data-testid="submitted">{submitted}</span>
+      </form>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveAttribute(
+      'name',
+      'appointmentTime'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Lähetä' }));
+    await waitFor(() => expect(canvas.getByTestId('submitted').textContent).toBe('09:30'));
+  },
+};
+
+// A consumer `onBlur` must run without displacing the internal revalidation
+// that the incomplete-entry check depends on.
+//
+// Uses `browserUserEvent`/`blurTimeInput` rather than the brief's plain
+// `userEvent.type` + `.tab()`: per the comment above `blurTimeInput`, the
+// `@storybook/testing-library` driver is inert for reaching `badInput` on
+// this native input, and `.tab()` moves between the input's own hour/minute
+// segments instead of leaving the control — same empirical constraints
+// IncompleteEntryShowsError et al. already work around.
+export const ConsumerBlurRunsAlongsideRevalidation: Story = {
+  args: { onBlur: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await browserUserEvent.type(input, '09'); // incomplete on purpose
+    await blurTimeInput(canvas);
+    await expect(args.onBlur).toHaveBeenCalledTimes(1);
+    // The internal revalidation still ran: the incomplete error is showing.
+    await waitFor(() =>
+      expect(canvas.getByText('Anna kellonaika muodossa tunnit:minuutit')).toBeVisible()
+    );
+  },
+};
+
+// An explicit `id` must reach the input so an external <label> can target it.
+export const AcceptsAnExplicitId: Story = {
+  args: { id: 'booking-time', label: undefined, 'aria-label': 'Kellonaika' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Kellonaika')).toHaveAttribute('id', 'booking-time');
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect, fn } from 'storybook/test';
+import { TimeField } from './TimeField';
+
+const meta = {
+  component: TimeField,
+  // Same curation as DateField: stories are browser test specs by default —
+  // still run by the vitest addon, but hidden from the sidebar (`!dev`) and the
+  // autodocs page (`!autodocs`). Documentation examples opt back in via `docExample`.
+  tags: ['!dev', '!autodocs'],
+  args: {
+    inputLabel: 'Valitse kellonaika',
+  },
+} satisfies Meta<typeof TimeField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const docExample = ['dev', 'autodocs'];
+
+export const Default: Story = { tags: docExample };
+
+export const Uncontrolled: Story = {
+  args: { defaultValue: '09:30', onChange: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveValue('09:30');
+    // fireEvent-free: typing into a time input targets the focused segment.
+    await userEvent.clear(input);
+    await userEvent.type(input, '1045');
+    await expect(input).toHaveValue('10:45');
+    await expect(args.onChange).toHaveBeenLastCalledWith('10:45');
+  },
+};
+
+export const Controlled: Story = {
+  render: function Render(args) {
+    const [value, setValue] = useState('08:00');
+    return (
+      <>
+        <TimeField {...args} value={value} onChange={setValue} />
+        <span data-testid="echo">{value}</span>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveValue('08:00');
+    await userEvent.clear(input);
+    await userEvent.type(input, '1115');
+    // The parent's state, not internal state, drives the displayed value.
+    await expect(canvas.getByTestId('echo')).toHaveTextContent('11:15');
+  },
+};
+
+export const IsANativeTimeInput: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The native input is what supplies keyboard increments and spinbutton
+    // semantics — if this regresses to type="text" the whole design is void.
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveAttribute('type', 'time');
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -749,6 +749,78 @@ export const MaxBoundaryIsInclusive: Story = {
   },
 };
 
+// A swapped pair leaves the browser with no satisfiable window — every value is
+// either below `min` or above `max`, so the field rejects everything, including
+// the window the consumer meant, with nothing pointing at the swapped props.
+// Order the bounds instead (same normalisation as DateField.tsx) and warn.
+export const SwappedMinMaxIsNormalised: Story = {
+  args: { min: '17:00', max: '08:00', defaultValue: '09:30' },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('min', '08:00');
+    await expect(input).toHaveAttribute('max', '17:00');
+    // 09:30 is inside the window the consumer meant, so it must not be flagged.
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    // The normalised window is still enforced — dropping both bounds would also
+    // clear the error above, so this is what distinguishes the two fixes.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0700');
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    await expect(capturedConsoleErrors.some((m) => m.includes('is after `max`'))).toBe(true);
+  },
+};
+
+// The normalisation compares strings, which is only a time comparison for
+// well-formed "HH:mm". The malformed `max` here is a truncated "08:0", which
+// does sort below a valid "09:00" — so an unguarded comparison would swap the
+// pair, inventing a 09:00 upper bound the consumer never set and throwing away
+// the lower bound they did set (the browser ignores the unparseable one). Note
+// that a merely non-padded bound like "1:00" would not reach this: it sorts
+// *above* "09:00", since '1' > '0'. Bounds it can't parse are left alone.
+export const MalformedBoundIsNotSwapped: Story = {
+  args: { min: '09:00', max: '08:0', defaultValue: '10:00' },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('min', '09:00');
+    await expect(input).toHaveAttribute('max', '08:0');
+    // 10:00 is above the real `min` and the malformed `max` is ignored by the
+    // browser, so nothing is out of range; a bogus swap would flag it.
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => m.includes('`max` must be "HH:mm"'))).toBe(true)
+    );
+    await expect(capturedConsoleErrors.some((m) => m.includes('is after `max`'))).toBe(false);
+  },
+};
+
 // Mirror of RangeErrorFollowsMinMaxChanges, which only ever raises `min`.
 export const RangeErrorFollowsMaxChanges: Story = {
   render: function Render(args) {

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -405,8 +405,12 @@ export const ConsumerErrorWinsOverRangeError: Story = {
   },
 };
 
-export const StepIsClampedToWholeMinutes: Story = {
-  args: { step: 5 },
+// `stepMinutes` is in minutes, so the DOM attribute is always 60x the prop —
+// this is the story that pins the unit conversion. Zero (or any value below a
+// minute) would mean "no granularity at all" to the browser, so it clamps to
+// one minute and says so.
+export const StepMinutesBelowOneIsClampedToOneMinute: Story = {
+  args: { stepMinutes: 0 },
   beforeEach: () => {
     capturedConsoleErrors = [];
     const original = console.error;
@@ -420,28 +424,19 @@ export const StepIsClampedToWholeMinutes: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
-    // A sub-60 step would make the browser render a seconds segment; the
-    // component clamps it to a whole minute so only hh:mm segments exist.
     await expect(input).toHaveAttribute('step', '60');
-    // The invalid sub-60 step also fires a dev-only warning naming both the
-    // value that was passed and the value actually used.
+    // The dev-only warning names both the value that was passed and the value
+    // actually used, in the prop's own unit.
     await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => m.includes('got 5, using 60'))).toBe(true)
+      expect(capturedConsoleErrors.some((m) => m.includes('got 0, using 1'))).toBe(true)
     );
-    // With the browser only ever seeing the clamped step, a normal
-    // minute-granularity entry must not be flagged as a step mismatch.
-    await userEvent.type(input, '0930');
-    await expect(
-      canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
-    ).not.toBeInTheDocument();
   },
 };
 
-// A step that IS >= 60 but isn't a multiple of it (e.g. 90s = 1.5min) would
-// otherwise slip through a floor-only clamp unchanged, breaking the same
-// "no seconds segment" contract as a sub-60 step: 90 rounds to 120, not 60.
-export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
-  args: { step: 90 },
+// A fractional step would make the browser render a seconds segment, which this
+// component does not support: 1.5 minutes rounds to 2 (=120s), not down to 1.
+export const FractionalStepMinutesRoundsToAWholeMinute: Story = {
+  args: { stepMinutes: 1.5 },
   beforeEach: () => {
     capturedConsoleErrors = [];
     const original = console.error;
@@ -455,20 +450,68 @@ export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
-    // 90s rounds to the nearer of 60/120 by whole minutes, i.e. 120.
     await expect(input).toHaveAttribute('step', '120');
     await waitFor(() =>
-      expect(capturedConsoleErrors.some((m) => m.includes('got 90, using 120'))).toBe(true)
+      expect(capturedConsoleErrors.some((m) => m.includes('got 1.5, using 2'))).toBe(true)
     );
   },
 };
 
-// With the clamp rounding to a whole-minute multiple, `stepMismatch` becomes
-// reachable (and meaningful) for a legitimate granularity like 15 minutes —
-// the booking-flow case #53 calls out. This is the only story in this
-// file that actually drives `stepMismatch` true/false, as distinct from the
-// two stories above, which only check the clamped `step` attribute and the
-// dev warning — they never assert on validity itself. It expects the
+// `Math.round(NaN)` is NaN and `Math.max(1, NaN)` is NaN, so without the
+// `Number.isFinite` guard this put `step="NaN"` in the DOM and warned the
+// self-contradictory "got NaN, using NaN".
+export const NaNStepMinutesFallsBackToOneMinute: Story = {
+  args: { stepMinutes: NaN },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('step', '60');
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => m.includes('got NaN, using 1'))).toBe(true)
+    );
+  },
+};
+
+// The other half of the same guard, and the one that used to fail silently:
+// Infinity survived `Math.max`/`Math.round` unchanged, so it compared equal to
+// itself and produced no warning at all on its way into the DOM.
+export const InfiniteStepMinutesFallsBackToOneMinute: Story = {
+  args: { stepMinutes: Infinity },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('step', '60');
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => m.includes('got Infinity, using 1'))).toBe(true)
+    );
+  },
+};
+
+// `stepMismatch` is reachable (and meaningful) for a legitimate granularity
+// like 15 minutes — the booking-flow case #53 calls out. This is the only story
+// in this file that actually drives `stepMismatch` true/false, as distinct from
+// the four clamping stories above, which only check the emitted `step` attribute
+// and the dev warning — they never assert on validity itself. It expects the
 // `stepMismatch`-specific message, not the range one, since every value here
 // stays inside [00:00, ∞) — only the grid is ever at issue.
 //
@@ -479,7 +522,7 @@ export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
 // a regression that special-cased the default instead of just filling the
 // same `min` prop.
 export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
-  args: { step: 900, min: '00:00' }, // 15 minutes; already a whole-minute multiple, so no dev warning.
+  args: { stepMinutes: 15, min: '00:00' }, // Already a whole number of minutes, so no dev warning.
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
@@ -509,7 +552,7 @@ export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
 // An off-grid time inside [min, max] is not "outside the allowed range" — it is
 // the wrong granularity, and the message has to say which (WCAG 3.3.3).
 export const StepMismatchHasItsOwnMessage: Story = {
-  args: { min: '08:00', max: '17:00', step: 900 },
+  args: { min: '08:00', max: '17:00', stepMinutes: 15 },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
@@ -536,11 +579,11 @@ export const StepMismatchHasItsOwnMessage: Story = {
 // would be flagged even without the default. The story that fails when the
 // default is removed is OffGridControlledValueIsFlaggedAtMount.
 export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
-  args: { step: 900 }, // 15 minutes, no explicit `min`.
+  args: { stepMinutes: 15 }, // No explicit `min`.
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
-    // The component filled in the '00:00' default so `step` actually bites.
+    // The component filled in the '00:00' default so the step grid actually bites.
     await expect(input).toHaveAttribute('min', '00:00');
     await userEvent.type(input, '0905'); // 5 minutes off the 15-minute grid.
     await waitFor(() =>
@@ -558,7 +601,7 @@ export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
 // red, which StepAloneEnforcesGranularityViaDefaultMin does not (it only
 // asserts the attribute is there, not that it is doing anything).
 export const OffGridControlledValueIsFlaggedAtMount: Story = {
-  args: { value: '09:05', step: 900, onChange: fn() },
+  args: { value: '09:05', stepMinutes: 15, onChange: fn() },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // No typing, no clicking — the value came straight from the prop.
@@ -575,7 +618,7 @@ export const OffGridControlledValueIsFlaggedAtMount: Story = {
 // Checked against both messages now that they've split, since either flag
 // firing would be a regression this story exists to catch.
 export const DefaultMinDoesNotFlagMidnightItself: Story = {
-  args: { step: 900 },
+  args: { stepMinutes: 15 },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika');
@@ -590,8 +633,8 @@ export const DefaultMinDoesNotFlagMidnightItself: Story = {
   },
 };
 
-// The default is purely a side effect of `step` — a field that never sets
-// `step` must not gain an implicit `min` it never asked for.
+// The default is purely a side effect of `stepMinutes` — a field that never sets
+// it must not gain an implicit `min` it never asked for.
 export const NoStepMeansNoImplicitMin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -878,7 +921,7 @@ export const WarnsOnMalformedTimeStrings: Story = {
 // The guard must stay quiet for well-formed values, including the empty string,
 // or it would cry wolf on every correctly-used field.
 export const DoesNotWarnOnWellFormedTimeStrings: Story = {
-  args: { value: '', min: '00:00', max: '23:59', step: 900, onChange: fn() },
+  args: { value: '', min: '00:00', max: '23:59', stepMinutes: 15, onChange: fn() },
   beforeEach: () => {
     capturedConsoleErrors = [];
     const original = console.error;
@@ -895,10 +938,10 @@ export const DoesNotWarnOnWellFormedTimeStrings: Story = {
 };
 
 // Issue #53 requires keyboard increments. The native input provides them, but
-// nothing asserted it — and the arrows are also the only place the `step` grid
-// is observable as *behaviour* rather than as an attribute.
+// nothing asserted it — and the arrows are also the only place the `stepMinutes`
+// grid is observable as *behaviour* rather than as an attribute.
 export const KeyboardArrowsIncrementByStep: Story = {
-  args: { defaultValue: '09:00', step: 900, onChange: fn() },
+  args: { defaultValue: '09:00', stepMinutes: 15, onChange: fn() },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
@@ -907,7 +950,7 @@ export const KeyboardArrowsIncrementByStep: Story = {
     await browserUserEvent.keyboard('{ArrowUp}');
     await expect(input).toHaveValue('10:00');
     await expect(args.onChange).toHaveBeenLastCalledWith('10:00');
-    // Move to the minute segment: ArrowUp there steps by `step`, not by 1.
+    // Move to the minute segment: ArrowUp there steps by `stepMinutes`, not by 1.
     await browserUserEvent.keyboard('{ArrowRight}{ArrowUp}');
     await expect(input).toHaveValue('10:15');
     await expect(args.onChange).toHaveBeenLastCalledWith('10:15');
@@ -920,7 +963,7 @@ export const KeyboardArrowsIncrementByStep: Story = {
 
 // ArrowDown must step back down and stay on the grid.
 export const KeyboardArrowsDecrementByStep: Story = {
-  args: { defaultValue: '10:15', step: 900, onChange: fn() },
+  args: { defaultValue: '10:15', stepMinutes: 15, onChange: fn() },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -525,11 +525,9 @@ export const StepMismatchHasItsOwnMessage: Story = {
   },
 };
 
-// Chromium never evaluates `stepMismatch` on a time input without a `min`
-// present (see the empirical finding documented above). Without the
-// component defaulting `min` to '00:00' whenever `step` is supplied and no
-// `min` was given, this story's off-grid value would be silently accepted —
-// this is the exact behaviour gap the default exists to close.
+// This story asserts the '00:00' default is applied; it types its value, so it
+// would be flagged even without the default. The story that fails when the
+// default is removed is OffGridControlledValueIsFlaggedAtMount.
 export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
   args: { step: 900 }, // 15 minutes, no explicit `min`.
   play: async ({ canvasElement }) => {
@@ -538,6 +536,23 @@ export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
     // The component filled in the '00:00' default so `step` actually bites.
     await expect(input).toHaveAttribute('min', '00:00');
     await userEvent.type(input, '0905'); // 5 minutes off the 15-minute grid.
+    await waitFor(() =>
+      expect(canvas.getByText('Valitse kellonaika sallitulla tarkkuudella')).toBeVisible()
+    );
+  },
+};
+
+// The counterfactual for the `min: '00:00'` default. A controlled field mounted
+// with an off-grid value and no user interaction is the ONE case where Chromium
+// won't evaluate `stepMismatch` without a `min` present — measured: no `min` →
+// false, `min="00:00"` → true. Deleting `effectiveMin` makes this story red,
+// which StepAloneEnforcesGranularityViaDefaultMin does not (it only asserts the
+// attribute is there, not that it is doing anything).
+export const OffGridControlledValueIsFlaggedAtMount: Story = {
+  args: { value: '09:05', step: 900, onChange: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // No typing, no clicking — the value came straight from the prop.
     await waitFor(() =>
       expect(canvas.getByText('Valitse kellonaika sallitulla tarkkuudella')).toBeVisible()
     );

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -137,6 +137,7 @@ export const IsANativeTimeInput: Story = {
     const canvas = within(canvasElement);
     // The native input is what supplies keyboard increments and spinbutton
     // semantics — if this regresses to type="text" the whole design is void.
+    // The increments themselves are asserted in KeyboardArrowsIncrementByStep.
     await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveAttribute('type', 'time');
   },
 };
@@ -866,5 +867,41 @@ export const DoesNotWarnOnWellFormedTimeStrings: Story = {
   },
   play: async () => {
     await waitFor(() => expect(capturedConsoleErrors.some((m) => m.includes('HH:mm'))).toBe(false));
+  },
+};
+
+// Issue #53 requires keyboard increments. The native input provides them, but
+// nothing asserted it — and the arrows are also the only place the `step` grid
+// is observable as *behaviour* rather than as an attribute.
+export const KeyboardArrowsIncrementByStep: Story = {
+  args: { defaultValue: '09:00', step: 900, onChange: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
+    await browserUserEvent.click(input);
+    // Focus lands on the hour segment; ArrowUp steps the hour by one.
+    await browserUserEvent.keyboard('{ArrowUp}');
+    await expect(input).toHaveValue('10:00');
+    await expect(args.onChange).toHaveBeenLastCalledWith('10:00');
+    // Move to the minute segment: ArrowUp there steps by `step`, not by 1.
+    await browserUserEvent.keyboard('{ArrowRight}{ArrowUp}');
+    await expect(input).toHaveValue('10:15');
+    await expect(args.onChange).toHaveBeenLastCalledWith('10:15');
+    // Every value handed upward is still "HH:mm".
+    for (const call of (args.onChange as ReturnType<typeof fn>).mock.calls) {
+      await expect(call[0]).toMatch(/^([01]\d|2[0-3]):[0-5]\d$/);
+    }
+  },
+};
+
+// ArrowDown must step back down and stay on the grid.
+export const KeyboardArrowsDecrementByStep: Story = {
+  args: { defaultValue: '10:15', step: 900, onChange: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
+    await browserUserEvent.click(input);
+    await browserUserEvent.keyboard('{ArrowRight}{ArrowDown}');
+    await expect(input).toHaveValue('10:00');
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent as browserUserEvent } from '@vitest/browser/context';
 import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
 import { timeInput } from './TimeField.css';
@@ -596,5 +597,91 @@ export const RangeErrorFollowsMinMaxChanges: Story = {
     await waitFor(() =>
       expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
     );
+  },
+};
+
+// Chromium fires NO event when the user half-fills an empty time input: the
+// value stays '' and `badInput` flips silently. So this can only be caught on
+// blur, which is why `revalidate` is wired to onBlur and not just to an effect
+// over `currentValue`. Without that, the field shows `09:--` and reports
+// nothing to anyone (WCAG 3.3.1) — the same case DateField.tsx:275-281 guards.
+//
+// Two driver substitutions were required, both verified empirically:
+// - `@storybook/testing-library`'s `userEvent` is inert for reaching this
+//   native input's `badInput` state at all (typing '09' never flips
+//   `validity.badInput`), so these four stories use the Playwright-backed
+//   driver from `@vitest/browser/context` instead.
+// - Even with that driver, `userEvent.tab()` does NOT blur the field: a
+//   multi-segment time input treats Tab as moving between its internal
+//   hour/minute segments (confirmed via `document.activeElement` staying on
+//   the input after `.tab()`), not as leaving the control. A click on a
+//   different focusable element is used instead to actually trigger blur.
+const blurTimeInput = (canvas: ReturnType<typeof within>) =>
+  browserUserEvent.click(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' }));
+
+export const IncompleteEntryShowsError: Story = {
+  args: { onChange: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await browserUserEvent.type(input, '09'); // hour only — minute left as `--`
+    await blurTimeInput(canvas);
+    await waitFor(() =>
+      expect(canvas.getByText('Anna kellonaika muodossa tunnit:minuutit')).toBeVisible()
+    );
+    // The value never became a real time, so nothing was committed upward.
+    await expect(args.onChange).not.toHaveBeenCalledWith(expect.stringMatching(/^\d{2}:\d{2}$/));
+  },
+};
+
+// A partially-filled field is not an empty field: the typed `09` must render in
+// the normal text colour, not the `--:--` placeholder grey.
+export const IncompleteEntryIsNotMarkedEmpty: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('data-empty', 'true');
+    await browserUserEvent.type(input, '09');
+    await blurTimeInput(canvas);
+    await waitFor(() => expect(input).not.toHaveAttribute('data-empty'));
+  },
+};
+
+// Completing the time clears the incomplete error again.
+export const CompletingTheTimeClearsIncompleteError: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await browserUserEvent.type(input, '09');
+    await blurTimeInput(canvas);
+    await waitFor(() =>
+      expect(canvas.getByText('Anna kellonaika muodossa tunnit:minuutit')).toBeVisible()
+    );
+    // Re-focus the field before typing again — blurring for the check above
+    // moved focus to the picker trigger. `@storybook/testing-library`'s
+    // `userEvent.clear`/`type` reliably resets focus to the first (hour)
+    // segment here, where `browserUserEvent`'s click-then-type left focus on
+    // whichever segment its default click position happened to hit (verified
+    // empirically) — so this one step reverts to the other driver.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0930');
+    await expect(input).toHaveValue('09:30');
+    await waitFor(() =>
+      expect(canvas.queryByText('Anna kellonaika muodossa tunnit:minuutit')).not.toBeInTheDocument()
+    );
+  },
+};
+
+// A consumer-supplied error still outranks the internal incomplete message.
+export const ConsumerErrorWinsOverIncompleteError: Story = {
+  args: { error: 'Varaus on jo täynnä' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await browserUserEvent.type(canvas.getByLabelText('Valitse kellonaika'), '09');
+    await blurTimeInput(canvas);
+    await expect(canvas.getByText('Varaus on jo täynnä')).toBeVisible();
+    await expect(
+      canvas.queryByText('Anna kellonaika muodossa tunnit:minuutit')
+    ).not.toBeInTheDocument();
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -171,3 +171,35 @@ export const DisabledDisablesBothParts: Story = {
     await expect(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' })).toBeDisabled();
   },
 };
+
+export const ClearButtonEmptiesTheField: Story = {
+  args: { defaultValue: '09:30', onChange: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Tyhjennä kellonaika' }));
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveValue('');
+    await expect(args.onChange).toHaveBeenLastCalledWith('');
+  },
+};
+
+export const ClearButtonOnlyWhenPopulatedAndEnabled: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Empty field: nothing to clear.
+    await expect(
+      canvas.queryByRole('button', { name: 'Tyhjennä kellonaika' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const ClearMovesFocusToTrigger: Story = {
+  args: { defaultValue: '09:30' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' });
+    await userEvent.click(canvas.getByRole('button', { name: 'Tyhjennä kellonaika' }));
+    // The ✕ unmounts the moment the field empties, so focus would otherwise
+    // fall to <body>. Same fix as DateField.handleClear.
+    await waitFor(() => expect(trigger).toHaveFocus());
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -107,3 +107,23 @@ export const HidesNativePickerIndicator: Story = {
     await expect(input).toHaveClass(timeInput);
   },
 };
+
+export const MarksEmptySegmentsForPlaceholderStyling: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    // `data-empty` is what TimeField.css.ts keys its `--:--` placeholder
+    // colouring off (Chromium's `-webkit-datetime-edit-*` shadow
+    // pseudo-elements don't support `:not([attr])` matching, so this can't be
+    // driven by a browser-set attribute). This only checks the attribute is
+    // wired correctly — the rendered colour itself is verified visually, not
+    // by a computed-style read, since that read is unreliable for these
+    // pseudo-elements (see HidesNativePickerIndicator above).
+    await expect(input).toHaveAttribute('data-empty', 'true');
+    await userEvent.type(input, '0945');
+    await expect(input).toHaveValue('09:45');
+    await expect(input).not.toHaveAttribute('data-empty');
+    await userEvent.clear(input);
+    await expect(input).toHaveAttribute('data-empty', 'true');
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -254,3 +254,81 @@ export const ClearMovesFocusToTrigger: Story = {
     await waitFor(() => expect(trigger).toHaveFocus());
   },
 };
+
+// Controlled (not uncontrolled, per the plan's rulings): also proves the
+// out-of-range value is still committed up to the parent — TimeField flags
+// it rather than blocking entry, matching how the native input itself never
+// refuses a keystroke for being out of [min, max].
+export const OutOfRangeShowsError: Story = {
+  args: { min: '08:00', max: '17:00' },
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <>
+        <TimeField {...args} value={value} onChange={setValue} />
+        <span data-testid="echo">{value}</span>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await userEvent.type(input, '0600');
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    await expect(canvas.getByTestId('echo').textContent).toBe('06:00');
+    // …and clears again once the value is back inside the range.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0900');
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      ).not.toBeInTheDocument()
+    );
+    await expect(canvas.getByTestId('echo').textContent).toBe('09:00');
+  },
+};
+
+export const ConsumerErrorWinsOverRangeError: Story = {
+  args: { min: '08:00', max: '17:00', error: 'Varaus on jo täynnä' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Valitse kellonaika'), '0600');
+    await expect(canvas.getByText('Varaus on jo täynnä')).toBeVisible();
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const StepIsClampedToWholeMinutes: Story = {
+  args: { step: 5 },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    // A sub-60 step would make the browser render a seconds segment; the
+    // component clamps it to a whole minute so only hh:mm segments exist.
+    await expect(input).toHaveAttribute('step', '60');
+    // The invalid sub-60 step also fires a dev-only warning.
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /step.*must be at least 60/i.test(m))).toBe(true)
+    );
+    // With the browser only ever seeing the clamped step, a normal
+    // minute-granularity entry must not be flagged as a step mismatch.
+    await userEvent.type(input, '0930');
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   // autodocs page (`!autodocs`). Documentation examples opt back in via `docExample`.
   tags: ['!dev', '!autodocs'],
   args: {
-    inputLabel: 'Valitse kellonaika',
+    label: 'Valitse kellonaika',
     pickerButtonLabel: 'Avaa kellonaikavalitsin',
   },
   parameters: {
@@ -142,7 +142,7 @@ export const IsANativeTimeInput: Story = {
 
 export const AccessibleNameViaAriaLabel: Story = {
   // With no visible label, an aria-label must give the input an accessible name.
-  args: { inputLabel: undefined, 'aria-label': 'Kellonaika' },
+  args: { label: undefined, 'aria-label': 'Kellonaika' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Kellonaika');
@@ -150,7 +150,7 @@ export const AccessibleNameViaAriaLabel: Story = {
   },
 };
 
-// When both `inputLabel` and `aria-label` are supplied, the visible label must
+// When both `label` and `aria-label` are supplied, the visible label must
 // win the accessible-name computation — forwarding `aria-label` unconditionally
 // would let it silently override the visible label's text (WCAG 2.5.3 Label in
 // Name), breaking voice-control activation by the visible label's wording.
@@ -165,9 +165,9 @@ export const VisibleLabelWinsOverAriaLabel: Story = {
 };
 
 export const WarnsWithoutAccessibleName: Story = {
-  // With neither inputLabel nor aria-label/aria-labelledby, the component must
+  // With neither label nor aria-label/aria-labelledby, the component must
   // warn the developer in dev (the input would otherwise be unnamed).
-  args: { inputLabel: undefined },
+  args: { label: undefined },
   beforeEach: () => {
     capturedConsoleErrors = [];
     const original = console.error;

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -424,7 +424,7 @@ export const StepIsClampedToWholeMinutes: Story = {
     // minute-granularity entry must not be flagged as a step mismatch.
     await userEvent.type(input, '0930');
     await expect(
-      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
     ).not.toBeInTheDocument();
   },
 };
@@ -460,7 +460,9 @@ export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
 // the booking-flow case the plan calls out. This is the only story in this
 // file that actually drives `stepMismatch` true/false, as distinct from the
 // two stories above, which only check the clamped `step` attribute and the
-// dev warning — they never assert on validity itself.
+// dev warning — they never assert on validity itself. It expects the
+// `stepMismatch`-specific message, not the range one, since every value here
+// stays inside [00:00, ∞) — only the grid is ever at issue.
 //
 // `min` is passed explicitly here (rather than relying on the component's
 // own '00:00' default — see StepAloneEnforcesGranularityViaDefaultMin below)
@@ -477,22 +479,48 @@ export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
     // On the 15-minute grid (00, 15, 30, 45) — no error.
     await userEvent.type(input, '0915');
     await expect(
-      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
     ).not.toBeInTheDocument();
     // Off the grid by 5 minutes — `stepMismatch` fires.
     await userEvent.clear(input);
     await userEvent.type(input, '0905');
     await waitFor(() =>
-      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+      expect(canvas.getByText('Valitse kellonaika sallitulla tarkkuudella')).toBeVisible()
     );
     // Back on the grid — clears again.
     await userEvent.clear(input);
     await userEvent.type(input, '0930');
     await waitFor(() =>
       expect(
-        canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+        canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
       ).not.toBeInTheDocument()
     );
+  },
+};
+
+// An off-grid time inside [min, max] is not "outside the allowed range" — it is
+// the wrong granularity, and the message has to say which (WCAG 3.3.3).
+export const StepMismatchHasItsOwnMessage: Story = {
+  args: { min: '08:00', max: '17:00', step: 900 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await userEvent.type(input, '0905'); // inside the window, off the 15-min grid
+    await waitFor(() =>
+      expect(canvas.getByText('Valitse kellonaika sallitulla tarkkuudella')).toBeVisible()
+    );
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    // A genuinely out-of-window value still gets the range message.
+    await userEvent.clear(input);
+    await userEvent.type(input, '0600');
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    await expect(
+      canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -510,7 +538,7 @@ export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
     await expect(input).toHaveAttribute('min', '00:00');
     await userEvent.type(input, '0905'); // 5 minutes off the 15-minute grid.
     await waitFor(() =>
-      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+      expect(canvas.getByText('Valitse kellonaika sallitulla tarkkuudella')).toBeVisible()
     );
   },
 };
@@ -519,6 +547,8 @@ export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
 // itself: `min` is inclusive, so `00:00 >= min('00:00')` must not read as
 // rangeUnderflow, and 0 seconds past midnight is trivially on any step grid
 // (0 is a multiple of everything), so `stepMismatch` must not fire either.
+// Checked against both messages now that they've split, since either flag
+// firing would be a regression this story exists to catch.
 export const DefaultMinDoesNotFlagMidnightItself: Story = {
   args: { step: 900 },
   play: async ({ canvasElement }) => {
@@ -528,6 +558,9 @@ export const DefaultMinDoesNotFlagMidnightItself: Story = {
     await expect(input).toHaveValue('00:00');
     await expect(
       canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Valitse kellonaika sallitulla tarkkuudella')
     ).not.toBeInTheDocument();
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -367,13 +367,12 @@ export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
 // two stories above, which only check the clamped `step` attribute and the
 // dev warning — they never assert on validity itself.
 //
-// `min` is required here, not incidental: empirically (verified against the
-// real Chromium instance this suite runs in, not by reading the spec),
-// Chromium only evaluates `stepMismatch` for a time input once a `min` is
-// present to anchor the step base — omitting `min` here, `0905` and `0915`
-// were both accepted with `stepMismatch: false` regardless of `step`. This
-// is worth knowing: a consumer who sets `step` without `min` gets no
-// off-grid enforcement at all.
+// `min` is passed explicitly here (rather than relying on the component's
+// own '00:00' default — see StepAloneEnforcesGranularityViaDefaultMin below)
+// to exercise the consumer-supplied-`min` path specifically: it must behave
+// identically to the defaulted path, and this is the story that would catch
+// a regression that special-cased the default instead of just filling the
+// same `min` prop.
 export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
   args: { step: 900, min: '00:00' }, // 15 minutes; already a whole-minute multiple, so no dev warning.
   play: async ({ canvasElement }) => {
@@ -399,6 +398,51 @@ export const StepMismatchFlagsOffGridValuesAtFifteenMinuteGranularity: Story = {
         canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
       ).not.toBeInTheDocument()
     );
+  },
+};
+
+// Chromium never evaluates `stepMismatch` on a time input without a `min`
+// present (see the empirical finding documented above). Without the
+// component defaulting `min` to '00:00' whenever `step` is supplied and no
+// `min` was given, this story's off-grid value would be silently accepted —
+// this is the exact behaviour gap the default exists to close.
+export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
+  args: { step: 900 }, // 15 minutes, no explicit `min`.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    // The component filled in the '00:00' default so `step` actually bites.
+    await expect(input).toHaveAttribute('min', '00:00');
+    await userEvent.type(input, '0905'); // 5 minutes off the 15-minute grid.
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+  },
+};
+
+// The one value the '00:00' default could plausibly disturb is midnight
+// itself: `min` is inclusive, so `00:00 >= min('00:00')` must not read as
+// rangeUnderflow, and 0 seconds past midnight is trivially on any step grid
+// (0 is a multiple of everything), so `stepMismatch` must not fire either.
+export const DefaultMinDoesNotFlagMidnightItself: Story = {
+  args: { step: 900 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await userEvent.type(input, '0000');
+    await expect(input).toHaveValue('00:00');
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+  },
+};
+
+// The default is purely a side effect of `step` — a field that never sets
+// `step` must not gain an implicit `min` it never asked for.
+export const NoStepMeansNoImplicitMin: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Valitse kellonaika')).not.toHaveAttribute('min');
   },
 };
 

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -283,7 +283,7 @@ export const ClearButtonEmptiesTheField: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Tyhjennä kellonaika' }));
     await expect(input).toHaveValue('');
     await expect(args.onChange).toHaveBeenLastCalledWith('');
-    // Task 3's empty-segment placeholder mechanism keys off this attribute —
+    // The empty-segment placeholder mechanism (#53) keys off this attribute —
     // clearing must flip it back to 'true', the same as a manually emptied field.
     await expect(input).toHaveAttribute('data-empty', 'true');
   },
@@ -358,7 +358,7 @@ export const ClearMovesFocusToTrigger: Story = {
   },
 };
 
-// Controlled (not uncontrolled, per the plan's rulings): also proves the
+// Controlled (not uncontrolled): also proves the
 // out-of-range value is still committed up to the parent — TimeField flags
 // it rather than blocking entry, matching how the native input itself never
 // refuses a keystroke for being out of [min, max].
@@ -465,7 +465,7 @@ export const StepRoundsToNearestMinuteWhenAboveSixty: Story = {
 
 // With the clamp rounding to a whole-minute multiple, `stepMismatch` becomes
 // reachable (and meaningful) for a legitimate granularity like 15 minutes —
-// the booking-flow case the plan calls out. This is the only story in this
+// the booking-flow case #53 calls out. This is the only story in this
 // file that actually drives `stepMismatch` true/false, as distinct from the
 // two stories above, which only check the clamped `step` attribute and the
 // dev warning — they never assert on validity itself. It expects the
@@ -549,12 +549,14 @@ export const StepAloneEnforcesGranularityViaDefaultMin: Story = {
   },
 };
 
-// The counterfactual for the `min: '00:00'` default. A controlled field mounted
-// with an off-grid value and no user interaction is the ONE case where Chromium
-// won't evaluate `stepMismatch` without a `min` present — measured: no `min` →
-// false, `min="00:00"` → true. Deleting `effectiveMin` makes this story red,
-// which StepAloneEnforcesGranularityViaDefaultMin does not (it only asserts the
-// attribute is there, not that it is doing anything).
+// The counterfactual for the `min: '00:00'` default. Without an explicit `min`,
+// the step base falls back to the `value` content attribute, which React keeps
+// in sync with this value on every commit — so `stepMismatch` can never be true
+// no matter what off-grid value is mounted. The injected `min` is what makes
+// `stepMismatch` observable at all: measured, no `min` → false, `min="00:00"` →
+// true for the same off-grid value. Deleting `effectiveMin` makes this story
+// red, which StepAloneEnforcesGranularityViaDefaultMin does not (it only
+// asserts the attribute is there, not that it is doing anything).
 export const OffGridControlledValueIsFlaggedAtMount: Story = {
   args: { value: '09:05', step: 900, onChange: fn() },
   play: async ({ canvasElement }) => {
@@ -766,8 +768,8 @@ export const IncompleteEntryShowsError: Story = {
     await waitFor(() =>
       expect(canvas.getByText('Anna kellonaika muodossa tunnit:minuutit')).toBeVisible()
     );
-    // The value never became a real time, so nothing was committed upward.
-    await expect(args.onChange).not.toHaveBeenCalledWith(expect.stringMatching(/^\d{2}:\d{2}$/));
+    // The entry never became a real time, so nothing was committed upward at all.
+    await expect(args.onChange).not.toHaveBeenCalled();
   },
 };
 
@@ -888,7 +890,7 @@ export const DoesNotWarnOnWellFormedTimeStrings: Story = {
     };
   },
   play: async () => {
-    await waitFor(() => expect(capturedConsoleErrors.some((m) => m.includes('HH:mm'))).toBe(false));
+    await expect(capturedConsoleErrors.some((m) => m.includes('HH:mm'))).toBe(false);
   },
 };
 
@@ -961,7 +963,7 @@ export const SubmitsUnderItsName: Story = {
 // A consumer `onBlur` must run without displacing the internal revalidation
 // that the incomplete-entry check depends on.
 //
-// Uses `browserUserEvent`/`blurTimeInput` rather than the brief's plain
+// Uses `browserUserEvent`/`blurTimeInput` rather than plain
 // `userEvent.type` + `.tab()`: per the comment above `blurTimeInput`, the
 // `@storybook/testing-library` driver is inert for reaching `badInput` on
 // this native input, and `.tab()` moves between the input's own hour/minute

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -86,7 +86,7 @@ export const BookingFlow: Story = {
         style={{
           display: 'flex',
           flexWrap: 'wrap',
-          gap: vars.primitives.spacing['2'],
+          gap: vars.primitives.spacing['3'],
           alignItems: 'flex-start',
         }}
       >

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -716,3 +716,51 @@ export const ConsumerErrorWinsOverIncompleteError: Story = {
     );
   },
 };
+
+// A malformed value is rejected outright by the native input, which leaves the
+// field visually empty while the consumer's state still holds their string —
+// so the only signal that anything is wrong has to come from us. A malformed
+// `min` is worse: the browser ignores the attribute, silently disabling both
+// the range check and (because the '00:00' fallback no longer fires) step
+// enforcement. Same hazard DateField.tsx:188-202 guards.
+export const WarnsOnMalformedTimeStrings: Story = {
+  args: { value: '9:30', min: '25:00', onChange: fn() },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The native input really does discard it — this is what the warning is for.
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveValue('');
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => m.includes('`value` must be "HH:mm"'))).toBe(true)
+    );
+    await expect(capturedConsoleErrors.some((m) => m.includes('`min` must be "HH:mm"'))).toBe(true);
+  },
+};
+
+// The guard must stay quiet for well-formed values, including the empty string,
+// or it would cry wolf on every correctly-used field.
+export const DoesNotWarnOnWellFormedTimeStrings: Story = {
+  args: { value: '', min: '00:00', max: '23:59', step: 900, onChange: fn() },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async () => {
+    await waitFor(() => expect(capturedConsoleErrors.some((m) => m.includes('HH:mm'))).toBe(false));
+  },
+};

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -633,6 +633,77 @@ export const RangeErrorFollowsMinMaxChanges: Story = {
   },
 };
 
+// Every other range story goes below `min`, which left `max` and the
+// `rangeOverflow` flag deletable without a single test going red.
+export const OverMaxShowsError: Story = {
+  args: { min: '08:00', max: '17:00' },
+  render: function Render(args) {
+    const [value, setValue] = useState('');
+    return (
+      <>
+        <TimeField {...args} value={value} onChange={setValue} />
+        <span data-testid="echo">{value}</span>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await expect(input).toHaveAttribute('max', '17:00');
+    await userEvent.type(input, '1930');
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+    // Flagged, not blocked — the same contract the underflow story asserts.
+    await expect(canvas.getByTestId('echo').textContent).toBe('19:30');
+    // …and clears once the value is back inside the window.
+    await userEvent.clear(input);
+    await userEvent.type(input, '1600');
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+      ).not.toBeInTheDocument()
+    );
+  },
+};
+
+// `max` is inclusive: the boundary value itself must not be flagged.
+export const MaxBoundaryIsInclusive: Story = {
+  args: { min: '08:00', max: '17:00' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    await userEvent.type(input, '1700');
+    await expect(input).toHaveValue('17:00');
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+  },
+};
+
+// Mirror of RangeErrorFollowsMinMaxChanges, which only ever raises `min`.
+export const RangeErrorFollowsMaxChanges: Story = {
+  render: function Render(args) {
+    const [max, setMax] = useState('17:00');
+    return (
+      <>
+        <TimeField {...args} min="08:00" max={max} defaultValue="16:00" />
+        <button onClick={() => setMax('15:00')}>Lower max to 15:00</button>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByText('Kellonaika on sallitun välin ulkopuolella')
+    ).not.toBeInTheDocument();
+    await userEvent.click(canvas.getByText('Lower max to 15:00'));
+    await waitFor(() =>
+      expect(canvas.getByText('Kellonaika on sallitun välin ulkopuolella')).toBeVisible()
+    );
+  },
+};
+
 // Chromium fires NO event when the user half-fills an empty time input: the
 // value stays '' and `badInput` flips silently. So this can only be caught on
 // blur, which is why `revalidate` is wired to onBlur and not just to an effect

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within, userEvent } from '@storybook/testing-library';
+import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
 
@@ -19,6 +19,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const docExample = ['dev', 'autodocs'];
+
+let capturedConsoleErrors: string[] = [];
 
 export const Default: Story = { tags: docExample };
 
@@ -63,5 +65,26 @@ export const IsANativeTimeInput: Story = {
     // The native input is what supplies keyboard increments and spinbutton
     // semantics — if this regresses to type="text" the whole design is void.
     await expect(canvas.getByLabelText('Valitse kellonaika')).toHaveAttribute('type', 'time');
+  },
+};
+
+export const WarnsWithoutAccessibleName: Story = {
+  // With neither inputLabel nor aria-label/aria-labelledby, the component must
+  // warn the developer in dev (the input would otherwise be unnamed).
+  args: { inputLabel: undefined },
+  beforeEach: () => {
+    capturedConsoleErrors = [];
+    const original = console.error;
+    console.error = (...messageArgs: unknown[]) => {
+      capturedConsoleErrors.push(String(messageArgs[0]));
+    };
+    return () => {
+      console.error = original;
+    };
+  },
+  play: async () => {
+    await waitFor(() =>
+      expect(capturedConsoleErrors.some((m) => /accessible name/i.test(m))).toBe(true)
+    );
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -6,6 +6,7 @@ import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
 import { timeInput } from './TimeField.css';
 import { DateField } from '../DateField';
+import { vars } from '../../theme';
 
 const meta = {
   component: TimeField,
@@ -79,10 +80,16 @@ export const BookingFlow: Story = {
     const [date, setDate] = useState<Date | null>(null);
     const [time, setTime] = useState('');
     return (
-      // flexWrap prevents the pairing from overflowing the viewport at narrow
-      // widths (e.g. the 320px check in the brief) — the brief's sample style
-      // omitted it, but the two fields together don't fit a 320px canvas.
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'flex-start' }}>
+      // flexWrap prevents the pairing from overflowing at narrow widths — the
+      // two fields together don't fit a 320px canvas.
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: vars.primitives.spacing['2'],
+          alignItems: 'flex-start',
+        }}
+      >
         <DateField
           label="Valitse päivämäärä"
           calendarButtonLabel="Avaa kalenteri"

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect, fn } from 'storybook/test';
 import { TimeField } from './TimeField';
+import { timeInput } from './TimeField.css';
 
 const meta = {
   component: TimeField,
@@ -86,5 +87,23 @@ export const WarnsWithoutAccessibleName: Story = {
     await waitFor(() =>
       expect(capturedConsoleErrors.some((m) => /accessible name/i.test(m))).toBe(true)
     );
+  },
+};
+
+export const HidesNativePickerIndicator: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika');
+    // Figma places the clock control OUTSIDE the field, so the browser's own
+    // in-field indicator must not render — otherwise there are two clock icons.
+    //
+    // Reading getComputedStyle(input, '::-webkit-calendar-picker-indicator')
+    // proved unreliable in this Chromium/Playwright combination — it reports
+    // 'block' regardless of the `display: none` rule targeting that shadow
+    // pseudo-element, so it cannot distinguish "rule applied" from "rule
+    // absent". Assert structurally instead: the input carries the `timeInput`
+    // class, which is the thing that contains the suppression rule (see
+    // TimeField.css.ts). The visual result is confirmed manually in Storybook.
+    await expect(input).toHaveClass(timeInput);
   },
 };

--- a/src/components/TimeField/TimeField.stories.tsx
+++ b/src/components/TimeField/TimeField.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   tags: ['!dev', '!autodocs'],
   args: {
     inputLabel: 'Valitse kellonaika',
+    pickerButtonLabel: 'Avaa kellonaikavalitsin',
   },
 } satisfies Meta<typeof TimeField>;
 
@@ -125,5 +126,48 @@ export const MarksEmptySegmentsForPlaceholderStyling: Story = {
     await expect(input).not.toHaveAttribute('data-empty');
     await userEvent.clear(input);
     await expect(input).toHaveAttribute('data-empty', 'true');
+  },
+};
+
+export const TriggerOpensNativePicker: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
+    // The picker panel is OS-level chrome Playwright cannot see into, so assert
+    // the invocation rather than the rendered widget.
+    const showPicker = fn();
+    Object.defineProperty(input, 'showPicker', { value: showPicker, configurable: true });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' }));
+    await expect(showPicker).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const TriggerFallsBackToFocus: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Valitse kellonaika') as HTMLInputElement;
+    // Safari <16 has no showPicker, and Chromium throws NotAllowedError without
+    // user activation. Either way the button must not be inert.
+    Object.defineProperty(input, 'showPicker', {
+      value: () => {
+        throw new DOMException('not allowed', 'NotAllowedError');
+      },
+      configurable: true,
+    });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' }));
+    await expect(input).toHaveFocus();
+  },
+};
+
+export const DisabledDisablesBothParts: Story = {
+  tags: docExample,
+  args: { disabled: true, defaultValue: '09:30' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Figma's one stated exception: disabling the component disables both subcomponents.
+    await expect(canvas.getByLabelText('Valitse kellonaika')).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Avaa kellonaikavalitsin' })).toBeDisabled();
   },
 };

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -218,13 +218,29 @@ export function TimeField({
           ? stepMismatchError
           : undefined);
 
+  const [clearRequests, setClearRequests] = useState(0);
+  const handledClearRequest = useRef(0);
+
   function handleClear() {
     if (!isControlled) setInternalValue('');
     onChange?.('');
-    // The ✕ disappears once the field is empty, so move focus to the adjacent
-    // picker trigger rather than letting it fall back to <body>.
-    requestAnimationFrame(() => pickerButtonRef.current?.focus());
+    // Only *request* the focus move; the effect below decides whether it happened.
+    setClearRequests((n) => n + 1);
   }
+
+  // The ✕ unmounts the moment the field empties, so focus would otherwise fall
+  // back to <body> — move it to the adjacent picker trigger. Conditional on the
+  // value having actually emptied: a controlled consumer that ignores `onChange`
+  // keeps both the value and the ✕, and moving focus there would be the visible
+  // half of an action that did nothing. Keyed on the click counter rather than on
+  // the value alone, because an ignored clear re-renders nothing to observe; the
+  // ref then marks the request consumed either way, so a later manual emptying
+  // (deleting the segments by hand) can't inherit a stale focus move.
+  useEffect(() => {
+    if (clearRequests === handledClearRequest.current) return;
+    handledClearRequest.current = clearRequests;
+    if (currentValue === '') pickerButtonRef.current?.focus();
+  }, [clearRequests, currentValue]);
 
   function openPicker() {
     const input = inputRef.current;

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -157,13 +157,19 @@ export function TimeField({
     onChange?.(next);
   }
 
+  // Forward an aria-label/aria-labelledby only when there is no visible label,
+  // so it can't silently override a visible label's accessible name.
+  const inputAriaProps =
+    !inputLabel && (ariaLabel || ariaLabelledby)
+      ? { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby }
+      : {};
+
   return (
     <TextField
       type="time"
       ref={inputRef}
       inputLabel={inputLabel}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledby}
+      {...inputAriaProps}
       helperText={helperText}
       error={shownError}
       disabled={disabled}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
+import cx from 'clsx';
 import { TextField } from '../TextField';
+import { timeInput } from './TimeField.css';
 
 export interface TimeFieldClassNames {
   root: string;
@@ -72,7 +74,7 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
-      classNames={{ root: classNames?.root, wrapper: classNames?.input }}
+      classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
     />
   );
 }

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -37,7 +37,7 @@ export interface TimeFieldProps {
   min?: string;
   /** Latest selectable time, "HH:mm". */
   max?: string;
-  /** Granularity in seconds; values below 60 are clamped to 60. Default 60. */
+  /** Granularity in seconds; clamped to the nearest whole minute (minimum 60). Default 60. */
   step?: number;
   disabled?: boolean;
   required?: boolean;
@@ -71,28 +71,39 @@ export function TimeField({
   const pickerButtonRef = useRef<HTMLButtonElement>(null);
   const [rangeError, setRangeError] = useState(false);
 
-  // A sub-60 step makes the browser render a seconds segment, which this
-  // component does not support.
-  const effectiveStep = Math.max(60, step);
+  // A step that isn't a whole number of minutes makes the browser render a
+  // seconds segment, which this component does not support — round to the
+  // nearest minute (and never below one) rather than merely flooring at 60,
+  // otherwise e.g. `step={90}` would slip through unchanged.
+  const effectiveStep = Math.max(60, Math.round(step / 60) * 60);
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production' && step < 60) {
-      console.error(`TimeField: \`step\` must be at least 60 seconds — got ${step}, using 60.`);
+    if (process.env.NODE_ENV !== 'production' && step !== effectiveStep) {
+      console.error(
+        `TimeField: \`step\` must be a whole number of minutes — got ${step}, using ${effectiveStep}.`
+      );
     }
-  }, [step]);
+  }, [step, effectiveStep]);
 
   const showClear = !disabled && currentValue !== '';
 
-  function validate(input: HTMLInputElement) {
+  // Revalidate off the native input's own `validity` object whenever anything
+  // that could change it does — not just user-driven change/blur events, but
+  // also a controlled consumer resetting `value`, or `min`/`max`/`step`
+  // themselves changing under an already-displayed value. This single effect
+  // subsumes what would otherwise be duplicate validate() calls wired to
+  // onChange and onBlur.
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
     const { rangeUnderflow, rangeOverflow, stepMismatch } = input.validity;
     setRangeError(rangeUnderflow || rangeOverflow || stepMismatch);
-  }
+  }, [currentValue, min, max, effectiveStep]);
 
   const shownError = error ?? (rangeError ? outOfRangeError : undefined);
 
   function handleClear() {
     if (!isControlled) setInternalValue('');
     onChange?.('');
-    setRangeError(false);
     // The ✕ disappears once the field is empty, so move focus to the adjacent
     // picker trigger rather than letting it fall back to <body>.
     requestAnimationFrame(() => pickerButtonRef.current?.focus());
@@ -130,7 +141,6 @@ export function TimeField({
     const next = event.currentTarget.value;
     if (!isControlled) setInternalValue(next);
     onChange?.(next);
-    validate(event.currentTarget);
   }
 
   return (
@@ -146,7 +156,6 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
-      onBlur={(e) => validate(e.currentTarget)}
       min={min}
       max={max}
       step={effectiveStep}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import cx from 'clsx';
 import { TextField } from '../TextField';
-import { timeInput } from './TimeField.css';
+import { Button } from '../Button';
+import { TimeIcon } from '../../icons/TimeIcon';
+import { timeInput, triggerIcon } from './TimeField.css';
 
 export interface TimeFieldClassNames {
   root: string;
@@ -18,6 +20,8 @@ export interface TimeFieldProps {
   onChange?: (time: string) => void;
   /** Visible field label. Provide this, `aria-label`, or `aria-labelledby`. */
   inputLabel?: string;
+  /** Accessible name for the clock trigger. Required — no default. */
+  pickerButtonLabel: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   helperText?: React.ReactNode;
@@ -34,6 +38,7 @@ export function TimeField({
   defaultValue,
   onChange,
   inputLabel,
+  pickerButtonLabel,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   helperText,
@@ -45,6 +50,25 @@ export function TimeField({
   const isControlled = value !== undefined;
   const [internalValue, setInternalValue] = useState(defaultValue ?? '');
   const currentValue = isControlled ? value : internalValue;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function openPicker() {
+    const input = inputRef.current;
+    if (!input) return;
+    // Feature-detect first (Safari <16 has no showPicker), then guard the call:
+    // Chromium throws NotAllowedError without user activation and
+    // InvalidStateError on a disabled/hidden input. Focusing keeps the button
+    // from being an inert control in any of those cases.
+    if (typeof input.showPicker === 'function') {
+      try {
+        input.showPicker();
+        return;
+      } catch {
+        // fall through to focus
+      }
+    }
+    input.focus();
+  }
 
   // Dev-only guard: without a visible label or an aria-label/aria-labelledby the
   // time input has no accessible name.
@@ -65,6 +89,7 @@ export function TimeField({
   return (
     <TextField
       type="time"
+      ref={inputRef}
       inputLabel={inputLabel}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
@@ -81,6 +106,18 @@ export function TimeField({
       // still `--`".
       data-empty={currentValue === '' ? 'true' : undefined}
       classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
+      endInstance={
+        <Button
+          variant="primary"
+          iconOnly
+          aria-label={pickerButtonLabel}
+          disabled={disabled}
+          onClick={openPicker}
+          className={classNames?.pickerButton}
+        >
+          <TimeIcon className={triggerIcon} />
+        </Button>
+      }
     />
   );
 }

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -74,6 +74,12 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
+      // Drives the empty-segment placeholder colour in TimeField.css.ts: the
+      // `-webkit-datetime-edit-*` shadow pseudo-elements don't support
+      // `:not([attr])` matching in Chromium, so component state (not an
+      // attribute the browser itself sets) has to signal "every segment is
+      // still `--`".
+      data-empty={currentValue === '' ? 'true' : undefined}
       classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
     />
   );

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -148,6 +148,17 @@ export function TimeField({
     }
   }, [stepMinutes, effectiveStepMinutes]);
 
+  // Correct a swapped pair, the way DateField.tsx does: left alone, `min="17:00"
+  // max="08:00"` makes every value in the intended window report an error while
+  // every value outside it passes, with nothing pointing at the swapped props.
+  // Only well-formed bounds are compared — the browser ignores an unparseable
+  // min/max, so swapping on one would invent a range the browser never had (the
+  // dev guard further down warns about those separately). "HH:mm" is zero-padded
+  // and fixed-width, so a plain string comparison is a time comparison.
+  const boundsSwapped = !!min && !!max && TIME_RE.test(min) && TIME_RE.test(max) && max < min;
+  const rangeMin = boundsSwapped ? max : min;
+  const rangeMax = boundsSwapped ? min : max;
+
   // Per the HTML step-base algorithm, `step` is measured from `min` if present,
   // otherwise from the `value` *content attribute*, otherwise from 0. React keeps
   // a controlled input's value content attribute in sync with the `value` prop on
@@ -156,9 +167,11 @@ export function TimeField({
   // component's post-commit effect reads it, for typed and programmatic values
   // alike. An explicit `min` pins the step base instead; `'00:00'` excludes no
   // values, since `min` is inclusive. Only when the consumer actually asked for a
-  // step: fields that never set `stepMinutes` get no implicit `min`.
+  // step: fields that never set `stepMinutes` get no implicit `min`. Reads
+  // `rangeMin`, not `min`, so a swapped pair pins the step base to the corrected
+  // lower bound rather than to the upper one.
   // Counterfactual test: OffGridControlledValueIsFlaggedAtMount.
-  const effectiveMin = min ?? (stepMinutesProp !== undefined ? '00:00' : undefined);
+  const effectiveMin = rangeMin ?? (stepMinutesProp !== undefined ? '00:00' : undefined);
 
   const showClear = !disabled && currentValue !== '';
 
@@ -190,7 +203,7 @@ export function TimeField({
   // changes no value and fires no event — which is why `onBlur` also
   // revalidates. If you read another validity flag here, check whether an
   // effect can actually see it flip.
-  useEffect(revalidate, [revalidate, currentValue, effectiveMin, max, domStep]);
+  useEffect(revalidate, [revalidate, currentValue, effectiveMin, rangeMax, domStep]);
 
   // Consumer error first, then incomplete entry (the user can't fix a range
   // problem they haven't finished typing), then the range window, then
@@ -264,7 +277,14 @@ export function TimeField({
         );
       }
     }
-  }, [value, defaultValue, min, max]);
+    // Normalising a swapped pair keeps the field usable, but the props are still
+    // wrong — say so, or the caller never finds out.
+    if (boundsSwapped) {
+      console.error(
+        `TimeField: \`min\` ("${min}") is after \`max\` ("${max}") — using the pair the other way round.`
+      );
+    }
+  }, [value, defaultValue, min, max, boundsSwapped]);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const next = event.currentTarget.value;
@@ -304,7 +324,7 @@ export function TimeField({
       id={id}
       autoComplete={autoComplete}
       min={effectiveMin}
-      max={max}
+      max={rangeMax}
       step={domStep}
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the
       // `-webkit-datetime-edit-*` shadow pseudo-elements can't be qualified by

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -28,7 +28,13 @@ export interface TimeFieldProps extends Pick<
   value?: string;
   /** Initial time for an uncontrolled field. Ignored when `value` is supplied. */
   defaultValue?: string;
-  /** Called with "HH:mm", or '' when cleared. */
+  /**
+   * Called with "HH:mm", or '' when cleared. Also called with '' while editing
+   * a segment of an otherwise-complete value (e.g. clearing the minutes of
+   * "09:30"), because the native input genuinely holds no time at that point.
+   * Unlike `DateField`, which keeps the last committed value and never fires
+   * `onChange(null)` mid-edit, TimeField commits the transient `''`.
+   */
   onChange?: (time: string) => void;
   /** Visible field label. Provide this, `aria-label`, or `aria-labelledby`. */
   label?: string;
@@ -39,7 +45,13 @@ export interface TimeFieldProps extends Pick<
   'aria-label'?: string;
   'aria-labelledby'?: string;
   helperText?: React.ReactNode;
-  /** Consumer-supplied error. Takes precedence over internal range validation. */
+  /**
+   * Consumer-supplied error. Takes precedence over the internal range,
+   * step-mismatch, and incomplete-entry messages. An empty string still
+   * counts as a supplied error and suppresses all of them, so avoid the
+   * common `error={errors.time ?? ''}` idiom — pass `undefined` (not `''`)
+   * when there is no consumer error, e.g. `error={errors.time}`.
+   */
   error?: string;
   /** Shown when the time falls outside [min, max]. Default: Finnish. */
   outOfRangeError?: string;
@@ -62,9 +74,10 @@ export interface TimeFieldProps extends Pick<
   /**
    * Granularity in seconds; clamped to the nearest whole minute (minimum 60,
    * for any finite value). Default 60. Enforced relative to `min`: if `step` is
-   * supplied and `min` is not, `min` defaults to `'00:00'` so that a value
-   * arriving from the `value` prop alone is still step-checked (see the comment
-   * on `effectiveMin`). `'00:00'` excludes no values on a 24-hour clock.
+   * supplied and `min` is not, `min` defaults to `'00:00'` so that `stepMismatch`
+   * is observable at all — without a `min`, the step check is never true for
+   * typed or programmatic values alike (see the comment on `effectiveMin`).
+   * `'00:00'` excludes no values on a 24-hour clock.
    */
   step?: number;
   disabled?: boolean;
@@ -124,14 +137,15 @@ export function TimeField({
     }
   }, [step, effectiveStep]);
 
-  // Chromium does not evaluate `stepMismatch` when the value came only from the
-  // content attribute and has never been made "dirty" — i.e. a controlled field
-  // mounted with an off-grid value and not yet touched, which is the common
-  // case. (Typed and IDL-set values are checked with or without a `min`, so this
-  // is narrower than "step needs a min".) Defaulting to the earliest
-  // representable time switches the check on and excludes no values, since `min`
-  // is inclusive. Only when the consumer actually asked for a `step`: fields
-  // that never set `step` get no implicit `min`.
+  // Per the HTML step-base algorithm, `step` is measured from `min` if present,
+  // otherwise from the `value` *content attribute*, otherwise from 0. React keeps
+  // a controlled input's value content attribute in sync with the `value` prop on
+  // every commit (`setDefaultValue`), so with no `min` the step base always equals
+  // the current value — meaning `stepMismatch` can never be true by the time this
+  // component's post-commit effect reads it, for typed and programmatic values
+  // alike. An explicit `min` pins the step base instead; `'00:00'` excludes no
+  // values, since `min` is inclusive. Only when the consumer actually asked for a
+  // `step`: fields that never set `step` get no implicit `min`.
   // Counterfactual test: OffGridControlledValueIsFlaggedAtMount.
   const effectiveMin = min ?? (stepProp !== undefined ? '00:00' : undefined);
 
@@ -284,8 +298,12 @@ export function TimeField({
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the
       // `-webkit-datetime-edit-*` shadow pseudo-elements can't be qualified by
       // an attribute selector, so component state has to signal "nothing is
-      // entered". A partially-filled field (`09:--`) is deliberately NOT empty
-      // — its typed segment should render in the normal text colour.
+      // entered". A partially-filled field (`09:--`) stops counting as empty
+      // once the entry settles on blur. While it's still being typed, though,
+      // half-filling an empty field fires no event — `validity.incomplete`
+      // stays `false`, so `data-empty` stays `'true'` and the whole edit
+      // region, typed digits included, stays in the placeholder colour until
+      // blur revalidates.
       data-empty={currentValue === '' && !validity.incomplete ? 'true' : undefined}
       classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
       rightSectionPointerEvents={showClear ? 'auto' : 'none'}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -21,7 +21,7 @@ export interface TimeFieldProps {
   /** Called with "HH:mm", or '' when cleared. */
   onChange?: (time: string) => void;
   /** Visible field label. Provide this, `aria-label`, or `aria-labelledby`. */
-  inputLabel?: string;
+  label?: string;
   /** Accessible name for the clock trigger. Required — no default. */
   pickerButtonLabel: string;
   /** Accessible name for the clear (✕) button. Default: Finnish. */
@@ -54,7 +54,7 @@ export function TimeField({
   value,
   defaultValue,
   onChange,
-  inputLabel,
+  label,
   pickerButtonLabel,
   clearButtonLabel = 'Tyhjennä kellonaika',
   'aria-label': ariaLabel,
@@ -144,12 +144,12 @@ export function TimeField({
   // Dev-only guard: without a visible label or an aria-label/aria-labelledby the
   // time input has no accessible name.
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production' && !inputLabel && !ariaLabel && !ariaLabelledby) {
+    if (process.env.NODE_ENV !== 'production' && !label && !ariaLabel && !ariaLabelledby) {
       console.error(
-        'TimeField: provide `inputLabel`, `aria-label` or `aria-labelledby` — the input has no accessible name otherwise.'
+        'TimeField: provide `label`, `aria-label` or `aria-labelledby` — the input has no accessible name otherwise.'
       );
     }
-  }, [inputLabel, ariaLabel, ariaLabelledby]);
+  }, [label, ariaLabel, ariaLabelledby]);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const next = event.currentTarget.value;
@@ -160,7 +160,7 @@ export function TimeField({
   // Forward an aria-label/aria-labelledby only when there is no visible label,
   // so it can't silently override a visible label's accessible name.
   const inputAriaProps =
-    !inputLabel && (ariaLabel || ariaLabelledby)
+    !label && (ariaLabel || ariaLabelledby)
       ? { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby }
       : {};
 
@@ -168,7 +168,7 @@ export function TimeField({
     <TextField
       type="time"
       ref={inputRef}
-      inputLabel={inputLabel}
+      inputLabel={label}
       {...inputAriaProps}
       helperText={helperText}
       error={shownError}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { TextField } from '../TextField';
+
+export interface TimeFieldClassNames {
+  root: string;
+  input: string;
+  pickerButton: string;
+}
+
+export interface TimeFieldProps {
+  /** Committed time as "HH:mm", or '' when empty. Omit for an uncontrolled field. */
+  value?: string;
+  /** Initial time for an uncontrolled field. Ignored when `value` is supplied. */
+  defaultValue?: string;
+  /** Called with "HH:mm", or '' when cleared. */
+  onChange?: (time: string) => void;
+  /** Visible field label. Provide this, `aria-label`, or `aria-labelledby`. */
+  inputLabel?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  helperText?: React.ReactNode;
+  /** Consumer-supplied error. Takes precedence over internal range validation. */
+  error?: string;
+  disabled?: boolean;
+  required?: boolean;
+  classNames?: Partial<TimeFieldClassNames>;
+}
+
+/** A time-entry field: a TREDS text input in native `time` mode. */
+export function TimeField({
+  value,
+  defaultValue,
+  onChange,
+  inputLabel,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  helperText,
+  error,
+  disabled,
+  required,
+  classNames,
+}: TimeFieldProps) {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+  const currentValue = isControlled ? value : internalValue;
+
+  // Dev-only guard: without a visible label or an aria-label/aria-labelledby the
+  // time input has no accessible name.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && !inputLabel && !ariaLabel && !ariaLabelledby) {
+      console.error(
+        'TimeField: provide `inputLabel`, `aria-label` or `aria-labelledby` — the input has no accessible name otherwise.'
+      );
+    }
+  }, [inputLabel, ariaLabel, ariaLabelledby]);
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const next = event.currentTarget.value;
+    if (!isControlled) setInternalValue(next);
+    onChange?.(next);
+  }
+
+  return (
+    <TextField
+      type="time"
+      inputLabel={inputLabel}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      helperText={helperText}
+      error={error}
+      disabled={disabled}
+      required={required}
+      value={currentValue}
+      onChange={handleChange}
+      classNames={{ root: classNames?.root, wrapper: classNames?.input }}
+    />
+  );
+}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -16,7 +16,14 @@ export interface TimeFieldClassNames {
   pickerButton: string;
 }
 
-export interface TimeFieldProps {
+export interface TimeFieldProps extends Pick<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  // Pure passthrough props: none of them can break the a11y wiring or the
+  // segment styling, and `name` is what makes the field submit at all. The
+  // set stays explicit rather than extending InputHTMLAttributes wholesale,
+  // which would reopen `type`, widen min/max/step, and hand out `className`.
+  'name' | 'id' | 'autoComplete' | 'onFocus' | 'onBlur'
+> {
   /** Committed time as "HH:mm", or '' when empty. Omit for an uncontrolled field. */
   value?: string;
   /** Initial time for an uncontrolled field. Ignored when `value` is supplied. */
@@ -86,6 +93,11 @@ export function TimeField({
   disabled,
   required,
   classNames,
+  name,
+  id,
+  autoComplete,
+  onFocus,
+  onBlur,
 }: TimeFieldProps) {
   const isControlled = value !== undefined;
   const [internalValue, setInternalValue] = useState(defaultValue ?? '');
@@ -235,8 +247,11 @@ export function TimeField({
     onChange?.(next);
   }
 
-  function handleBlur() {
+  function handleBlur(event: React.FocusEvent<HTMLInputElement>) {
+    // Revalidate first so a consumer reading the DOM in their own handler sees
+    // the settled state, then hand the event on.
     revalidate();
+    onBlur?.(event);
   }
 
   // Forward an aria-label/aria-labelledby only when there is no visible label,
@@ -258,7 +273,11 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
+      onFocus={onFocus}
       onBlur={handleBlur}
+      name={name}
+      id={id}
+      autoComplete={autoComplete}
       min={effectiveMin}
       max={max}
       step={effectiveStep}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import cx from 'clsx';
 import { TextField } from '../TextField';
 import { Button } from '../Button';
+import { IconButton } from '../IconButton';
 import { TimeIcon } from '../../icons/TimeIcon';
+import { CloseIcon } from '../../icons/CloseIcon';
 import { timeInput, triggerIcon } from './TimeField.css';
 
 export interface TimeFieldClassNames {
@@ -22,6 +24,8 @@ export interface TimeFieldProps {
   inputLabel?: string;
   /** Accessible name for the clock trigger. Required — no default. */
   pickerButtonLabel: string;
+  /** Accessible name for the clear (✕) button. Default: Finnish. */
+  clearButtonLabel?: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   helperText?: React.ReactNode;
@@ -39,6 +43,7 @@ export function TimeField({
   onChange,
   inputLabel,
   pickerButtonLabel,
+  clearButtonLabel = 'Tyhjennä kellonaika',
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   helperText,
@@ -51,6 +56,17 @@ export function TimeField({
   const [internalValue, setInternalValue] = useState(defaultValue ?? '');
   const currentValue = isControlled ? value : internalValue;
   const inputRef = useRef<HTMLInputElement>(null);
+  const pickerButtonRef = useRef<HTMLButtonElement>(null);
+
+  const showClear = !disabled && currentValue !== '';
+
+  function handleClear() {
+    if (!isControlled) setInternalValue('');
+    onChange?.('');
+    // The ✕ disappears once the field is empty, so move focus to the adjacent
+    // picker trigger rather than letting it fall back to <body>.
+    requestAnimationFrame(() => pickerButtonRef.current?.focus());
+  }
 
   function openPicker() {
     const input = inputRef.current;
@@ -106,8 +122,22 @@ export function TimeField({
       // still `--`".
       data-empty={currentValue === '' ? 'true' : undefined}
       classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
+      rightSectionPointerEvents={showClear ? 'auto' : 'none'}
+      rightSection={
+        showClear ? (
+          <IconButton
+            size="sm"
+            variant="default"
+            aria-label={clearButtonLabel}
+            onClick={handleClear}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : undefined
+      }
       endInstance={
         <Button
+          ref={pickerButtonRef}
           variant="primary"
           iconOnly
           aria-label={pickerButtonLabel}

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -31,6 +31,14 @@ export interface TimeFieldProps {
   helperText?: React.ReactNode;
   /** Consumer-supplied error. Takes precedence over internal range validation. */
   error?: string;
+  /** Shown when the time falls outside [min, max] or off `step`. Default: Finnish. */
+  outOfRangeError?: string;
+  /** Earliest selectable time, "HH:mm". */
+  min?: string;
+  /** Latest selectable time, "HH:mm". */
+  max?: string;
+  /** Granularity in seconds; values below 60 are clamped to 60. Default 60. */
+  step?: number;
   disabled?: boolean;
   required?: boolean;
   classNames?: Partial<TimeFieldClassNames>;
@@ -48,6 +56,10 @@ export function TimeField({
   'aria-labelledby': ariaLabelledby,
   helperText,
   error,
+  outOfRangeError = 'Kellonaika on sallitun välin ulkopuolella',
+  min,
+  max,
+  step = 60,
   disabled,
   required,
   classNames,
@@ -57,12 +69,30 @@ export function TimeField({
   const currentValue = isControlled ? value : internalValue;
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerButtonRef = useRef<HTMLButtonElement>(null);
+  const [rangeError, setRangeError] = useState(false);
+
+  // A sub-60 step makes the browser render a seconds segment, which this
+  // component does not support.
+  const effectiveStep = Math.max(60, step);
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && step < 60) {
+      console.error(`TimeField: \`step\` must be at least 60 seconds — got ${step}, using 60.`);
+    }
+  }, [step]);
 
   const showClear = !disabled && currentValue !== '';
+
+  function validate(input: HTMLInputElement) {
+    const { rangeUnderflow, rangeOverflow, stepMismatch } = input.validity;
+    setRangeError(rangeUnderflow || rangeOverflow || stepMismatch);
+  }
+
+  const shownError = error ?? (rangeError ? outOfRangeError : undefined);
 
   function handleClear() {
     if (!isControlled) setInternalValue('');
     onChange?.('');
+    setRangeError(false);
     // The ✕ disappears once the field is empty, so move focus to the adjacent
     // picker trigger rather than letting it fall back to <body>.
     requestAnimationFrame(() => pickerButtonRef.current?.focus());
@@ -100,6 +130,7 @@ export function TimeField({
     const next = event.currentTarget.value;
     if (!isControlled) setInternalValue(next);
     onChange?.(next);
+    validate(event.currentTarget);
   }
 
   return (
@@ -110,11 +141,15 @@ export function TimeField({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       helperText={helperText}
-      error={error}
+      error={shownError}
       disabled={disabled}
       required={required}
       value={currentValue}
       onChange={handleChange}
+      onBlur={(e) => validate(e.currentTarget)}
+      min={min}
+      max={max}
+      step={effectiveStep}
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the
       // `-webkit-datetime-edit-*` shadow pseudo-elements don't support
       // `:not([attr])` matching in Chromium, so component state (not an

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -7,6 +7,9 @@ import { TimeIcon } from '../../icons/TimeIcon';
 import { CloseIcon } from '../../icons/CloseIcon';
 import { timeInput, triggerIcon } from './TimeField.css';
 
+/** Zero-padded 24-hour "HH:mm" — the only shape the native time input accepts. */
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
 export interface TimeFieldClassNames {
   root: string;
   input: string;
@@ -186,6 +189,31 @@ export function TimeField({
       );
     }
   }, [label, ariaLabel, ariaLabelledby]);
+
+  // Dev-only guard: the native input silently discards a time string it can't
+  // parse. For `value`/`defaultValue` that means an empty-looking field while
+  // the consumer believes a value is set; for `min`/`max` it means the
+  // attribute is ignored, which disables the range check AND — since the
+  // `'00:00'` fallback only fires when `min` is `undefined` — step enforcement
+  // along with it. Warn rather than sanitize: a controlled field must render
+  // what it was given, and the bug belongs to the caller.
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    const entries: [string, string | undefined][] = [
+      ['value', value],
+      ['defaultValue', defaultValue],
+      ['min', min],
+      ['max', max],
+    ];
+    for (const [name, candidate] of entries) {
+      if (candidate !== undefined && candidate !== '' && !TIME_RE.test(candidate)) {
+        console.error(
+          `TimeField: \`${name}\` must be "HH:mm" (zero-padded, 24-hour) — got "${candidate}". ` +
+            'The browser ignores unparseable values, so this silently does nothing.'
+        );
+      }
+    }
+  }, [value, defaultValue, min, max]);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const next = event.currentTarget.value;

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -53,10 +53,11 @@ export interface TimeFieldProps {
   /** Latest selectable time, "HH:mm". */
   max?: string;
   /**
-   * Granularity in seconds; clamped to the nearest whole minute (minimum 60). Default 60.
-   * Enforced relative to `min` — Chromium does not evaluate `step` without a `min` present, so
-   * if `step` is supplied and `min` is not, `min` defaults to `'00:00'` (the earliest
-   * representable time, so this excludes no values) purely to switch on step enforcement.
+   * Granularity in seconds; clamped to the nearest whole minute (minimum 60,
+   * for any finite value). Default 60. Enforced relative to `min`: if `step` is
+   * supplied and `min` is not, `min` defaults to `'00:00'` so that a value
+   * arriving from the `value` prop alone is still step-checked (see the comment
+   * on `effectiveMin`). `'00:00'` excludes no values on a 24-hour clock.
    */
   step?: number;
   disabled?: boolean;
@@ -111,12 +112,15 @@ export function TimeField({
     }
   }, [step, effectiveStep]);
 
-  // Chromium never evaluates `stepMismatch` on a time input without a `min`
-  // present (verified empirically, not documented behaviour) — so a `step`
-  // given without a `min` would otherwise enforce nothing at all. Default to
-  // the earliest representable time, which excludes no values, purely to
-  // switch step enforcement on. Only when the consumer actually asked for a
-  // `step`: fields that never set `step` get no implicit `min`.
+  // Chromium does not evaluate `stepMismatch` when the value came only from the
+  // content attribute and has never been made "dirty" — i.e. a controlled field
+  // mounted with an off-grid value and not yet touched, which is the common
+  // case. (Typed and IDL-set values are checked with or without a `min`, so this
+  // is narrower than "step needs a min".) Defaulting to the earliest
+  // representable time switches the check on and excludes no values, since `min`
+  // is inclusive. Only when the consumer actually asked for a `step`: fields
+  // that never set `step` get no implicit `min`.
+  // Counterfactual test: OffGridControlledValueIsFlaggedAtMount.
   const effectiveMin = min ?? (stepProp !== undefined ? '00:00' : undefined);
 
   const showClear = !disabled && currentValue !== '';

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import cx from 'clsx';
 import { TextField } from '../TextField';
 import { Button } from '../Button';
@@ -33,6 +33,12 @@ export interface TimeFieldProps {
   error?: string;
   /** Shown when the time falls outside [min, max] or off `step`. Default: Finnish. */
   outOfRangeError?: string;
+  /**
+   * Shown when the segments hold an incomplete time (e.g. an hour with no
+   * minutes). The native input reports this as `badInput` and keeps its own
+   * value empty, so without this the entry is discarded silently. Default: Finnish.
+   */
+  invalidTimeError?: string;
   /** Earliest selectable time, "HH:mm". */
   min?: string;
   /** Latest selectable time, "HH:mm". */
@@ -62,6 +68,7 @@ export function TimeField({
   helperText,
   error,
   outOfRangeError = 'Kellonaika on sallitun välin ulkopuolella',
+  invalidTimeError = 'Anna kellonaika muodossa tunnit:minuutit',
   min,
   max,
   step: stepProp,
@@ -74,7 +81,11 @@ export function TimeField({
   const currentValue = isControlled ? value : internalValue;
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerButtonRef = useRef<HTMLButtonElement>(null);
-  const [rangeError, setRangeError] = useState(false);
+  const [validity, setValidity] = useState({
+    incomplete: false,
+    outOfRange: false,
+    stepMismatch: false,
+  });
   const step = stepProp ?? 60;
 
   // A step that isn't a whole number of minutes makes the browser render a
@@ -100,20 +111,45 @@ export function TimeField({
 
   const showClear = !disabled && currentValue !== '';
 
-  // Revalidate off the native input's own `validity` object whenever anything
-  // that could change it does — not just user-driven change/blur events, but
-  // also a controlled consumer resetting `value`, or `min`/`max`/`step`
-  // themselves changing under an already-displayed value. This single effect
-  // subsumes what would otherwise be duplicate validate() calls wired to
-  // onChange and onBlur.
-  useEffect(() => {
+  // Read the flags straight off the native input rather than reimplementing
+  // range/step arithmetic. `badInput` is separated from the range flags because
+  // it means something different to the user (incomplete entry, not a value
+  // outside the allowed window) and needs its own message.
+  const revalidate = useCallback(() => {
     const input = inputRef.current;
-    if (!input) return;
-    const { rangeUnderflow, rangeOverflow, stepMismatch } = input.validity;
-    setRangeError(rangeUnderflow || rangeOverflow || stepMismatch);
-  }, [currentValue, effectiveMin, max, effectiveStep]);
+    if (!input) {
+      // The ref is the only route to `validity`; losing it would silently
+      // disable every range and step check for the lifetime of the component.
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('TimeField: input ref is not attached — validation is inactive.');
+      }
+      return;
+    }
+    const { rangeUnderflow, rangeOverflow, stepMismatch, badInput } = input.validity;
+    setValidity({
+      incomplete: badInput,
+      outOfRange: rangeUnderflow || rangeOverflow,
+      stepMismatch,
+    });
+  }, []);
 
-  const shownError = error ?? (rangeError ? outOfRangeError : undefined);
+  // Covers every input that can move the range and step flags: the value, and
+  // `min`/`max`/`step` themselves changing under an already-displayed value.
+  // `badInput` cannot be observed this way — half-filling an *empty* field
+  // changes no value and fires no event — which is why `onBlur` also
+  // revalidates. If you read another validity flag here, check whether an
+  // effect can actually see it flip.
+  useEffect(revalidate, [revalidate, currentValue, effectiveMin, max, effectiveStep]);
+
+  // Consumer error first, then incomplete entry (the user can't fix a range
+  // problem they haven't finished typing), then the range window.
+  const shownError =
+    error ??
+    (validity.incomplete
+      ? invalidTimeError
+      : validity.outOfRange || validity.stepMismatch
+        ? outOfRangeError
+        : undefined);
 
   function handleClear() {
     if (!isControlled) setInternalValue('');
@@ -157,6 +193,10 @@ export function TimeField({
     onChange?.(next);
   }
 
+  function handleBlur() {
+    revalidate();
+  }
+
   // Forward an aria-label/aria-labelledby only when there is no visible label,
   // so it can't silently override a visible label's accessible name.
   const inputAriaProps =
@@ -176,15 +216,16 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
+      onBlur={handleBlur}
       min={effectiveMin}
       max={max}
       step={effectiveStep}
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the
-      // `-webkit-datetime-edit-*` shadow pseudo-elements don't support
-      // `:not([attr])` matching in Chromium, so component state (not an
-      // attribute the browser itself sets) has to signal "every segment is
-      // still `--`".
-      data-empty={currentValue === '' ? 'true' : undefined}
+      // `-webkit-datetime-edit-*` shadow pseudo-elements can't be qualified by
+      // an attribute selector, so component state has to signal "nothing is
+      // entered". A partially-filled field (`09:--`) is deliberately NOT empty
+      // — its typed segment should render in the normal text colour.
+      data-empty={currentValue === '' && !validity.incomplete ? 'true' : undefined}
       classNames={{ root: classNames?.root, input: cx(timeInput, classNames?.input) }}
       rightSectionPointerEvents={showClear ? 'auto' : 'none'}
       rightSection={

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -72,14 +72,19 @@ export interface TimeFieldProps extends Pick<
   /** Latest selectable time, "HH:mm". */
   max?: string;
   /**
-   * Granularity in seconds; clamped to the nearest whole minute (minimum 60,
-   * for any finite value). Default 60. Enforced relative to `min`: if `step` is
-   * supplied and `min` is not, `min` defaults to `'00:00'` so that `stepMismatch`
-   * is observable at all — without a `min`, the step check is never true for
-   * typed or programmatic values alike (see the comment on `effectiveMin`).
-   * `'00:00'` excludes no values on a 24-hour clock.
+   * Granularity in **minutes**; rounded to a whole minute, minimum 1. Default 1.
+   * Named for its unit because the underlying `<input type="time">` measures
+   * `step` in seconds, and this component supports no sub-minute granularity —
+   * a seconds-unit prop that only accepts multiples of 60 would invite a
+   * factor-of-60 mistake for nothing.
+   *
+   * Enforced relative to `min`: if `stepMinutes` is supplied and `min` is not,
+   * `min` defaults to `'00:00'` so that `stepMismatch` is observable at all —
+   * without a `min`, the step check is never true for typed or programmatic
+   * values alike (see the comment on `effectiveMin`). `'00:00'` excludes no
+   * values on a 24-hour clock.
    */
-  step?: number;
+  stepMinutes?: number;
   disabled?: boolean;
   required?: boolean;
   classNames?: Partial<TimeFieldClassNames>;
@@ -102,7 +107,7 @@ export function TimeField({
   invalidTimeError = 'Anna kellonaika muodossa tunnit:minuutit',
   min,
   max,
-  step: stepProp,
+  stepMinutes: stepMinutesProp,
   disabled,
   required,
   classNames,
@@ -122,20 +127,26 @@ export function TimeField({
     outOfRange: false,
     stepMismatch: false,
   });
-  const step = stepProp ?? 60;
+  const stepMinutes = stepMinutesProp ?? 1;
 
   // A step that isn't a whole number of minutes makes the browser render a
-  // seconds segment, which this component does not support — round to the
-  // nearest minute (and never below one) rather than merely flooring at 60,
-  // otherwise e.g. `step={90}` would slip through unchanged.
-  const effectiveStep = Math.max(60, Math.round(step / 60) * 60);
+  // seconds segment, which this component does not support, so round to the
+  // nearest minute and never go below one. `Number.isFinite` first: without it
+  // `Math.round(NaN)` keeps NaN all the way into the DOM attribute (and into a
+  // self-contradictory "got NaN, using NaN" warning), while `Infinity` compares
+  // equal to itself and would slip through with no warning at all.
+  const effectiveStepMinutes = Number.isFinite(stepMinutes)
+    ? Math.max(1, Math.round(stepMinutes))
+    : 1;
+  // The DOM attribute is in seconds; the prop is in minutes.
+  const domStep = effectiveStepMinutes * 60;
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production' && step !== effectiveStep) {
+    if (process.env.NODE_ENV !== 'production' && stepMinutes !== effectiveStepMinutes) {
       console.error(
-        `TimeField: \`step\` must be a whole number of minutes — got ${step}, using ${effectiveStep}.`
+        `TimeField: \`stepMinutes\` must be a whole number of minutes, at least 1 — got ${stepMinutes}, using ${effectiveStepMinutes}.`
       );
     }
-  }, [step, effectiveStep]);
+  }, [stepMinutes, effectiveStepMinutes]);
 
   // Per the HTML step-base algorithm, `step` is measured from `min` if present,
   // otherwise from the `value` *content attribute*, otherwise from 0. React keeps
@@ -145,9 +156,9 @@ export function TimeField({
   // component's post-commit effect reads it, for typed and programmatic values
   // alike. An explicit `min` pins the step base instead; `'00:00'` excludes no
   // values, since `min` is inclusive. Only when the consumer actually asked for a
-  // `step`: fields that never set `step` get no implicit `min`.
+  // step: fields that never set `stepMinutes` get no implicit `min`.
   // Counterfactual test: OffGridControlledValueIsFlaggedAtMount.
-  const effectiveMin = min ?? (stepProp !== undefined ? '00:00' : undefined);
+  const effectiveMin = min ?? (stepMinutesProp !== undefined ? '00:00' : undefined);
 
   const showClear = !disabled && currentValue !== '';
 
@@ -179,7 +190,7 @@ export function TimeField({
   // changes no value and fires no event — which is why `onBlur` also
   // revalidates. If you read another validity flag here, check whether an
   // effect can actually see it flip.
-  useEffect(revalidate, [revalidate, currentValue, effectiveMin, max, effectiveStep]);
+  useEffect(revalidate, [revalidate, currentValue, effectiveMin, max, domStep]);
 
   // Consumer error first, then incomplete entry (the user can't fix a range
   // problem they haven't finished typing), then the range window, then
@@ -294,7 +305,7 @@ export function TimeField({
       autoComplete={autoComplete}
       min={effectiveMin}
       max={max}
-      step={effectiveStep}
+      step={domStep}
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the
       // `-webkit-datetime-edit-*` shadow pseudo-elements can't be qualified by
       // an attribute selector, so component state has to signal "nothing is

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -37,7 +37,12 @@ export interface TimeFieldProps {
   min?: string;
   /** Latest selectable time, "HH:mm". */
   max?: string;
-  /** Granularity in seconds; clamped to the nearest whole minute (minimum 60). Default 60. */
+  /**
+   * Granularity in seconds; clamped to the nearest whole minute (minimum 60). Default 60.
+   * Enforced relative to `min` — Chromium does not evaluate `step` without a `min` present, so
+   * if `step` is supplied and `min` is not, `min` defaults to `'00:00'` (the earliest
+   * representable time, so this excludes no values) purely to switch on step enforcement.
+   */
   step?: number;
   disabled?: boolean;
   required?: boolean;
@@ -59,7 +64,7 @@ export function TimeField({
   outOfRangeError = 'Kellonaika on sallitun välin ulkopuolella',
   min,
   max,
-  step = 60,
+  step: stepProp,
   disabled,
   required,
   classNames,
@@ -70,6 +75,7 @@ export function TimeField({
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerButtonRef = useRef<HTMLButtonElement>(null);
   const [rangeError, setRangeError] = useState(false);
+  const step = stepProp ?? 60;
 
   // A step that isn't a whole number of minutes makes the browser render a
   // seconds segment, which this component does not support — round to the
@@ -84,6 +90,14 @@ export function TimeField({
     }
   }, [step, effectiveStep]);
 
+  // Chromium never evaluates `stepMismatch` on a time input without a `min`
+  // present (verified empirically, not documented behaviour) — so a `step`
+  // given without a `min` would otherwise enforce nothing at all. Default to
+  // the earliest representable time, which excludes no values, purely to
+  // switch step enforcement on. Only when the consumer actually asked for a
+  // `step`: fields that never set `step` get no implicit `min`.
+  const effectiveMin = min ?? (stepProp !== undefined ? '00:00' : undefined);
+
   const showClear = !disabled && currentValue !== '';
 
   // Revalidate off the native input's own `validity` object whenever anything
@@ -97,7 +111,7 @@ export function TimeField({
     if (!input) return;
     const { rangeUnderflow, rangeOverflow, stepMismatch } = input.validity;
     setRangeError(rangeUnderflow || rangeOverflow || stepMismatch);
-  }, [currentValue, min, max, effectiveStep]);
+  }, [currentValue, effectiveMin, max, effectiveStep]);
 
   const shownError = error ?? (rangeError ? outOfRangeError : undefined);
 
@@ -156,7 +170,7 @@ export function TimeField({
       required={required}
       value={currentValue}
       onChange={handleChange}
-      min={min}
+      min={effectiveMin}
       max={max}
       step={effectiveStep}
       // Drives the empty-segment placeholder colour in TimeField.css.ts: the

--- a/src/components/TimeField/TimeField.tsx
+++ b/src/components/TimeField/TimeField.tsx
@@ -34,8 +34,14 @@ export interface TimeFieldProps {
   helperText?: React.ReactNode;
   /** Consumer-supplied error. Takes precedence over internal range validation. */
   error?: string;
-  /** Shown when the time falls outside [min, max] or off `step`. Default: Finnish. */
+  /** Shown when the time falls outside [min, max]. Default: Finnish. */
   outOfRangeError?: string;
+  /**
+   * Shown when the time is inside [min, max] but off the `step` grid. Kept
+   * separate from `outOfRangeError` because "outside the allowed range" is
+   * wrong and unactionable for a granularity problem. Default: Finnish.
+   */
+  stepMismatchError?: string;
   /**
    * Shown when the segments hold an incomplete time (e.g. an hour with no
    * minutes). The native input reports this as `badInput` and keeps its own
@@ -71,6 +77,7 @@ export function TimeField({
   helperText,
   error,
   outOfRangeError = 'Kellonaika on sallitun välin ulkopuolella',
+  stepMismatchError = 'Valitse kellonaika sallitulla tarkkuudella',
   invalidTimeError = 'Anna kellonaika muodossa tunnit:minuutit',
   min,
   max,
@@ -145,14 +152,17 @@ export function TimeField({
   useEffect(revalidate, [revalidate, currentValue, effectiveMin, max, effectiveStep]);
 
   // Consumer error first, then incomplete entry (the user can't fix a range
-  // problem they haven't finished typing), then the range window.
+  // problem they haven't finished typing), then the range window, then
+  // granularity — each with the message that actually names the problem.
   const shownError =
     error ??
     (validity.incomplete
       ? invalidTimeError
-      : validity.outOfRange || validity.stepMismatch
+      : validity.outOfRange
         ? outOfRangeError
-        : undefined);
+        : validity.stepMismatch
+          ? stepMismatchError
+          : undefined);
 
   function handleClear() {
     if (!isControlled) setInternalValue('');

--- a/src/components/TimeField/index.ts
+++ b/src/components/TimeField/index.ts
@@ -1,0 +1,1 @@
+export { TimeField, type TimeFieldProps, type TimeFieldClassNames } from './TimeField';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -35,3 +35,4 @@ export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider';
 export { Typography } from './Typography/Typography';
 export { DateField, type DateFieldProps, type DateFieldClassNames } from './DateField';
 export { TextLink, type TextLinkProps, type TextLinkSize } from './TextLink/TextLink';
+export { TimeField, type TimeFieldProps, type TimeFieldClassNames } from './TimeField';


### PR DESCRIPTION
Closes #53

Adds the **TimeField** (Kellonaikakenttä) component — a Finnish-locale time-entry control, the last
input primitive needed for booking/scheduling flows alongside `DateField`.

## Approach

Figma (`3015:5116`) specifies the anatomy as *"a text field and button components"*, and that is
what this builds:

```
TimeField
└── TextField (TREDS)  type="time"
    ├── native <input type="time">                        ← value, min/max/step, keyboard, a11y
    ├── rightSection: IconButton sm/default + CloseIcon    ← clear ✕, conditional
    └── endInstance:  Button primary iconOnly + TimeIcon   ← opens the native picker
```

The clock button opens the **browser's own** picker via `input.showPicker()`. Figma designs the
button but not its target, and no time-picker UI exists anywhere in the kit — so rather than invent
one, this leans on the platform, which also supplies keyboard increments and spinbutton semantics
for free. Not Mantine's `TimeInput`: that is the same native input underneath but carries its own
styles-API names, so it would duplicate the TREDS input styling `TextField` already has.

**Value shape is the string `"HH:mm"`** (`''` when empty), not a `Date` — no timezone or
phantom-date baggage, and `min`/`max`/`stepMinutes` map straight onto the native attributes.

Validation reads the native input's own `ValidityState` rather than reimplementing modular time
arithmetic. A single `revalidate()` covers the value and the bounds changing, and also runs on blur
— which is load-bearing, not belt-and-braces, for the reason in the first bullet below.

## Public API

```ts
label?, pickerButtonLabel (required), clearButtonLabel?
value?, defaultValue?, onChange?          // "HH:mm" | ''
helperText?, error?
outOfRangeError?, stepMismatchError?, invalidTimeError?
min?, max?, stepMinutes?, disabled?, required?, classNames?
name?, id?, autoComplete?, onFocus?, onBlur?
```

Deliberately a **closed prop set** — no `...rest`, so `type` and `className` cannot be reopened and
the native-time design cannot be broken from outside. `name`/`id`/`autoComplete`/`onFocus`/`onBlur`
are explicit passthroughs: without `name` the field contributes nothing to a native form submission,
and the closed set left no workaround.

`stepMinutes` is measured in **minutes**, not the native attribute's seconds. The component
supports no sub-minute granularity — it clamps to whole minutes — so the only values a seconds-unit
prop ever accepted were multiples of 60, and `step={15}` reading as minutes but meaning seconds was
a factor-of-60 trap for nothing in return. The ×60 conversion to the DOM attribute happens in one
place.

Three distinct error messages rather than one, so the text names the actual problem (WCAG 3.3.3
Error Suggestion): out of range, off the `stepMinutes` grid, and incomplete entry. A consumer-supplied
`error` outranks all three — note that `error=''` counts as supplied and suppresses them, matching
`DateField`, so pass `undefined` when there is no error.

## Deviations from Figma — deliberate, flagging so they aren't read as drift

1. **A clear (✕) button was added**, which Figma does not draw on TimeField. Justified by `DateField`
   parity: a populated field with no way to empty it is a usability gap, not a design choice.
2. **The clock button opens the native OS picker.** Figma designs the button but not its behaviour,
   so nothing designed is contradicted.

## Accepted trade-off

`<input type="time">` renders its segments in the **viewer's OS locale**, so an `en-US` viewer sees
`09:30 AM` rather than `09:30`. The value read and written is always 24-hour `HH:mm` regardless, so
no data is locale-dependent — only glyphs. This is disclosed in the component's own docs
description, and it is reversible: a bespoke picker could later swap in behind the same `"HH:mm"`
API without a breaking change.

## Platform behaviour worth knowing about

All of these were measured in this repo's own Chromium, and each is documented in a code comment so
it isn't "cleaned up" later and silently broken.

- **Half-filling an empty time input fires no `input` or `change` event at all** — the value stays
  `''` while `validity.badInput` flips to `true`. An effect over the value therefore cannot observe
  it, which is why `revalidate()` is also wired to `onBlur`. Without that, typing `09` and leaving
  the field showed `09:--` with no error and committed nothing.
- **`step` is measured from `min` if present, otherwise from the `value` content attribute** (the
  HTML step-base algorithm). React keeps a controlled input's `value` content attribute in sync with
  the `value` prop on every commit, so with no `min` the step base always equals the current value
  and `stepMismatch` can never be true. `min` therefore defaults to `'00:00'` whenever
  `stepMinutes` is supplied and `min` is not — which excludes no values, since `min` is inclusive.
  Removing that default turns off step enforcement entirely;
  `OffGridControlledValueIsFlaggedAtMount` is the story that goes red if anyone does.
- **A non-whole-minute step makes the browser render a seconds segment** — measured by control
  width: steps of 60/900 seconds give an 89px control, 30 and 90 give 111px. So `stepMinutes` is
  rounded rather than floored (`1.5` → `2`) and never drops below 1, with a dev warning naming both
  the value passed and the value used. `NaN` and `Infinity` fall back to one minute and both warn.
- **A swapped `min`/`max` pair leaves the browser with no satisfiable window** — every value is
  either below `min` or above `max`, so `min="17:00" max="08:00"` rejects everything, including the
  8-to-17 window the consumer meant, with nothing pointing at the swapped props. The pair is
  ordered instead (the same normalisation `DateField` already does) and warned about. Only
  well-formed bounds are compared: the browser ignores an unparseable bound, so swapping on one
  would invent a range it never had.
- **A malformed time string is silently discarded.** `value="9:30"` or `"25:00"` leaves the input
  empty while the consumer's state says otherwise, and a malformed `min` silently disables the range
  check. A dev-only guard now warns on `value`/`defaultValue`/`min`/`max`.
- **Attribute selectors never match on `::-webkit-datetime-edit-*`**, so the empty-segment
  placeholder colour is driven by a `data-empty` attribute off component state instead.
  `getComputedStyle` also cannot read those pseudo-elements, so the chrome-suppression CSS is
  verified visually rather than by computed-style assertions.

## Shared-component change

`TextField` is now `forwardRef<HTMLInputElement, TextFieldProps>`. `TimeField` needs the real
`<input>` to call `showPicker()` and to read `validity`, and `ref` was not assignable to `TextField`
before this. The change is additive — no prop-surface change — and `SearchField` and `DateField`
pass no ref, so there is no regression surface.

## Acceptance-criteria notes

- **"ARIA spinbutton pattern"** is met natively by `<input type="time">` rather than hand-rolled
  ARIA — deliberate, and consistent with the native-picker decision.
- **"Keyboard increments"** are asserted behaviourally, not by proxy: arrows step the focused
  segment and the minute arrows honour the grid (`10:00` → `10:15` at `stepMinutes={15}`). This needs the
  Playwright-backed driver from `vitest/browser`; the simulated `userEvent` is inert for native
  segment spinners.
- **"Composes Fieldset for grouping"** is satisfied by TimeField working *inside* a `Fieldset`
  (a consumer-side `<fieldset>/<legend>` wrapper). A grouped booking-flow story follows once #125
  lands; this work was correctly not blocked on it.

## Testing

**374/374 passing** across 28 files, 53 of them TimeField stories. `tsc`, ESLint, Prettier and
`npm run build` all clean; `dist/index.d.ts` exports `TimeField`, `TimeFieldProps` and
`TimeFieldClassNames` with no `TimeField.css` leakage. No new design tokens; `src/theme/` untouched.

Coverage includes controlled and uncontrolled modes, both range bounds and the inclusive boundary,
step granularity driven through real `stepMismatch` transitions, incomplete entry, error precedence,
keyboard increments, the clear button's focus rescue *and its restraint when a controlled consumer
ignores `onChange`*, swapped and malformed range bounds, the `showPicker` fallback path, native form
submission via `FormData`, and accessible-name resolution — the last asserting that a visible label
wins over `aria-label` when both are supplied (WCAG 2.5.3 Label in Name).

Several stories were verified by mutation rather than assumed: `max` and `rangeOverflow`, the `step`
attribute, and the `min` default were each neutralised in turn to confirm the story that claims to
guard them actually goes red. Before this, `max` and `rangeOverflow` could both be deleted with the
whole suite staying green.

The four fixes in the last round were each verified the same way, and it caught a bad test:
`MalformedBoundIsNotSwapped` originally used `max: '1:00'` and passed *with the guard deleted*,
because `'1:00'` sorts **above** `'09:00'` (`'1' > '0'`) and so never exercised the comparison. A
truncated `'08:0'` does sort below it, and the story now fails without the guard.

Note the native picker panel is OS chrome Playwright cannot see into, so tests assert that
`showPicker` was *invoked*, never what it renders.

## Follow-ups (not blocking)

Filed separately so this PR stays reviewable:

- **#129 — `DateField`/`TimeField` `classNames` parity.** `DateFieldClassNames.input` targets
  Mantine's *wrapper* slot while `TimeFieldClassNames.input` targets the input itself — same key,
  different element, in two components used side by side. TimeField's is the correct reading;
  renaming DateField's is breaking. Also covers the missing calendar-trigger and clear-button keys,
  and the fact that neither component's `classNames` contract has a story.
- **#130 — the remaining TimeField follow-ups.** `aria-describedby` passthrough for the
  error-summary pattern (needs a merge with Mantine's computed ids, not a plain passthrough); the
  bare `catch` discarding the error object; `setValidity`'s fresh object literal forcing a re-render;
  and a set of coverage and test-hygiene gaps.

Five items originally deferred to #130 were folded back in here instead, and #130's body records
which and why. Four were a few lines each in code this PR already touches; the fifth — the
`stepMinutes` rename — is a one-way door that is free only until TimeField publishes. Doing them now
also cost no review thrash, since no review had yet been submitted.

Neither issue blocks merge.

---

⚠️ **Breaking changes within this branch** — TimeField is unreleased, so no published consumer is
affected:

1. `inputLabel` was renamed to `label`, matching `DateField`, the component it is designed to be
   paired with.
2. `step` (seconds) became `stepMinutes` (minutes). `step={900}` is now `stepMinutes={15}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
