### PR TITLE
fix(#131): stop marking Vanilla Extract modules external in the dts build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,12 @@ export default [
   {
     input: 'dist/types/src/index.d.ts',
     output: { file: 'dist/index.d.ts', format: 'es' },
-    external: [/\.css$/],
+    // Only bare package specifiers are real stylesheets (e.g.
+    // '@mantine/core/styles.layer.css'). A relative '.css' specifier is a
+    // Vanilla Extract '.css.ts' module whose declarations must be inlined —
+    // marking those external leaves dangling imports in dist/index.d.ts,
+    // since dist/components/**/ is never emitted.
+    external: [/^[^./].*\.css$/],
     plugins: [dts()],
   },
 ];


### PR DESCRIPTION
## Summary

`dist/index.d.ts` shipped a reference to `./components/TextLink/TextLink.css` — a path the published package never emits — so `TextLinkSize` dangled for consumers. Fixes #131.

The fix is one line in `rollup.config.js`'s dts stage:

```diff
-    external: [/\.css$/],
+    external: [/^[^./].*\.css$/],
```

## Why the issue's proposed fix doesn't work

The issue suggests re-exporting the type from the sibling `TextLink.tsx`. That re-export was **already on `main`** (`TextLink.tsx:13`, `export type { TextLinkSize }`) and the reference dangled anyway — `rollup-plugin-dts` follows a type back to its defining module, so a re-export doesn't move where the declaration comes from.

## Actual root cause

The dts stage marked **every** specifier ending in `.css` as external. That's correct for real stylesheet imports, which arrive as bare package specifiers (`@mantine/core/styles.layer.css`). But a *relative* `.css` specifier is a Vanilla Extract `.css.ts` module, and its `TextLink.css.d.ts` sits right there in `dist/types/`, perfectly resolvable — the `external` rule was the only thing telling `dts()` not to inline it.

Narrowing the pattern to bare specifiers fixes the whole class of bug, not just this one symbol.

## The failure was silent, not loud

Worth recording, since it's worse than the issue describes: under the old config `TextLinkSize` resolved to **`any`** for consumers. The `size` prop lost type checking entirely rather than erroring. A consumer file asserting `@ts-expect-error` on invalid sizes reports those directives as *unused* against the old output — the type accepted anything.

## Verification

| Check | Result |
| --- | --- |
| `grep -n "\.css'" dist/index.d.ts` (the issue's criterion) | empty |
| `grep -nE "from '\./" dist/index.d.ts` | empty — no relative import survives the rollup at all |
| Consumer typecheck against built `dist/index.d.ts` | passes; `TextLinkSize` accepts `'h3'`, rejects `'margin'` and `'nope'` |
| Same consumer typecheck against **old** config output | fails — both `@ts-expect-error` directives unused, i.e. the type was `any` |
| Build warnings | none; the genuine `@mantine/core/styles.layer.css` import is elided from the declarations either way, so the old rule was only muting a warning |
| `npm test` | 320/320 across 27 files |
| prettier + eslint | clean |

## Other `.css.ts` exports

The issue asks whether any others leak. Four `.css.ts` files export non-style values — `Card`, `Pagination`, `iconButtonState`, `theme` — but none reach the public API surface. The fixed build adds exactly two declarations: `TextLinkSize` and the internal, unexported `declare const components` it derives from (~280 lines of theme-contract shape). I left that inlined const as-is: it's genuinely what the type derives from, and avoiding it would mean restructuring where `TextLinkSize` is defined, which is a separate concern from this bug.

No source files changed — build config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
